### PR TITLE
feat(PEE-33): configurar build tool, testes e quality gate básico

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,10 +22,10 @@ jobs:
       with:
         fetch-depth: 0  # SonarCloud precisa do histórico completo para algumas métricas
 
-    - name: Configurar JDK 17
+    - name: Configurar JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
 
     - name: Setup Gradle

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,6 +86,7 @@ jacocoTestReport {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it, exclude: [
+                "**/*Application.class",
                 "**/config/**",
                 "**/model/**",
                 "**/dto/**",
@@ -94,3 +95,29 @@ jacocoTestReport {
         }))
     }
 }
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule {
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.60
+            }
+        }
+    }
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                "**/*Application.class",
+                "**/config/**",
+                "**/model/**",
+                "**/dto/**",
+                "**/exception/**"
+            ])
+        }))
+    }
+}
+
+check.dependsOn jacocoTestCoverageVerification

--- a/app/sonar-project.properties
+++ b/app/sonar-project.properties
@@ -1,16 +1,21 @@
 # Informações do projeto
 sonar.projectKey=urbana-do-brasil_urbana-connect
 sonar.organization=urbana-do-brasil
+sonar.projectName=urbana-connect
+sonar.projectVersion=0.0.1-SNAPSHOT
 
-# Configurações de código-fonte e testes
+# Código-fonte e testes
 sonar.sources=src/main/java
 sonar.tests=src/test/java
-sonar.java.binaries=build/classes
+sonar.java.binaries=build/classes/java/main
+sonar.java.test.binaries=build/classes/java/test
+sonar.java.source=21
 sonar.sourceEncoding=UTF-8
-sonar.java.source=17
 
-# Configurações do JaCoCo para relatórios de cobertura
+# Cobertura JaCoCo
 sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
 
-# Exclusões (opcional)
-sonar.exclusions=src/main/java/com/urbanaconnect/config/**/* 
+# Exclusões
+sonar.exclusions=\
+  **/*Application.java,\
+  **/config/**

--- a/app/src/test/java/br/com/urbana/connect/interfaces/rest/HealthControllerTest.java
+++ b/app/src/test/java/br/com/urbana/connect/interfaces/rest/HealthControllerTest.java
@@ -1,0 +1,28 @@
+package br.com.urbana.connect.interfaces.rest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import br.com.urbana.connect.application.config.SecurityConfig;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(HealthController.class)
+@Import(SecurityConfig.class)
+class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldReturnOk() throws Exception {
+        mockMvc.perform(get("/api/v1/health"))
+            .andExpect(status().isOk())
+            .andExpect(content().string("OK"));
+    }
+}


### PR DESCRIPTION
## Resumo

- CI atualizado para JDK 21 (alinhado com baseline PEE-31)
- `sonar-project.properties` reescrito para o projeto greenfield (Java 21, paths corretos)
- JaCoCo com threshold mínimo de **60% de cobertura de linhas** — build falha se não atingido
- `HealthControllerTest` adicionado como primeiro teste de entrypoint REST

## Quality Gate

```
jacocoTestCoverageVerification
  LINE coverage ≥ 60%   → BUILD SUCCESSFUL ✓
```

## Jira

[PEE-33](https://urbanadobrasil.atlassian.net/browse/PEE-33) — Configurar build tool, testes e quality gate básico

🤖 Generated with [Claude Code](https://claude.com/claude-code)