### PR TITLE
feat: complete Urba conversational service flow

### DIFF
--- a/.env.poc.example
+++ b/.env.poc.example
@@ -4,6 +4,9 @@ SERVER_PORT=8081
 MONGODB_URI=mongodb://localhost:27017/urbana-connect-poc
 HERMES_BASE_URL=http://127.0.0.1:8652
 HERMES_POC_HOST_PORT=8652
+# Current local Hermes runtime image; override only when validating another
+# explicitly identified image, such as a homologation tag.
+HERMES_IMAGE=urbana-hermes-agent:pee-103-2f5472a15
 # Generate independent local values with: openssl rand -hex 32
 HERMES_API_SERVER_KEY=
 HERMES_INTERNAL_TOOL_TOKEN=

--- a/apps/poc-chat/e2e/quality-chat.spec.ts
+++ b/apps/poc-chat/e2e/quality-chat.spec.ts
@@ -1,0 +1,757 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+
+const runLiveQuality = process.env.PLAYWRIGHT_LIVE === '1'
+  && process.env.PLAYWRIGHT_BASE_URL !== undefined;
+const turnTimeoutMs = 120_000;
+
+type CanonicalMessage = {
+  id: string;
+  eventId: string;
+  correlationId: string;
+  contactId: string;
+  direction: 'INBOUND' | 'OUTBOUND';
+  senderType: 'CONTACT' | 'URBA' | 'HUMAN' | 'SYSTEM';
+  type: string;
+  text: string | null;
+  createdAt: string;
+};
+
+type ProjectionConversation = {
+  mode?: 'AI' | 'HUMAN';
+  ownership?: 'URBA' | 'HUMAN';
+  version?: number;
+  termsStatus?: string;
+  paymentStatus?: string;
+  commercialStage?: string;
+  [key: string]: unknown;
+};
+
+type Projection = {
+  contactId: string;
+  messages: CanonicalMessage[];
+  conversation: ProjectionConversation;
+  ownership?: 'URBA' | 'HUMAN';
+  resumeStatus?: string;
+  resumeId?: string | null;
+  controlAvailability?: {
+    approvePaymentProof?: boolean;
+    recordHumanMessage?: boolean;
+    returnToUrba?: boolean;
+  };
+  turn: { status: string; correlationId: string } | null;
+};
+
+type QualityEvidence = {
+  firstPresentation: boolean;
+  discovery: boolean;
+  comparison: boolean;
+  catalogExplanation: boolean;
+  noInformativeAdvance: boolean;
+  icpPrompt: boolean;
+  partialIcp: boolean;
+  termsAfterIcp: boolean;
+  ambiguousAcceptance: boolean;
+  clearAcceptance: boolean;
+  paymentInstruction: boolean;
+  proofHandoff: boolean;
+  humanSilence: boolean;
+  canonicalHumanDecision: boolean;
+  resumed: boolean;
+  proactiveContinuation: boolean;
+  transcriptIntegrity: boolean;
+  safeLanguage: boolean;
+  observations: string[];
+};
+
+type RubricResult = {
+  score: number;
+  maximumScore: number;
+  failures: string[];
+  observations: string[];
+};
+
+const handoffPattern = /(?:encaminh|transfer|atendimento humano|falar com (?:a )?arquitet[ao]|vou .*arquitet[ao]|continuar[aá].*(?:conversa|atendimento))/i;
+const technicalLanguagePattern = /problema no sistema|erro interno|falha interna|ferramenta falhou|illegalstateexception|correlationid|\bapi\b|\bbanco de dados\b|stack trace|\bexception\b|\bretry\b|idempotenc|\bhermes\b|prepare[_ ]terms|\bicp\b/i;
+const paymentInstructionPattern = /pagamento|pix|comprovante|instru[cç][aã]o|chave/i;
+
+test.describe('qualidade conversacional ao vivo', () => {
+  test.skip(
+    !runLiveQuality,
+    'execute com PLAYWRIGHT_LIVE=1 e PLAYWRIGHT_BASE_URL apontando para o stack local real',
+  );
+
+  test('reproduz o fluxo completo, preserva o transcript e avalia a rubric de qualidade', async ({ page }, testInfo) => {
+    test.setTimeout(20 * 60_000);
+    const suffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const contactName = `E2E Qualidade ${suffix}`;
+    const evidence = createQualityEvidence();
+    let alias = '';
+    let latestProjection: Projection | null = null;
+
+    try {
+      await page.goto('/');
+      await createContact(page, contactName);
+
+      alias = await sendAndCaptureAlias(page, 'Olá!');
+      latestProjection = await waitForCanonicalReply(page, alias, 0);
+      evidence.firstPresentation = hasFirstPresentation(latestProjection);
+      evidence.observations.push(`primeira apresentação: ${lastOutboundText(latestProjection)}`);
+
+      latestProjection = await sendAndWait(
+        page,
+        alias,
+        'É para um quarto infantil, com dinossauros e dragões. Quero uma pintura temática e reaproveitar os móveis que já tenho.',
+        latestProjection,
+      );
+      evidence.discovery = hasPaintingRecommendation(latestProjection);
+
+      latestProjection = await sendAndWait(
+        page,
+        alias,
+        'Qual é a diferença entre Decor Pintura e Decor Interiores?',
+        latestProjection,
+      );
+      evidence.comparison = hasServiceComparison(latestProjection);
+
+      latestProjection = await sendAndWait(
+        page,
+        alias,
+        'Confirmo Decor Pintura. Como funciona esse serviço?',
+        latestProjection,
+      );
+      latestProjection = await sendAndWait(
+        page,
+        alias,
+        'Pode detalhar entregas, responsabilidades, materiais, execução, prazo e suporte?',
+        latestProjection,
+      );
+      evidence.catalogExplanation = hasCatalogExplanation(latestProjection);
+      evidence.noInformativeAdvance = hasNoCommercialAdvance(latestProjection);
+
+      latestProjection = await sendAndWait(
+        page,
+        alias,
+        'Quero contratar o Decor Pintura para esse quarto.',
+        latestProjection,
+      );
+      const initialIcpReply = lastOutboundTextFor(latestProjection, /quero contratar|contratar o decor pintura/i);
+      evidence.icpPrompt = hasAllIcpTopics(initialIcpReply)
+        && !hasTermsBeenPresented(latestProjection)
+        && !hasPaymentBeenPrepared(latestProjection);
+      evidence.observations.push(`campos solicitados no primeiro checkpoint: ${icpTopics(initialIcpReply).join(', ') || 'nenhum sinal semântico'}`);
+
+      latestProjection = await sendAndWait(
+        page,
+        alias,
+        'Pode me chamar de Dani.',
+        latestProjection,
+      );
+      const partialIcpReply = lastOutboundTextFor(latestProjection, /pode me chamar de dani/i);
+      evidence.partialIcp = hasRemainingIcpTopics(partialIcpReply)
+        && !hasTopic(partialIcpReply, 'pronoun');
+      evidence.observations.push(`campos restantes após resposta parcial: ${icpTopics(partialIcpReply).join(', ') || 'nenhum sinal semântico'}`);
+
+      latestProjection = await sendAndWait(
+        page,
+        alias,
+        'É a primeira vez que contrato esse tipo de serviço e trabalho como designer.',
+        latestProjection,
+      );
+      evidence.termsAfterIcp = hasTermsBeenPresented(latestProjection)
+        && !hasPaymentBeenPrepared(latestProjection);
+      evidence.observations.push(`estado após concluir o checkpoint: termos=${termsStatus(latestProjection) ?? 'ausente'}, pagamento=${paymentStatus(latestProjection) ?? 'ausente'}`);
+
+      latestProjection = await sendAndWait(page, alias, 'Ok.', latestProjection);
+      const ambiguousReply = lastOutboundTextFor(latestProjection, /^ok\.?$/i);
+      evidence.ambiguousAcceptance = termsStatus(latestProjection) === 'PRESENTED'
+        && paymentStatus(latestProjection) === 'NOT_STARTED'
+        && !paymentInstructionPattern.test(normalize(ambiguousReply));
+
+      latestProjection = await sendAndWait(
+        page,
+        alias,
+        'Aceito claramente os termos apresentados e quero seguir com a contratação.',
+        latestProjection,
+      );
+      evidence.clearAcceptance = termsStatus(latestProjection) === 'ACCEPTED'
+        && paymentStatus(latestProjection) === 'NOT_STARTED';
+
+      latestProjection = await sendAndWait(page, alias, 'Prefiro pagar por PIX.', latestProjection);
+      const paymentReply = lastOutboundTextFor(latestProjection, /prefiro pagar por pix/i);
+      evidence.paymentInstruction = paymentStatus(latestProjection) === 'PREPARED'
+        && paymentInstructionPattern.test(normalize(paymentReply))
+        && hasOnlyTestResource(paymentReply);
+
+      const outboundBeforeProof = outboundCount(latestProjection);
+      await enqueueCustomerMessage(
+        page,
+        alias,
+        'Envio agora o comprovante de teste para validação humana.',
+        'PAYMENT_PROOF',
+      );
+      latestProjection = await waitForCanonicalReply(page, alias, outboundBeforeProof);
+      const proofInbound = latestInboundByText(latestProjection, /comprovante de teste/);
+      const proofReply = proofInbound === null ? [] : outboundForCorrelation(latestProjection, proofInbound.correlationId);
+      const proofAckCount = proofReply.filter((message) => handoffPattern.test(message.text ?? '')).length;
+      const allHandoffMessages = outboundMessages(latestProjection)
+        .filter((message) => handoffPattern.test(message.text ?? ''));
+      evidence.proofHandoff = paymentStatus(latestProjection) === 'PROOF_RECEIVED'
+        && ownership(latestProjection) === 'HUMAN'
+        && outboundCount(latestProjection) > outboundBeforeProof
+        && proofReply.length === 1
+        && proofAckCount === 1
+        && allHandoffMessages.length === 1
+        && proofInbound !== null
+        && latestProjection.messages.indexOf(allHandoffMessages[0]!) > latestProjection.messages.indexOf(proofInbound);
+      evidence.observations.push(`handoff após comprovante: ownership=${ownership(latestProjection) ?? 'ausente'}, acks canônicos=${proofAckCount}`);
+
+      // The proof is injected as an external ingress event rather than typed
+      // through the local composer. Reload so the POC consumes that canonical
+      // projection through its normal initial synchronization path.
+      await page.reload();
+      await expect(page.getByRole('heading', { name: contactName })).toBeVisible();
+      await expect(page.getByRole('textbox', { name: /^mensagem$/i })).toBeDisabled();
+      await expect(page.getByLabel(/responsabilidade: atendimento humano/i)).toBeVisible();
+
+      const outboundBeforeHumanMessage = outboundCount(latestProjection);
+      await enqueueCustomerMessage(page, alias, 'Tenho uma dúvida enquanto aguardo o atendimento humano.');
+      latestProjection = await waitForHumanMessageAndSilence(
+        page,
+        alias,
+        /tenho uma dúvida enquanto aguardo o atendimento humano/i,
+        outboundBeforeHumanMessage,
+      );
+      evidence.humanSilence = ownership(latestProjection) === 'HUMAN'
+        && outboundCount(latestProjection) === outboundBeforeHumanMessage;
+
+      const approveButton = page.getByRole('button', { name: /aprovar pagamento.*ação da arquiteta\/teste/i });
+      await expect(approveButton).toBeVisible();
+      await approveButton.click();
+      latestProjection = await waitForProjection(
+        page,
+        alias,
+        (candidate) => ownership(candidate) === 'HUMAN' && paymentStatus(candidate) === 'CONFIRMED',
+        'pagamento confirmado pela ação local da arquiteta',
+      );
+
+      const humanDecision = 'Pagamento validado; pode seguir com o próximo passo do atendimento.';
+      const humanMessageBox = page.getByRole('textbox', { name: /mensagem humana.*ação da arquiteta\/teste/i });
+      await humanMessageBox.fill(humanDecision);
+      await page.getByRole('button', { name: /registrar mensagem humana.*ação da arquiteta\/teste/i }).click();
+      latestProjection = await waitForProjection(
+        page,
+        alias,
+        (candidate) => candidate.messages.some((message) => message.senderType === 'HUMAN' && message.text === humanDecision),
+        'mensagem de decisão humana canônica',
+      );
+      evidence.canonicalHumanDecision = latestProjection.messages.some(
+        (message) => message.senderType === 'HUMAN' && message.text === humanDecision,
+      );
+
+      const projectionBeforeReturn = latestProjection;
+      // Controls are backed by the canonical projection; resync after the
+      // operator action before exercising the next control in this external
+      // ingress scenario.
+      await page.reload();
+      await expect(page.getByRole('heading', { name: contactName })).toBeVisible();
+      const returnButton = page.getByRole('button', { name: /devolver responsabilidade.*ação da arquiteta\/teste/i });
+      await expect(returnButton).toBeVisible();
+      const resumeObservation = waitForResumeAndProactiveReply(
+        page,
+        alias,
+        projectionBeforeReturn,
+      );
+      await returnButton.click();
+      const resumeResult = await resumeObservation;
+      latestProjection = resumeResult.projection;
+      evidence.resumed = ownership(latestProjection) === 'URBA'
+        && resumeStatus(latestProjection) === 'COMPLETED'
+        && resumeResult.pendingSnapshots.every((candidate) => ownership(candidate) === 'HUMAN'
+          && outboundCount(candidate) <= outboundCount(projectionBeforeReturn));
+      const resumedMessages = new Set(projectionBeforeReturn.messages.map((message) => message.id));
+      const proactiveMessages = latestProjection.messages
+        .filter((message) => !resumedMessages.has(message.id))
+        .filter((message) => message.direction === 'OUTBOUND' && message.senderType === 'URBA');
+      evidence.proactiveContinuation = proactiveMessages.length === 1
+        && /briefing|medidas|fotos|v[ií]deos|material/i.test(normalize(proactiveMessages[0]?.text ?? ''));
+      evidence.observations.push(`retomada: ownership=${ownership(latestProjection) ?? 'ausente'}, status=${resumeStatus(latestProjection) ?? 'ausente'}, mensagens proativas=${proactiveMessages.length}`);
+
+      evidence.transcriptIntegrity = hasCanonicalTranscript(latestProjection)
+        && latestProjection.messages.some((message) => message.senderType === 'HUMAN' && message.text === humanDecision);
+      evidence.safeLanguage = hasSafeCustomerLanguage(latestProjection);
+
+      const rubric = evaluateTranscript(latestProjection, evidence);
+      await attachQualityReport(testInfo, alias, latestProjection, rubric);
+      expect(rubric.failures, formatDiagnostic(rubric)).toEqual([]);
+    } catch (error) {
+      evidence.observations.push(`falha de execução: ${error instanceof Error ? error.message : 'erro não textual'}`);
+      if (alias.length > 0) {
+        latestProjection = await fetchProjectionSafely(page, alias, latestProjection);
+      }
+      const rubric = latestProjection === null
+        ? unavailableProjectionRubric()
+        : evaluateTranscript(latestProjection, evidence);
+      await attachQualityReport(testInfo, alias, latestProjection, rubric);
+      throw error;
+    }
+  });
+});
+
+async function createContact(page: Page, name: string): Promise<void> {
+  await page.getByRole('textbox', { name: /nome do contato/i }).fill(name);
+  await page.getByRole('button', { name: /criar contato/i }).click();
+  await expect(page.getByRole('heading', { name })).toBeVisible();
+}
+
+async function sendAndCaptureAlias(page: Page, text: string): Promise<string> {
+  const requestPromise = page.waitForRequest((request) => request.method() === 'POST'
+    && /\/api\/poc\/conversations\/manual-[a-f0-9-]{36}\/messages$/.test(new URL(request.url()).pathname));
+  await sendMessage(page, text);
+  const request = await requestPromise;
+  const match = new URL(request.url()).pathname.match(/\/conversations\/(manual-[a-f0-9-]{36})\/messages$/);
+  if (match?.[1] === undefined) {
+    throw new Error(`Não foi possível obter o alias local da URL ${request.url()}.`);
+  }
+  return match[1];
+}
+
+async function sendAndWait(
+  page: Page,
+  alias: string,
+  text: string,
+  previousProjection: Projection,
+): Promise<Projection> {
+  await sendMessage(page, text);
+  return waitForCanonicalReply(page, alias, outboundCount(previousProjection));
+}
+
+async function sendMessage(page: Page, text: string): Promise<void> {
+  const composer = page.getByRole('textbox', { name: /mensagem/i });
+  await composer.fill(text);
+  await composer.press('Enter');
+  await expect(page.getByText(text, { exact: true })).toBeVisible();
+}
+
+async function enqueueCustomerMessage(
+  page: Page,
+  alias: string,
+  text: string,
+  type: 'TEXT' | 'PAYMENT_PROOF' = 'TEXT',
+): Promise<void> {
+  const result = await page.evaluate(async ({ contactAlias, message, messageType }) => {
+    const response = await fetch(`/api/poc/conversations/${encodeURIComponent(contactAlias)}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventId: `ui-${crypto.randomUUID()}`,
+        type: messageType,
+        text: message,
+        occurredAt: new Date().toISOString(),
+      }),
+    });
+    return { status: response.status, body: await response.text() };
+  }, { contactAlias: alias, message: text, messageType: type });
+  if (result.status >= 500) {
+    throw new Error(`A mensagem de observação humana retornou HTTP ${result.status}.`);
+  }
+}
+
+async function waitForCanonicalReply(page: Page, alias: string, previousOutbound: number): Promise<Projection> {
+  let last: Projection | null = null;
+  await expect.poll(async () => {
+    last = await fetchProjection(page, alias);
+    return outboundCount(last);
+  }, { timeout: turnTimeoutMs, intervals: [1_000, 2_000, 5_000] }).toBeGreaterThan(previousOutbound);
+  return last ?? fetchProjection(page, alias);
+}
+
+async function waitForHumanMessageAndSilence(
+  page: Page,
+  alias: string,
+  messagePattern: RegExp,
+  previousOutbound: number,
+): Promise<Projection> {
+  let last: Projection | null = null;
+  await expect.poll(async () => {
+    last = await fetchProjection(page, alias);
+    return last.messages.some((message) => message.direction === 'INBOUND'
+      && message.senderType === 'CONTACT'
+      && messagePattern.test(message.text ?? ''))
+      && ownership(last) === 'HUMAN'
+      && outboundCount(last) === previousOutbound;
+  }, { timeout: turnTimeoutMs, intervals: [1_000, 2_000, 5_000] }).toBe(true);
+  return last ?? fetchProjection(page, alias);
+}
+
+async function waitForProjection(
+  page: Page,
+  alias: string,
+  predicate: (projection: Projection) => boolean,
+  description: string,
+): Promise<Projection> {
+  let last: Projection | null = null;
+  await expect.poll(async () => {
+    last = await fetchProjection(page, alias);
+    return predicate(last);
+  }, { timeout: turnTimeoutMs, intervals: [1_000, 2_000, 5_000] }).toBe(true);
+  if (last === null) {
+    throw new Error(`A projeção não confirmou ${description}.`);
+  }
+  return last;
+}
+
+async function waitForResumeAndProactiveReply(
+  page: Page,
+  alias: string,
+  previousProjection: Projection,
+): Promise<{ projection: Projection; pendingSnapshots: Projection[] }> {
+  const pendingSnapshots: Projection[] = [];
+  let lastError: unknown = null;
+  const deadline = Date.now() + turnTimeoutMs;
+  while (Date.now() < deadline) {
+    let candidate: Projection | null = null;
+    try {
+      candidate = await fetchProjection(page, alias);
+    } catch (error) {
+      lastError = error;
+    }
+    if (candidate !== null) {
+      if (resumeStatus(candidate) === 'SYNCHRONIZING' || resumeStatus(candidate) === 'DECIDING'
+        || resumeStatus(candidate) === 'RECONCILING' || resumeStatus(candidate) === 'PENDING') {
+        pendingSnapshots.push(candidate);
+      }
+      if (ownership(candidate) === 'URBA' && resumeStatus(candidate) === 'COMPLETED') {
+        if (pendingSnapshots.some((pending) => outboundCount(pending) > outboundCount(previousProjection))) {
+          throw new Error('A projeção publicou resposta antes de concluir a sincronização da retomada.');
+        }
+        return { projection: candidate, pendingSnapshots };
+      }
+    }
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 1_000));
+  }
+
+  const detail = lastError instanceof Error ? `: ${lastError.message}` : '';
+  throw new Error(`A retomada não retornou uma projeção final antes do timeout${detail}.`);
+}
+
+async function fetchProjection(page: Page, alias: string): Promise<Projection> {
+  return page.evaluate(async (contactAlias) => {
+    const response = await fetch(`/api/poc/conversations/${encodeURIComponent(contactAlias)}`);
+    if (!response.ok) {
+      throw new Error(`Projection HTTP ${response.status}`);
+    }
+    const value: unknown = await response.json();
+    if (typeof value !== 'object' || value === null || !('messages' in value)
+      || !Array.isArray(value.messages) || !('conversation' in value)
+      || typeof value.conversation !== 'object' || value.conversation === null) {
+      throw new Error('Projection without canonical messages or conversation state');
+    }
+    return value as Projection;
+  }, alias);
+}
+
+async function fetchProjectionSafely(
+  page: Page,
+  alias: string,
+  fallback: Projection | null,
+): Promise<Projection | null> {
+  try {
+    return await fetchProjection(page, alias);
+  } catch {
+    return fallback;
+  }
+}
+
+function createQualityEvidence(): QualityEvidence {
+  return {
+    firstPresentation: false,
+    discovery: false,
+    comparison: false,
+    catalogExplanation: false,
+    noInformativeAdvance: false,
+    icpPrompt: false,
+    partialIcp: false,
+    termsAfterIcp: false,
+    ambiguousAcceptance: false,
+    clearAcceptance: false,
+    paymentInstruction: false,
+    proofHandoff: false,
+    humanSilence: false,
+    canonicalHumanDecision: false,
+    resumed: false,
+    proactiveContinuation: false,
+    transcriptIntegrity: false,
+    safeLanguage: false,
+    observations: [],
+  };
+}
+
+function evaluateTranscript(projection: Projection, evidence: QualityEvidence): RubricResult {
+  const criteria: Array<[string, boolean]> = [
+    ['primeira apresentação espontânea', evidence.firstPresentation],
+    ['descoberta e recomendação de Decor Pintura', evidence.discovery],
+    ['comparação factual entre serviços', evidence.comparison],
+    ['explicação progressiva do catálogo', evidence.catalogExplanation],
+    ['turno informativo sem avanço comercial', evidence.noInformativeAdvance],
+    ['checkpoint com os campos de enriquecimento ausentes', evidence.icpPrompt],
+    ['segunda mensagem somente com campos ainda ausentes', evidence.partialIcp],
+    ['termos apresentados somente após o checkpoint', evidence.termsAfterIcp],
+    ['aceite ambíguo não libera pagamento', evidence.ambiguousAcceptance],
+    ['aceite textual claro precede o pagamento', evidence.clearAcceptance],
+    ['instrução de pagamento de teste vinculada ao fluxo', evidence.paymentInstruction],
+    ['comprovante gera handoff canônico único', evidence.proofHandoff],
+    ['nenhuma resposta automática sob ownership humano', evidence.humanSilence],
+    ['decisão humana preservada como mensagem canônica', evidence.canonicalHumanDecision],
+    ['retorno HUMANO → URBA concluído', evidence.resumed],
+    ['continuação proativa única após sincronização', evidence.proactiveContinuation],
+    ['transcript integral sem duplicação', evidence.transcriptIntegrity],
+    ['linguagem visível sem detalhes técnicos', evidence.safeLanguage],
+  ];
+  const failures = criteria
+    .filter(([, passed]) => !passed)
+    .map(([label]) => `Critério não comprovado: ${label}.`);
+  const score = criteria.filter(([, passed]) => passed).length;
+  return {
+    score,
+    maximumScore: criteria.length,
+    failures,
+    observations: [
+      ...evidence.observations,
+      `ownership final: ${ownership(projection) ?? 'ausente'}`,
+      `resume final: ${resumeStatus(projection) ?? 'ausente'}`,
+      `mensagens canônicas: ${projection.messages.length}; respostas visíveis: ${outboundCount(projection)}`,
+      `status do último turno: ${projection.turn?.status ?? 'ausente'}`,
+    ],
+  };
+}
+
+function hasFirstPresentation(projection: Projection): boolean {
+  const firstOutbound = outboundMessages(projection)[0];
+  return firstOutbound?.senderType === 'URBA'
+    && containsAll(normalize(firstOutbound.text ?? ''), ['urba', 'urbana do brasil']);
+}
+
+function hasPaintingRecommendation(projection: Projection): boolean {
+  const text = normalize(repliesAfterCustomerQuestion(projection, /quarto infantil|pintura tem[aá]tica|reaproveitar/i).join('\n'));
+  return text.includes('decor pintura') && /pintura|tematic|dinossauro|dr[aã]gao|reaproveit/.test(text);
+}
+
+function hasServiceComparison(projection: Projection): boolean {
+  const text = normalize(repliesAfterCustomerQuestion(projection, /diferen[cç]a entre decor pintura e decor interiores/i).join('\n'));
+  return text.includes('decor pintura')
+    && text.includes('decor interiores')
+    && /pintura|desenho|tinta/.test(text)
+    && /layout|mobiliario|moveis|composicao/.test(text);
+}
+
+function hasCatalogExplanation(projection: Projection): boolean {
+  const text = normalize(repliesAfterCustomerQuestion(projection, /como funciona|detalhar entregas|o que eu recebo|processo|suporte/i).join('\n'));
+  return /consultoria\s+online|online.*consultoria/.test(text)
+    && /manual/.test(text)
+    && /tour\s+virtual/.test(text)
+    && /(?:3|tres)\s+op(?:c|ç)oes?/.test(text)
+    && /(?:2|duas)\s+rodadas?/.test(text);
+}
+
+function hasNoCommercialAdvance(projection: Projection): boolean {
+  return termsStatus(projection) === 'NOT_PRESENTED'
+    && paymentStatus(projection) === 'NOT_STARTED'
+    && ownership(projection) === 'URBA';
+}
+
+function hasAllIcpTopics(text: string): boolean {
+  return icpTopics(text).length === 3;
+}
+
+function hasRemainingIcpTopics(text: string): boolean {
+  const topics = icpTopics(text);
+  return topics.length > 0 && topics.length < 3;
+}
+
+function icpTopics(text: string): string[] {
+  return (['pronoun', 'firstTimeHiring', 'occupation'] as const).filter((topic) => hasTopic(text, topic));
+}
+
+function hasTopic(text: string, topic: 'pronoun' | 'firstTimeHiring' | 'occupation'): boolean {
+  const normalized = normalize(text);
+  if (topic === 'pronoun') {
+    return /pronome|tratamento|refir|cham[ae]d|senhor|senhora/.test(normalized);
+  }
+  if (topic === 'firstTimeHiring') {
+    return /primeir|contrat(ou|ar|a).*vez|ja.*contrat/.test(normalized);
+  }
+  return /profiss|ocupacao|profissional|area|trabalh|atuacao/.test(normalized);
+}
+
+function termsStatus(projection: Projection): string | undefined {
+  return projection.conversation.termsStatus;
+}
+
+function paymentStatus(projection: Projection): string | undefined {
+  return projection.conversation.paymentStatus;
+}
+
+function hasTermsBeenPresented(projection: Projection): boolean {
+  return termsStatus(projection) === 'PRESENTED' || termsStatus(projection) === 'ACCEPTED';
+}
+
+function hasPaymentBeenPrepared(projection: Projection): boolean {
+  return paymentStatus(projection) === 'PREPARED'
+    || paymentStatus(projection) === 'PROOF_RECEIVED'
+    || paymentStatus(projection) === 'CONFIRMED';
+}
+
+function ownership(projection: Projection): 'URBA' | 'HUMAN' | undefined {
+  return projection.ownership ?? projection.conversation.ownership
+    ?? (projection.conversation.mode === 'HUMAN' ? 'HUMAN' : undefined);
+}
+
+function resumeStatus(projection: Projection): string | undefined {
+  return projection.resumeStatus;
+}
+
+function outboundMessages(projection: Projection): CanonicalMessage[] {
+  return projection.messages.filter((message) => message.direction === 'OUTBOUND'
+    && (message.senderType === 'URBA' || message.senderType === 'HUMAN'));
+}
+
+function outboundCount(projection: Projection | null): number {
+  return projection === null ? 0 : outboundMessages(projection).length;
+}
+
+function lastOutboundText(projection: Projection): string {
+  return outboundMessages(projection).at(-1)?.text?.trim() ?? '';
+}
+
+function lastOutboundTextFor(projection: Projection, inboundPattern: RegExp): string {
+  const inboundIndex = [...projection.messages].reverse().findIndex((message) => message.direction === 'INBOUND'
+    && message.senderType === 'CONTACT'
+    && inboundPattern.test(message.text ?? ''));
+  if (inboundIndex < 0) {
+    return lastOutboundText(projection);
+  }
+  const actualIndex = projection.messages.length - 1 - inboundIndex;
+  const inbound = projection.messages[actualIndex];
+  if (inbound === undefined) {
+    return lastOutboundText(projection);
+  }
+  return outboundForCorrelation(projection, inbound.correlationId).at(-1)?.text?.trim()
+    ?? projection.messages.slice(actualIndex + 1).find((message) => message.direction === 'OUTBOUND')?.text?.trim()
+    ?? '';
+}
+
+function latestInboundByText(projection: Projection, pattern: RegExp): CanonicalMessage | null {
+  return [...projection.messages].reverse().find((message) => message.direction === 'INBOUND'
+    && message.senderType === 'CONTACT'
+    && pattern.test(message.text ?? '')) ?? null;
+}
+
+function outboundForCorrelation(projection: Projection, correlationId: string): CanonicalMessage[] {
+  return outboundMessages(projection).filter((message) => message.correlationId === correlationId);
+}
+
+function repliesAfterCustomerQuestion(projection: Projection, question: RegExp): string[] {
+  const replies: string[] = [];
+  projection.messages.forEach((message, index) => {
+    if (message.direction !== 'INBOUND' || message.senderType !== 'CONTACT' || !question.test(message.text ?? '')) {
+      return;
+    }
+    const correlated = outboundForCorrelation(projection, message.correlationId);
+    if (correlated.length > 0) {
+      replies.push(...correlated.map((candidate) => candidate.text ?? ''));
+      return;
+    }
+    for (let next = index + 1; next < projection.messages.length; next += 1) {
+      const candidate = projection.messages[next];
+      if (candidate?.direction === 'INBOUND') {
+        break;
+      }
+      if (candidate?.direction === 'OUTBOUND') {
+        replies.push(candidate.text ?? '');
+      }
+    }
+  });
+  return replies;
+}
+
+function hasOnlyTestResource(text: string): boolean {
+  const urls = text.match(/https?:\/\/[^\s)]+/gi) ?? [];
+  return urls.every((url) => /localhost|127\.0\.0\.1|\.local(?:\/|$)|\.test(?:\/|$)|poc|teste|test/i.test(url));
+}
+
+function hasSafeCustomerLanguage(projection: Projection): boolean {
+  return outboundMessages(projection).every((message) => !technicalLanguagePattern.test(normalize(message.text ?? '')));
+}
+
+function hasCanonicalTranscript(projection: Projection): boolean {
+  const ids = new Set<string>();
+  const eventFallbacks = new Set<string>();
+  return projection.messages.length > 0
+    && projection.messages.every((message) => {
+      const eventFallback = `${message.eventId}|${message.direction}|${message.correlationId}`;
+      if (ids.has(message.id) || eventFallbacks.has(eventFallback)) {
+        return false;
+      }
+      ids.add(message.id);
+      eventFallbacks.add(eventFallback);
+      return message.eventId.length > 0
+        && message.correlationId.length > 0
+        && message.contactId === projection.contactId
+        && (message.type === 'TEXT'
+          || (message.direction === 'INBOUND'
+            && message.senderType === 'CONTACT'
+            && message.type === 'PAYMENT_PROOF'))
+        && message.createdAt.length > 0;
+    });
+}
+
+function containsAll(text: string, values: string[]): boolean {
+  return values.every((value) => text.includes(value));
+}
+
+function normalize(value: string): string {
+  return value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+}
+
+function unavailableProjectionRubric(): RubricResult {
+  return {
+    score: 0,
+    maximumScore: 18,
+    failures: ['Infraestrutura/projeção: não foi possível obter o transcript canônico para uma avaliação honesta.'],
+    observations: [],
+  };
+}
+
+async function attachQualityReport(
+  testInfo: TestInfo,
+  alias: string,
+  projection: Projection | null,
+  rubric: RubricResult,
+): Promise<void> {
+  const report = {
+    alias: alias || null,
+    rubric,
+    transcript: projection?.messages.map((message) => ({
+      createdAt: message.createdAt,
+      direction: message.direction,
+      senderType: message.senderType,
+      correlationId: message.correlationId,
+      text: message.text,
+    })) ?? [],
+    ownership: projection === null ? null : ownership(projection) ?? null,
+    resumeStatus: projection === null ? null : resumeStatus(projection) ?? null,
+    turn: projection?.turn ?? null,
+  };
+  await testInfo.attach('quality-chat-transcript.json', {
+    body: JSON.stringify(report, null, 2),
+    contentType: 'application/json',
+  });
+}
+
+function formatDiagnostic(rubric: RubricResult): string {
+  return [
+    `Score de qualidade: ${rubric.score}/${rubric.maximumScore}`,
+    ...rubric.failures.map((failure) => `- ${failure}`),
+    ...rubric.observations.map((observation) => `- ${observation}`),
+  ].join('\n');
+}

--- a/apps/poc-chat/nginx/default.conf.template
+++ b/apps/poc-chat/nginx/default.conf.template
@@ -80,8 +80,36 @@ server {
         proxy_hide_header Access-Control-Allow-Methods;
     }
 
-    # No API route is proxied by default. This also blocks /flush, metrics,
-    # payment-proof and tool endpoints exposed by the backend POC controller.
+    # Operator-only controls for the local POC. They use an opaque contact
+    # alias and the server-side token, and never share the customer ingress.
+    location ~ "^/api/poc/conversations/(manual-[a-f0-9-]{36})/(human/messages|ownership/urba|payment-proof/approve)$" {
+        if ($request_method != POST) { return 405; }
+
+        proxy_pass http://urbana_connect_poc;
+        proxy_http_version 1.1;
+        proxy_set_header Host urbana-connect;
+        proxy_set_header Authorization "Bearer ${HERMES_POC_API_TOKEN}";
+        proxy_set_header Proxy-Authorization "";
+        proxy_set_header Cookie "";
+        proxy_set_header Origin "";
+        proxy_set_header Referer "";
+        proxy_set_header X-Forwarded-For "";
+        proxy_set_header X-Forwarded-Host "";
+        proxy_set_header X-Forwarded-Proto "";
+        proxy_set_header X-Real-IP "";
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 10s;
+        proxy_read_timeout 35s;
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Credentials;
+        proxy_hide_header Access-Control-Allow-Headers;
+        proxy_hide_header Access-Control-Allow-Methods;
+    }
+
+    # No other API route is proxied by default. This blocks /flush, metrics,
+    # tools and every internal or legacy endpoint exposed by the backend POC.
     location /api/ {
         return 404;
     }

--- a/apps/poc-chat/nginx/nginx.contract.test.ts
+++ b/apps/poc-chat/nginx/nginx.contract.test.ts
@@ -12,7 +12,7 @@ const readRepository = (relativePath: string) =>
   readFileSync(resolve(repositoryRoot, relativePath), "utf8");
 
 describe("poc-chat container contract", () => {
-  it("keeps the browser surface to the two chat routes and health", () => {
+  it("keeps the browser surface to chat, local operator controls and health", () => {
     const template = readApp("nginx/default.conf.template");
 
     expect(template).toMatch(
@@ -21,7 +21,9 @@ describe("poc-chat container contract", () => {
     expect(template).toMatch(/\/messages\$\s*"?\s*\{/);
     expect(template).toMatch(/location\s+~\*?\s+"?\^\/api\/poc\/conversations\/\(manual-[^\n]+\)\$"?\s*\{/);
     expect(template).toMatch(/location\s*=\s*\/health\s*\{/);
+    expect(template).toContain("human/messages|ownership/urba|payment-proof/approve");
     expect(template).toMatch(/location\s+\/api\/\s*\{\s*return\s+404;/s);
+    expect(template).toContain("# No other API route is proxied by default.");
     expect(template).toMatch(/try_files\s+\$uri\s*=404;/);
   });
 
@@ -61,5 +63,21 @@ describe("poc-chat container contract", () => {
     expect(dockerfile).toContain("/docker-entrypoint.d/10-poc-token.sh");
     expect(compose).toMatch(/\/etc\/nginx\/conf\.d/);
     expect(compose).toMatch(/tmpfs:/);
+  });
+
+  it("builds the backend image from the current source and preserves local compose wiring", () => {
+    const backendDockerfile = readRepository("apps/urbana-connect-api/Dockerfile.poc.runtime-jar");
+    const compose = readRepository("infra/local-poc/docker-compose.poc.yml");
+
+    expect(backendDockerfile).toMatch(/^FROM eclipse-temurin:21-jdk-jammy AS build/m);
+    expect(backendDockerfile).toContain("COPY gradle.properties .");
+    expect(backendDockerfile).toMatch(/\.\/gradlew --no-daemon clean bootJar/);
+    expect(backendDockerfile).toMatch(/COPY --from=build \/workspace\/app\/build\/libs\/\*\.jar app\.jar/);
+    expect(backendDockerfile).not.toMatch(/COPY build\/libs\/[^\n]+ app\.jar/);
+
+    expect(compose).toMatch(/urbana-connect:\s*\n\s+build:\s*\n\s+context: \.\.\/\.\.\/apps\/urbana-connect-api/);
+    expect(compose).toMatch(/dockerfile: Dockerfile\.poc\.runtime-jar/);
+    expect(compose).toMatch(/poc-chat:\s*\n\s+build:[\s\S]*?depends_on:\s*\n\s+urbana-connect:\s*\n\s+condition: service_healthy/);
+    expect(compose).toContain("HERMES_POC_API_TOKEN: ${HERMES_INTERNAL_TOOL_TOKEN");
   });
 });

--- a/apps/poc-chat/src/App.tsx
+++ b/apps/poc-chat/src/App.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { ConversationClient } from './api/conversationClient';
+import { createIdempotencyKey } from './api/contracts';
+import type { PocControlAction, PocControlAvailability } from './api/contracts';
 import { ChatView } from './components/ChatView';
 import { ConversationList } from './components/ConversationList';
 import {
@@ -14,6 +16,7 @@ import {
   conversationReducer,
   createConversationState,
   createConversationUiState,
+  type ConversationUiState,
   type ConversationState,
 } from './state/conversationReducer';
 import { ConversationTracker } from './state/conversationTracker';
@@ -97,8 +100,51 @@ export default function App() {
     }
   }
 
+  async function handlePocControl(action: PocControlAction, humanMessage?: string): Promise<void> {
+    const alias = uiState.activeContactAlias;
+    const conversation = alias === null ? undefined : conversationRef.current[alias];
+    if (alias === null || conversation === undefined) {
+      throw new Error('Ação local indisponível.');
+    }
+    if (action === 'APPROVE_PAYMENT_PROOF') {
+      if (typeof client.approvePaymentProof !== 'function') {
+        throw new Error('Ação local indisponível.');
+      }
+      await client.approvePaymentProof(alias);
+    } else if (action === 'RECORD_HUMAN_MESSAGE') {
+      if (conversation.ownership !== 'HUMAN'
+          || typeof client.recordHumanMessage !== 'function'
+          || humanMessage === undefined
+          || humanMessage.trim().length === 0) {
+        throw new Error('Ação local indisponível.');
+      }
+      await client.recordHumanMessage(alias, createIdempotencyKey(), {
+        text: humanMessage.trim(),
+        occurredAt: new Date().toISOString(),
+      });
+    } else {
+      if (conversation.ownership !== 'HUMAN'
+          || conversation.conversationVersion === null
+          || typeof client.returnToUrba !== 'function') {
+        throw new Error('Ação local indisponível.');
+      }
+      await client.returnToUrba(
+        alias,
+        createIdempotencyKey(),
+        conversation.conversationVersion,
+      );
+    }
+    await tracker.sync(alias);
+  }
+
   const contacts = uiState.contacts.filter((contact) => !contact.archived);
   const activeContact = contacts.find((contact) => contact.contactAlias === uiState.activeContactAlias) ?? null;
+  const activeConversation = activeContact === null
+    ? null
+    : conversationState[activeContact.contactAlias] ?? createConversationUiState();
+  const activePocControls = activeConversation === null
+    ? null
+    : availablePocControls(activeConversation, client);
   const unreadAliases = new Set(
     Object.entries(conversationState)
       .filter(([, state]) => state.unread)
@@ -134,9 +180,10 @@ export default function App() {
         {activeContact ? (
           <ChatView
             contact={activeContact}
-            conversation={conversationState[activeContact.contactAlias] ?? createConversationUiState()}
+            conversation={{ ...activeConversation!, pocControls: activePocControls }}
             onSend={handleSend}
             onRetry={handleRetry}
+            onPocControl={handlePocControl}
           />
         ) : (
           <section className="welcome-panel" aria-label="Boas-vindas">
@@ -148,6 +195,27 @@ export default function App() {
       </div>
     </div>
   );
+}
+
+function availablePocControls(
+  conversation: ConversationUiState,
+  client: ConversationClient,
+): PocControlAvailability | null {
+  if (conversation.pocControls === null) {
+    return null;
+  }
+  const humanOwned = conversation.ownership === 'HUMAN' || conversation.mode === 'HUMAN';
+  return {
+    approvePaymentProof: conversation.pocControls.approvePaymentProof
+      && typeof client.approvePaymentProof === 'function',
+    recordHumanMessage: humanOwned
+      && conversation.pocControls.recordHumanMessage
+      && typeof client.recordHumanMessage === 'function',
+    returnToUrba: humanOwned
+      && conversation.pocControls.returnToUrba
+      && conversation.conversationVersion !== null
+      && typeof client.returnToUrba === 'function',
+  };
 }
 
 function normalizeInitialUiState(state: PersistedUiState): PersistedUiState {

--- a/apps/poc-chat/src/api/contracts.test.ts
+++ b/apps/poc-chat/src/api/contracts.test.ts
@@ -1,5 +1,7 @@
 import {
+  parseHumanMessageReceipt,
   parseConversationProjection,
+  parseResumeReceipt,
   parseTurnReceipt,
   type TurnSummary,
 } from './contracts';
@@ -68,6 +70,122 @@ describe('safe conversation contract', () => {
     }, CONTACT_ID).turn).toBeNull();
   });
 
+  it('accepts additive legacy ownership, resume and local-control fields without exposing internals', () => {
+    const parsed = parseConversationProjection({
+      contactId: CONTACT_ID,
+      conversation: {
+        mode: 'HUMAN',
+        ownership: 'HUMAN',
+        resume: {
+          status: 'RECONCILING',
+          retryAllowed: false,
+          failureClass: 'HUMAN_CONTEXT_PENDING',
+          hermesSessionId: 'secret-session',
+          rawError: 'secret-error',
+        },
+      pocControls: {
+          approvePaymentProof: true,
+          recordDecision: false,
+          returnToUrba: true,
+          endpoint: '/internal/secret',
+        },
+        internalOwnerId: 'secret-owner',
+      },
+      messages: [],
+      turn: null,
+    }, CONTACT_ID);
+
+    expect(parsed.conversation).toEqual({
+      mode: 'HUMAN',
+      ownership: 'HUMAN',
+      resume: {
+        status: 'RECONCILING',
+        retryAllowed: false,
+        failureClass: 'HUMAN_CONTEXT_PENDING',
+      },
+      pocControls: {
+        approvePaymentProof: true,
+        recordHumanMessage: false,
+        returnToUrba: true,
+      },
+    });
+    expect(JSON.stringify(parsed)).not.toMatch(/secret-session|secret-error|secret-owner|internal\/secret/i);
+  });
+
+  it('normalizes the current top-level ownership, resume, version and control projection', () => {
+    const parsed = parseConversationProjection({
+      contactId: CONTACT_ID,
+      ownership: 'HUMAN',
+      resumeStatus: 'SYNCHRONIZING',
+      resumeId: 'resume-123',
+      controlAvailability: {
+        approvePaymentProof: true,
+        recordHumanMessage: true,
+        returnToUrba: true,
+        internalEndpoint: '/secret/internal',
+      },
+      conversation: {
+        mode: 'HUMAN',
+        version: 7,
+        internalOwnerId: 'secret-owner',
+      },
+      messages: [],
+      turn: null,
+    }, CONTACT_ID);
+
+    expect(parsed).toMatchObject({
+      ownership: 'HUMAN',
+      resumeStatus: 'SYNCHRONIZING',
+      resumeId: 'resume-123',
+      conversationVersion: 7,
+      controlAvailability: {
+        approvePaymentProof: true,
+        recordHumanMessage: true,
+        returnToUrba: true,
+      },
+      conversation: { mode: 'HUMAN' },
+    });
+    expect(JSON.stringify(parsed)).not.toMatch(/secret-owner|internalEndpoint|secret\/internal/i);
+  });
+
+  it('preserves the version when a normalized projection is validated again', () => {
+    const raw = {
+      contactId: CONTACT_ID,
+      conversation: { mode: 'HUMAN', version: 7 },
+      messages: [],
+      turn: null,
+    };
+
+    const normalized = parseConversationProjection(raw, CONTACT_ID);
+    const revalidated = parseConversationProjection(normalized, CONTACT_ID);
+
+    expect(revalidated.conversationVersion).toBe(7);
+  });
+
+  it('accepts all backend resume statuses while keeping the legacy statuses parseable', () => {
+    for (const status of [
+      'NONE',
+      'PENDING',
+      'SYNCHRONIZING',
+      'DECIDING',
+      'COMPLETED',
+      'RETURNED_TO_HUMAN',
+      'FAILED_SAFE',
+      'RECONCILING',
+      'FAILED_SAFE_TO_RETRY',
+      'FAILED_TERMINAL',
+    ]) {
+      expect(parseConversationProjection({
+        contactId: CONTACT_ID,
+        ownership: 'URBA',
+        resumeStatus: status,
+        conversation: {},
+        messages: [],
+        turn: null,
+      }, CONTACT_ID).resumeStatus).toBe(status);
+    }
+  });
+
   it('keeps the event identity when parsing an accepted receipt', () => {
     expect(parseTurnReceipt({
       eventId: EVENT_ID,
@@ -76,5 +194,37 @@ describe('safe conversation contract', () => {
       output: null,
       error: null,
     }, EVENT_ID).eventId).toBe(EVENT_ID);
+  });
+
+  it('parses the human-message and ownership-resume receipts without exposing technical fields', () => {
+    expect(parseHumanMessageReceipt({
+      eventId: 'human-event-1',
+      status: 'RECORDED',
+      duplicate: false,
+      message: 'Mensagem humana registrada.',
+      internalSessionId: 'secret-session',
+    })).toEqual({
+      eventId: 'human-event-1',
+      status: 'RECORDED',
+      duplicate: false,
+      message: 'Mensagem humana registrada.',
+    });
+
+    expect(parseResumeReceipt({
+      resumeId: 'resume-123',
+      status: 'SYNCHRONIZING',
+      ownership: 'HUMAN',
+      message: null,
+      duplicate: false,
+      customerMessage: 'A conversa permanece com a arquiteta.',
+      internalSessionId: 'secret-session',
+    })).toEqual({
+      resumeId: 'resume-123',
+      status: 'SYNCHRONIZING',
+      ownership: 'HUMAN',
+      message: null,
+      duplicate: false,
+      customerMessage: 'A conversa permanece com a arquiteta.',
+    });
   });
 });

--- a/apps/poc-chat/src/api/contracts.ts
+++ b/apps/poc-chat/src/api/contracts.ts
@@ -5,6 +5,25 @@ export const EVENT_ID_PATTERN = /^ui-[a-f0-9-]{36}$/;
 export type MessageDirection = 'INBOUND' | 'OUTBOUND';
 export type MessageSender = 'CONTACT' | 'URBA' | 'HUMAN' | 'SYSTEM';
 export type ConversationMode = 'AI' | 'HUMAN';
+export type ConversationOwnership = 'URBA' | 'HUMAN';
+export type ResumeStatus =
+  | 'NONE'
+  | 'PENDING'
+  | 'SYNCHRONIZING'
+  | 'DECIDING'
+  | 'COMPLETED'
+  | 'RETURNED_TO_HUMAN'
+  | 'FAILED_SAFE'
+  // Legacy projection values remain accepted during the POC transition.
+  | 'IDLE'
+  | 'WAITING'
+  | 'RECONCILING'
+  | 'FAILED_SAFE_TO_RETRY'
+  | 'FAILED_TERMINAL';
+export type PocControlAction =
+  | 'APPROVE_PAYMENT_PROOF'
+  | 'RECORD_HUMAN_MESSAGE'
+  | 'RETURN_TO_URBA';
 export type TurnStatus =
   | 'QUEUED'
   | 'RUNNING'
@@ -30,7 +49,24 @@ export interface CanonicalMessage {
 
 export interface ConversationSummary {
   mode?: ConversationMode;
-  [key: string]: unknown;
+  ownership?: ConversationOwnership;
+  resume?: ResumeSummary | null;
+  pocControls?: PocControlAvailability | null;
+  resumeStatus?: ResumeStatus;
+  resumeId?: string | null;
+  controlAvailability?: PocControlAvailability | null;
+}
+
+export interface ResumeSummary {
+  status: ResumeStatus;
+  retryAllowed: boolean;
+  failureClass: string | null;
+}
+
+export interface PocControlAvailability {
+  approvePaymentProof: boolean;
+  recordHumanMessage: boolean;
+  returnToUrba: boolean;
 }
 
 export interface ConversationProjection {
@@ -38,6 +74,11 @@ export interface ConversationProjection {
   conversation: ConversationSummary;
   messages: CanonicalMessage[];
   turn: TurnSummary | null;
+  ownership?: ConversationOwnership;
+  resumeStatus?: ResumeStatus;
+  resumeId?: string | null;
+  controlAvailability?: PocControlAvailability;
+  conversationVersion?: number;
 }
 
 export interface TurnSummary {
@@ -69,6 +110,27 @@ export interface SyntheticTextPayload {
   type: 'TEXT';
   text: string;
   occurredAt: string;
+}
+
+export interface HumanMessagePayload {
+  text: string;
+  occurredAt: string;
+}
+
+export interface HumanMessageReceipt {
+  eventId: string;
+  status: string;
+  duplicate: boolean;
+  message: string | null;
+}
+
+export interface ResumeReceipt {
+  resumeId: string | null;
+  status: ResumeStatus;
+  ownership: ConversationOwnership;
+  message: string | null;
+  duplicate: boolean;
+  customerMessage: string | null;
 }
 
 export function canonicalContactId(contactAlias: string): string {
@@ -116,12 +178,50 @@ export function parseConversationProjection(
     throw new Error('invalid conversation projection');
   }
 
-  return {
+  const conversation = parseConversationSummary(value.conversation);
+  const projection: ConversationProjection = {
     contactId: value.contactId,
-    conversation: value.conversation as ConversationSummary,
+    conversation,
     messages: value.messages.filter(isCanonicalMessage),
     turn: value.turn === undefined || value.turn === null ? null : parseTurnSummary(value.turn),
   };
+
+  const ownership = parseOwnership(value.ownership);
+  if (ownership !== undefined) {
+    projection.ownership = ownership;
+    conversation.ownership = ownership;
+  }
+
+  const resumeStatus = parseResumeStatus(value.resumeStatus);
+  if (resumeStatus !== undefined) {
+    projection.resumeStatus = resumeStatus;
+    conversation.resumeStatus = resumeStatus;
+  }
+
+  if (hasOwn(value, 'resumeId')) {
+    const resumeId = parseNullableString(value.resumeId);
+    projection.resumeId = resumeId;
+    conversation.resumeId = resumeId;
+  }
+
+  const controlAvailability = parseControlAvailability(value.controlAvailability);
+  if (controlAvailability !== null) {
+    projection.controlAvailability = controlAvailability;
+    conversation.controlAvailability = controlAvailability;
+  }
+
+  // The HTTP client returns this normalized projection to the reducer, which
+  // validates it once more before committing it to UI state. Preserve the
+  // normalized field as well as the raw backend locations so optimistic and
+  // canonical paths expose the same concurrency version.
+  const conversationVersion = parseVersion(value.version)
+    ?? parseVersion(value.conversationVersion)
+    ?? parseVersion(value.conversation.version);
+  if (conversationVersion !== undefined) {
+    projection.conversationVersion = conversationVersion;
+  }
+
+  return projection;
 }
 
 export function parseTurnSummary(value: unknown): TurnSummary {
@@ -151,9 +251,10 @@ export function parseTurnSummary(value: unknown): TurnSummary {
   };
 }
 
-export function parseTurnReceipt(value: unknown, expectedEventId: string): TurnReceipt {
+export function parseTurnReceipt(value: unknown, expectedEventId?: string): TurnReceipt {
   if (!isRecord(value)
-      || value.eventId !== expectedEventId
+      || !isNonEmptyString(value.eventId)
+      || (expectedEventId !== undefined && value.eventId !== expectedEventId)
       || !isNonEmptyString(value.correlationId)
       || !isTurnReceiptStatus(value.status)) {
     throw new Error('invalid turn receipt');
@@ -168,8 +269,50 @@ export function parseTurnReceipt(value: unknown, expectedEventId: string): TurnR
   };
 }
 
+export function parseHumanMessageReceipt(value: unknown): HumanMessageReceipt {
+  if (!isRecord(value)
+      || !isNonEmptyString(value.eventId)
+      || !isNonEmptyString(value.status)
+      || typeof value.duplicate !== 'boolean'
+      || !isNullableString(value.message)) {
+    throw new Error('invalid human message receipt');
+  }
+
+  return {
+    eventId: value.eventId,
+    status: value.status,
+    duplicate: value.duplicate,
+    message: value.message,
+  };
+}
+
+export function parseResumeReceipt(value: unknown): ResumeReceipt {
+  if (!isRecord(value)
+      || !isNullableString(value.resumeId)
+      || !isResumeStatus(value.status)
+      || !isOwnership(value.ownership)
+      || !isNullableString(value.message)
+      || typeof value.duplicate !== 'boolean'
+      || !isNullableString(value.customerMessage)) {
+    throw new Error('invalid resume receipt');
+  }
+
+  return {
+    resumeId: value.resumeId,
+    status: value.status,
+    ownership: value.ownership,
+    message: value.message,
+    duplicate: value.duplicate,
+    customerMessage: value.customerMessage,
+  };
+}
+
 export function createEventId(uuidFactory: () => string = () => crypto.randomUUID()): string {
   return `ui-${uuidFactory()}`;
+}
+
+export function createIdempotencyKey(uuidFactory: () => string = () => crypto.randomUUID()): string {
+  return `poc-${uuidFactory()}`;
 }
 
 export function createContactAlias(uuidFactory: () => string = () => crypto.randomUUID()): string {
@@ -191,8 +334,117 @@ function isTurnReceiptStatus(value: unknown): value is TurnReceiptStatus {
   return value === 'DUPLICATE' || isTurnStatus(value);
 }
 
+function parseConversationSummary(value: Record<string, unknown>): ConversationSummary {
+  const summary: ConversationSummary = {};
+  if (value.mode === 'AI' || value.mode === 'HUMAN') {
+    summary.mode = value.mode;
+  }
+  if (value.ownership === 'URBA' || value.ownership === 'HUMAN') {
+    summary.ownership = value.ownership;
+  }
+  if (value.resume === null) {
+    summary.resume = null;
+  } else if (isRecord(value.resume)) {
+    const resume = parseResumeSummary(value.resume);
+    if (resume !== null) {
+      summary.resume = resume;
+    }
+  }
+  if (isRecord(value.pocControls)) {
+    summary.pocControls = {
+      approvePaymentProof: value.pocControls.approvePaymentProof === true,
+      recordHumanMessage: value.pocControls.recordHumanMessage === true
+        || value.pocControls.recordDecision === true,
+      returnToUrba: value.pocControls.returnToUrba === true,
+    };
+  }
+  const resumeStatus = parseResumeStatus(value.resumeStatus);
+  if (resumeStatus !== undefined) {
+    summary.resumeStatus = resumeStatus;
+  }
+  if (hasOwn(value, 'resumeId')) {
+    summary.resumeId = parseNullableString(value.resumeId);
+  }
+  const controlAvailability = parseControlAvailability(value.controlAvailability);
+  if (controlAvailability !== null) {
+    summary.controlAvailability = controlAvailability;
+  }
+  return summary;
+}
+
+function parseResumeSummary(value: Record<string, unknown>): ResumeSummary | null {
+  if (!isResumeStatus(value.status)
+      || typeof value.retryAllowed !== 'boolean'
+      || (value.failureClass !== null && !isNonEmptyString(value.failureClass))) {
+    return null;
+  }
+  return {
+    status: value.status,
+    retryAllowed: value.retryAllowed,
+    failureClass: value.failureClass,
+  };
+}
+
+function isResumeStatus(value: unknown): value is ResumeStatus {
+  return value === 'NONE'
+    || value === 'PENDING'
+    || value === 'SYNCHRONIZING'
+    || value === 'DECIDING'
+    || value === 'COMPLETED'
+    || value === 'RETURNED_TO_HUMAN'
+    || value === 'FAILED_SAFE'
+    || value === 'IDLE'
+    || value === 'WAITING'
+    || value === 'RECONCILING'
+    || value === 'FAILED_SAFE_TO_RETRY'
+    || value === 'FAILED_TERMINAL';
+}
+
+function parseResumeStatus(value: unknown): ResumeStatus | undefined {
+  return isResumeStatus(value) ? value : undefined;
+}
+
+function parseOwnership(value: unknown): ConversationOwnership | undefined {
+  return isOwnership(value) ? value : undefined;
+}
+
+function isOwnership(value: unknown): value is ConversationOwnership {
+  return value === 'URBA' || value === 'HUMAN';
+}
+
+function parseControlAvailability(value: unknown): PocControlAvailability | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  return {
+    approvePaymentProof: value.approvePaymentProof === true,
+    recordHumanMessage: value.recordHumanMessage === true || value.recordDecision === true,
+    returnToUrba: value.returnToUrba === true,
+  };
+}
+
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === 'string';
+}
+
+function parseNullableString(value: unknown): string | null {
+  return isNonEmptyString(value) ? value : null;
+}
+
+function parseVersion(value: unknown): number | undefined {
+  return typeof value === 'number'
+    && Number.isSafeInteger(value)
+    && value >= 0
+    ? value
+    : undefined;
+}
+
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/poc-chat/src/api/conversationClient.test.ts
+++ b/apps/poc-chat/src/api/conversationClient.test.ts
@@ -7,6 +7,8 @@ import {
 const ALIAS = 'manual-11111111-1111-4111-8111-111111111111';
 const EVENT_ID = 'ui-22222222-2222-4222-8222-222222222222';
 const OCCURRED_AT = '2026-08-06T12:00:00.000Z';
+const HUMAN_IDEMPOTENCY_KEY = 'human-message-key-1';
+const RESUME_IDEMPOTENCY_KEY = 'resume-key-1';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -118,6 +120,90 @@ describe('ConversationClient', () => {
     expect(JSON.stringify(result)).not.toContain('must-not-reach-ui');
   });
 
+  it('adapts the local-only payment approval route without sending a client message', async () => {
+    const fetchMock = vi.fn<FetchImplementation>().mockResolvedValue(jsonResponse({
+      eventId: 'approval:poc:manual-11111111-1111-4111-8111-111111111111:4',
+      correlationId: 'approval-correlation',
+      status: 'COMPLETED',
+      output: { message: 'Fixture local aprovada.' },
+      error: null,
+    }));
+    const client = new ConversationClient(fetchMock);
+
+    await expect(client.approvePaymentProof(ALIAS)).resolves.toMatchObject({
+      status: 'COMPLETED',
+      correlationId: 'approval-correlation',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/poc/conversations/${ALIAS}/payment-proof/approve`,
+      expect.objectContaining({ method: 'POST', credentials: 'same-origin' }),
+    );
+    expect(fetchMock.mock.calls[0]?.[1]).not.toHaveProperty('body');
+    expect(JSON.stringify(fetchMock.mock.calls)).not.toMatch(/whatsapp|email|paymentUrl|secret/i);
+  });
+
+  it('records a human message through the operator route with idempotency', async () => {
+    const fetchMock = vi.fn<FetchImplementation>().mockResolvedValue(jsonResponse({
+      eventId: 'human-event-1',
+      status: 'RECORDED',
+      duplicate: false,
+      message: 'Mensagem humana registrada.',
+    }));
+    const client = new ConversationClient(fetchMock);
+
+    await expect(client.recordHumanMessage(ALIAS, HUMAN_IDEMPOTENCY_KEY, {
+      text: 'Vou acompanhar seu atendimento por aqui.',
+      occurredAt: OCCURRED_AT,
+    })).resolves.toMatchObject({ status: 'RECORDED', duplicate: false });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/poc/conversations/${ALIAS}/human/messages`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          text: 'Vou acompanhar seu atendimento por aqui.',
+          occurredAt: OCCURRED_AT,
+        }),
+      }),
+    );
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toEqual({
+      'Content-Type': 'application/json',
+      'Idempotency-Key': HUMAN_IDEMPOTENCY_KEY,
+    });
+    expect(JSON.stringify(fetchMock.mock.calls)).not.toMatch(/whatsapp|email|paymentUrl|secret/i);
+  });
+
+  it('returns ownership to Urba with the projection version and idempotency', async () => {
+    const fetchMock = vi.fn<FetchImplementation>().mockResolvedValue(jsonResponse({
+      resumeId: 'resume-123',
+      status: 'COMPLETED',
+      ownership: 'URBA',
+      message: 'A Urba retomou o atendimento.',
+      duplicate: false,
+      customerMessage: 'A Urba retomou o atendimento.',
+    }));
+    const client = new ConversationClient(fetchMock);
+
+    await expect(client.returnToUrba(ALIAS, RESUME_IDEMPOTENCY_KEY, 7)).resolves.toMatchObject({
+      resumeId: 'resume-123',
+      status: 'COMPLETED',
+      ownership: 'URBA',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/poc/conversations/${ALIAS}/ownership/urba`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ expectedVersion: 7 }),
+      }),
+    );
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toEqual({
+      'Content-Type': 'application/json',
+      'Idempotency-Key': RESUME_IDEMPOTENCY_KEY,
+    });
+  });
+
   it.each([502, 504])('marks upstream %s failures as retryable transport errors', async (status) => {
     const fetchMock = vi.fn<FetchImplementation>().mockResolvedValue(jsonResponse({}, status));
     const client = new ConversationClient(fetchMock);
@@ -133,10 +219,11 @@ describe('ConversationClient', () => {
     expect(error).toMatchObject({ status, retryable: true });
   });
 
-  it('has no client operation for flush or technical endpoints', () => {
+  it('does not expose technical endpoints and exposes only the local operator operations', () => {
     const client = new ConversationClient(vi.fn<FetchImplementation>());
     expect(client).not.toHaveProperty('flush');
     expect(client).not.toHaveProperty('getMetrics');
-    expect(client).not.toHaveProperty('approvePaymentProof');
+    expect(client).toHaveProperty('recordHumanMessage');
+    expect(client).toHaveProperty('returnToUrba');
   });
 });

--- a/apps/poc-chat/src/api/conversationClient.ts
+++ b/apps/poc-chat/src/api/conversationClient.ts
@@ -4,8 +4,13 @@ import {
   isContactAlias,
   isEventId,
   parseConversationProjection,
+  parseHumanMessageReceipt,
+  parseResumeReceipt,
   parseTurnReceipt,
   type ConversationProjection,
+  type HumanMessagePayload,
+  type HumanMessageReceipt,
+  type ResumeReceipt,
   type SyntheticTextPayload,
   type TurnReceipt,
 } from './contracts';
@@ -18,6 +23,17 @@ export type FetchImplementation = (
 export interface ConversationApi {
   sendTextMessage(contactAlias: string, payload: SyntheticTextPayload): Promise<TurnReceipt>;
   getConversationProjection(contactAlias: string): Promise<ConversationProjection>;
+  approvePaymentProof?(contactAlias: string): Promise<TurnReceipt>;
+  recordHumanMessage?(
+    contactAlias: string,
+    idempotencyKey: string,
+    payload: HumanMessagePayload,
+  ): Promise<HumanMessageReceipt>;
+  returnToUrba?(
+    contactAlias: string,
+    idempotencyKey: string,
+    expectedVersion: number,
+  ): Promise<ResumeReceipt>;
 }
 
 export type ConversationHttpErrorKind = 'transport' | 'http' | 'invalid-response';
@@ -102,6 +118,100 @@ export class ConversationClient implements ConversationApi {
     }
   }
 
+  /**
+   * POC-only operator checkpoint. This is deliberately separate from the
+   * customer message ingress and is exposed only when the projection grants
+   * the matching local control.
+   */
+  async approvePaymentProof(contactAlias: string): Promise<TurnReceipt> {
+    validateAlias(contactAlias);
+    const response = await this.request(
+      `/api/poc/conversations/${encodeURIComponent(contactAlias)}/payment-proof/approve`,
+      { method: 'POST', credentials: 'same-origin' },
+    );
+    try {
+      return parseTurnReceipt(await this.readJson(response));
+    } catch (error) {
+      if (error instanceof ConversationHttpError) {
+        throw error;
+      }
+      throw new ConversationHttpError('O serviço local retornou um recibo de controle inválido.', {
+        status: response.status,
+        kind: 'invalid-response',
+      });
+    }
+  }
+
+  async recordHumanMessage(
+    contactAlias: string,
+    idempotencyKey: string,
+    payload: HumanMessagePayload,
+  ): Promise<HumanMessageReceipt> {
+    validateAlias(contactAlias);
+    validateIdempotencyKey(idempotencyKey);
+    validateHumanMessagePayload(payload);
+    const response = await this.request(
+      `/api/poc/conversations/${encodeURIComponent(contactAlias)}/human/messages`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Idempotency-Key': idempotencyKey,
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify(payload),
+      },
+    );
+    try {
+      return parseHumanMessageReceipt(await this.readJson(response));
+    } catch (error) {
+      if (error instanceof ConversationHttpError) {
+        throw error;
+      }
+      throw new ConversationHttpError('O serviço local retornou um recibo de mensagem humana inválido.', {
+        status: response.status,
+        kind: 'invalid-response',
+      });
+    }
+  }
+
+  async returnToUrba(
+    contactAlias: string,
+    idempotencyKey: string,
+    expectedVersion: number,
+  ): Promise<ResumeReceipt> {
+    validateAlias(contactAlias);
+    validateIdempotencyKey(idempotencyKey);
+    if (!Number.isSafeInteger(expectedVersion) || expectedVersion < 0) {
+      throw new ConversationHttpError('A versão da conversa é inválida.', {
+        kind: 'invalid-response',
+      });
+    }
+    const response = await this.request(
+      `/api/poc/conversations/${encodeURIComponent(contactAlias)}/ownership/urba`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Idempotency-Key': idempotencyKey,
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({ expectedVersion }),
+      },
+    );
+    try {
+      return parseResumeReceipt(await this.readJson(response));
+    } catch (error) {
+      if (error instanceof ConversationHttpError) {
+        throw error;
+      }
+      throw new ConversationHttpError('O serviço local retornou um recibo de retomada inválido.', {
+        status: response.status,
+        kind: 'invalid-response',
+      });
+    }
+  }
+
   private async request(path: string, init: RequestInit): Promise<Response> {
     const controller = new AbortController();
     const timeout = globalThis.setTimeout(() => controller.abort(), this.timeoutMs);
@@ -158,6 +268,27 @@ function validatePayload(payload: SyntheticTextPayload): void {
       || payload.text.length > MAX_TEXT_LENGTH
       || Number.isNaN(Date.parse(payload.occurredAt))) {
     throw new ConversationHttpError('A mensagem textual é inválida.', {
+      kind: 'invalid-response',
+    });
+  }
+}
+
+function validateHumanMessagePayload(payload: HumanMessagePayload): void {
+  if (typeof payload.text !== 'string'
+      || payload.text.trim().length === 0
+      || payload.text.length > MAX_TEXT_LENGTH
+      || Number.isNaN(Date.parse(payload.occurredAt))) {
+    throw new ConversationHttpError('A mensagem humana é inválida.', {
+      kind: 'invalid-response',
+    });
+  }
+}
+
+function validateIdempotencyKey(idempotencyKey: string): void {
+  if (typeof idempotencyKey !== 'string'
+      || idempotencyKey.trim().length === 0
+      || idempotencyKey.length > 128) {
+    throw new ConversationHttpError('A chave de idempotência é inválida.', {
       kind: 'invalid-response',
     });
   }

--- a/apps/poc-chat/src/components/ArchitectControls.tsx
+++ b/apps/poc-chat/src/components/ArchitectControls.tsx
@@ -1,0 +1,102 @@
+import { useState, type FormEvent } from 'react';
+import type { ConversationOwnership, PocControlAction, PocControlAvailability } from '../api/contracts';
+
+interface ArchitectControlsProps {
+  ownership: ConversationOwnership | null;
+  availability: PocControlAvailability;
+  onAction: (action: PocControlAction, decision?: string) => void | Promise<void>;
+}
+
+const CONTROL_LABEL = 'ação da arquiteta/teste';
+
+export function ArchitectControls({ ownership, availability, onAction }: ArchitectControlsProps) {
+  const [decision, setDecision] = useState('');
+  const [busyAction, setBusyAction] = useState<PocControlAction | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasControl = availability.approvePaymentProof
+    || (ownership === 'HUMAN' && (availability.recordHumanMessage || availability.returnToUrba));
+  if (!hasControl) {
+    return null;
+  }
+
+  async function run(action: PocControlAction, value?: string): Promise<void> {
+    setBusyAction(action);
+    setError(null);
+    try {
+      await onAction(action, value);
+      if (action === 'RECORD_HUMAN_MESSAGE') {
+        setDecision('');
+      }
+    } catch {
+      setError('A ação de teste não foi concluída. A conversa permanece sob responsabilidade humana.');
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  function submitDecision(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    const normalized = decision.trim();
+    if (normalized.length === 0) {
+      setError('Informe a mensagem humana de teste antes de registrar.');
+      return;
+    }
+    void run('RECORD_HUMAN_MESSAGE', normalized);
+  }
+
+  return (
+    <aside className="architect-controls" aria-label="Controles locais da arquiteta">
+      <div className="architect-controls__heading">
+        <h2>Controles locais — {CONTROL_LABEL}</h2>
+        <p>Não envia mensagem do cliente, WhatsApp, e-mail ou pagamento real.</p>
+      </div>
+      <div className="architect-controls__actions">
+        {availability.approvePaymentProof ? (
+          <button
+            type="button"
+            disabled={busyAction !== null}
+            onClick={() => void run('APPROVE_PAYMENT_PROOF')}
+          >
+            Aprovar pagamento — {CONTROL_LABEL}
+          </button>
+        ) : null}
+        {ownership === 'HUMAN' && availability.recordHumanMessage ? (
+          <form onSubmit={submitDecision} className="architect-controls__decision">
+            <label htmlFor="architect-human-message">Mensagem humana — {CONTROL_LABEL}</label>
+            <textarea
+              id="architect-human-message"
+              aria-label={`Mensagem humana — ${CONTROL_LABEL}`}
+              value={decision}
+              onChange={(event) => {
+                setDecision(event.target.value);
+                if (error !== null) {
+                  setError(null);
+                }
+              }}
+              rows={2}
+              disabled={busyAction !== null}
+              placeholder="Registre uma mensagem somente para este teste local"
+            />
+            <button
+              type="submit"
+              disabled={busyAction !== null}
+            >
+              Registrar mensagem humana — {CONTROL_LABEL}
+            </button>
+          </form>
+        ) : null}
+        {ownership === 'HUMAN' && availability.returnToUrba ? (
+          <button
+            type="button"
+            disabled={busyAction !== null}
+            onClick={() => void run('RETURN_TO_URBA')}
+          >
+            Devolver responsabilidade — {CONTROL_LABEL}
+          </button>
+        ) : null}
+      </div>
+      {error !== null ? <p className="architect-controls__error" role="alert">{error}</p> : null}
+    </aside>
+  );
+}

--- a/apps/poc-chat/src/components/ChatView.test.tsx
+++ b/apps/poc-chat/src/components/ChatView.test.tsx
@@ -102,4 +102,59 @@ describe('ChatView', () => {
     expect(screen.getByRole('status')).toHaveTextContent(text);
     expect(screen.queryByText(/resposta da urba/i)).not.toBeInTheDocument();
   });
+
+  it('shows canonical handoff ack, complementary human ownership and local architect/test controls', async () => {
+    const user = userEvent.setup();
+    const onPocControl = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ChatView
+        contact={contact}
+        conversation={state({
+          mode: 'HUMAN',
+          ownership: 'HUMAN',
+          messages: [{
+            id: 'handoff-ack',
+            eventId: 'handoff-ack-event',
+            correlationId: 'corr-1',
+            contactId: `poc:${alias}`,
+            direction: 'OUTBOUND',
+            senderType: 'URBA',
+            type: 'TEXT',
+            text: 'Vou encaminhar sua conversa para a arquiteta, que continuará com você por aqui.',
+            createdAt: '2026-08-06T12:00:01.000Z',
+          }],
+          pocControls: {
+            approvePaymentProof: true,
+            recordHumanMessage: true,
+            returnToUrba: true,
+          },
+          resumeStatus: 'SYNCHRONIZING',
+          resumeId: 'resume-123',
+        })}
+        onSend={vi.fn()}
+        onRetry={vi.fn()}
+        onPocControl={onPocControl}
+      />,
+    );
+
+    expect(screen.getByText(/encaminhar sua conversa para a arquiteta/i)).toBeInTheDocument();
+    expect(screen.getByText(/aguardando atendimento/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /controles locais/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /ação da arquiteta\/teste/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /aprovar pagamento.*ação da arquiteta\/teste/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /registrar mensagem humana.*ação da arquiteta\/teste/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /devolver responsabilidade.*ação da arquiteta\/teste/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /mensagem humana.*ação da arquiteta\/teste/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /^mensagem$/i })).toBeDisabled();
+    expect(screen.getByText(/retomada.*reconciliação/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /aprovar pagamento.*ação da arquiteta\/teste/i }));
+    expect(onPocControl).toHaveBeenCalledWith('APPROVE_PAYMENT_PROOF', undefined);
+    await user.type(screen.getByRole('textbox', { name: /mensagem humana.*ação da arquiteta\/teste/i }), 'Vou acompanhar por aqui.');
+    await user.click(screen.getByRole('button', { name: /registrar mensagem humana.*ação da arquiteta\/teste/i }));
+    expect(onPocControl).toHaveBeenCalledWith('RECORD_HUMAN_MESSAGE', 'Vou acompanhar por aqui.');
+    await user.click(screen.getByRole('button', { name: /devolver responsabilidade.*ação da arquiteta\/teste/i }));
+    expect(onPocControl).toHaveBeenCalledWith('RETURN_TO_URBA', undefined);
+    expect(screen.queryByText(/paymentUrl|hermes|correlationId|stack/i)).not.toBeInTheDocument();
+  });
 });

--- a/apps/poc-chat/src/components/ChatView.tsx
+++ b/apps/poc-chat/src/components/ChatView.tsx
@@ -1,5 +1,7 @@
 import type { LocalContact } from '../state/contactStore';
+import type { PocControlAction, ResumeStatus } from '../api/contracts';
 import { getVisibleMessages, type ConversationUiState } from '../state/conversationReducer';
+import { ArchitectControls } from './ArchitectControls';
 import { FailureState } from './FailureState';
 import { MessageBubble } from './MessageBubble';
 import { MessageComposer } from './MessageComposer';
@@ -9,10 +11,14 @@ interface ChatViewProps {
   conversation: ConversationUiState;
   onSend: (text: string) => void;
   onRetry: (eventId: string) => void;
+  onPocControl?: (action: PocControlAction, decision?: string) => void | Promise<void>;
 }
 
-export function ChatView({ contact, conversation, onSend, onRetry }: ChatViewProps) {
+export function ChatView({ contact, conversation, onSend, onRetry, onPocControl }: ChatViewProps) {
   const visibleMessages = getVisibleMessages(conversation);
+  const ownership = conversation.ownership
+    ?? (conversation.mode === 'HUMAN' ? 'HUMAN' : null);
+  const humanOwned = ownership === 'HUMAN' || conversation.mode === 'HUMAN';
   return (
     <section className="chat-view" aria-label={`Conversa com ${contact.displayName}`}>
       <header className="chat-view__header">
@@ -21,7 +27,9 @@ export function ChatView({ contact, conversation, onSend, onRetry }: ChatViewPro
         </div>
         <div>
           <h1>{contact.displayName}</h1>
-          <p>{conversation.mode === 'HUMAN' ? 'Aguardando atendimento' : 'Conversa local'}</p>
+          <p aria-label={ownership === 'HUMAN' ? 'Responsabilidade: atendimento humano' : 'Responsabilidade: Urba'}>
+            {ownership === 'HUMAN' ? 'Aguardando atendimento' : 'Conversa local'}
+          </p>
         </div>
       </header>
       <div className="message-history" role="log" aria-live="polite" aria-label="Histórico da conversa">
@@ -47,14 +55,42 @@ export function ChatView({ contact, conversation, onSend, onRetry }: ChatViewPro
         {conversation.processingState === 'HUMAN' ? (
           <p className="processing-indicator" role="status">Esta conversa aguarda atendimento humano.</p>
         ) : null}
+        {isResumePending(conversation.resumeStatus) ? (
+          <p className="processing-indicator processing-indicator--reconciling" role="status">
+            {isResumeReconciling(conversation.resumeStatus)
+              ? 'A retomada está em reconciliação. O acompanhamento continua…'
+              : 'A retomada está aguardando processamento. O acompanhamento continua…'}
+          </p>
+        ) : null}
       </div>
+      {conversation.pocControls !== null && onPocControl !== undefined ? (
+        <ArchitectControls
+          ownership={ownership}
+          availability={conversation.pocControls}
+          onAction={onPocControl}
+        />
+      ) : null}
       <FailureState
         pending={conversation.optimisticMessages}
         processingState={conversation.processingState}
         turn={conversation.turn}
         onRetry={onRetry}
       />
-      <MessageComposer onSend={onSend} disabled={conversation.processingState === 'HUMAN'} />
+      <MessageComposer onSend={onSend} disabled={humanOwned || conversation.processingState === 'HUMAN'} />
     </section>
   );
+}
+
+function isResumePending(status: ResumeStatus | null): boolean {
+  return status === 'PENDING'
+    || status === 'SYNCHRONIZING'
+    || status === 'DECIDING'
+    || status === 'WAITING'
+    || status === 'RECONCILING';
+}
+
+function isResumeReconciling(status: ResumeStatus | null): boolean {
+  return status === 'SYNCHRONIZING'
+    || status === 'DECIDING'
+    || status === 'RECONCILING';
 }

--- a/apps/poc-chat/src/state/conversationReducer.handoff.test.ts
+++ b/apps/poc-chat/src/state/conversationReducer.handoff.test.ts
@@ -2,6 +2,7 @@ import {
   conversationReducer,
   createConversationState,
   getVisibleMessages,
+  hasPendingWork,
 } from './conversationReducer';
 
 const ALIAS = 'manual-11111111-1111-4111-8111-111111111111';
@@ -68,5 +69,169 @@ describe('conversationReducer handoff contract', () => {
 
     expect(getVisibleMessages(state[ALIAS]!)).toHaveLength(2);
     expect(getVisibleMessages(state[ALIAS]!)[1]?.senderType).toBe('HUMAN');
+  });
+
+  it('keeps the canonical handoff ack visible and exposes legacy ownership/resume/control state separately', () => {
+    const handedOff = conversationReducer(createConversationState(), {
+      type: 'PROJECTION_RECEIVED',
+      alias: ALIAS,
+      projection: {
+        contactId: `poc:${ALIAS}`,
+        conversation: {
+          mode: 'HUMAN',
+          ownership: 'HUMAN',
+          resume: {
+            status: 'RECONCILING',
+            retryAllowed: false,
+            failureClass: 'HUMAN_CONTEXT_PENDING',
+          },
+          pocControls: {
+            approvePaymentProof: true,
+            recordDecision: false,
+            returnToUrba: true,
+          },
+        },
+        messages: [{
+          id: 'handoff-ack',
+          eventId: 'handoff-ack-event',
+          correlationId: 'corr-1',
+          contactId: `poc:${ALIAS}`,
+          direction: 'OUTBOUND',
+          senderType: 'URBA',
+          type: 'TEXT',
+          text: 'Vou encaminhar sua conversa para a arquiteta, que continuará com você por aqui.',
+          createdAt: '2026-08-06T12:00:01.000Z',
+        }],
+        turn: null,
+      },
+    });
+
+    expect(handedOff[ALIAS]).toMatchObject({
+      mode: 'HUMAN',
+      ownership: 'HUMAN',
+      processingState: 'HUMAN',
+      resume: {
+        status: 'RECONCILING',
+        retryAllowed: false,
+        failureClass: 'HUMAN_CONTEXT_PENDING',
+      },
+      pocControls: {
+        approvePaymentProof: true,
+        recordHumanMessage: false,
+        returnToUrba: true,
+      },
+    });
+    expect(getVisibleMessages(handedOff[ALIAS]!)).toEqual([
+      expect.objectContaining({
+        senderType: 'URBA',
+        text: expect.stringMatching(/encaminhar sua conversa/),
+      }),
+    ]);
+    expect(hasPendingWork(handedOff[ALIAS])).toBe(false);
+  });
+
+  it('uses a resume reconciliation state for polling when no turn summary is present', () => {
+    const state = conversationReducer(createConversationState(), {
+      type: 'PROJECTION_RECEIVED',
+      alias: ALIAS,
+      projection: {
+        contactId: `poc:${ALIAS}`,
+        conversation: {
+          mode: 'AI',
+          resume: {
+            status: 'RECONCILING',
+            retryAllowed: false,
+            failureClass: 'AMBIGUOUS_TRANSPORT',
+          },
+        },
+        messages: [],
+        turn: null,
+      },
+    });
+
+    expect(state[ALIAS]?.processingState).toBe('RECONCILING');
+    expect(hasPendingWork(state[ALIAS])).toBe(true);
+  });
+
+  it('normalizes current top-level ownership/resume/control fields and keeps resume polling fail-closed', () => {
+    const state = conversationReducer(createConversationState(), {
+      type: 'PROJECTION_RECEIVED',
+      alias: ALIAS,
+      projection: {
+        contactId: `poc:${ALIAS}`,
+        ownership: 'HUMAN',
+        resumeStatus: 'SYNCHRONIZING',
+        resumeId: 'resume-123',
+        controlAvailability: {
+          approvePaymentProof: true,
+          recordHumanMessage: true,
+          returnToUrba: true,
+        },
+        conversation: { mode: 'HUMAN', version: 7 },
+        messages: [{
+          id: 'handoff-ack',
+          eventId: 'handoff-ack-event',
+          correlationId: 'corr-1',
+          contactId: `poc:${ALIAS}`,
+          direction: 'OUTBOUND',
+          senderType: 'URBA',
+          type: 'TEXT',
+          text: 'Vou encaminhar sua conversa para a arquiteta.',
+          createdAt: '2026-08-06T12:00:01.000Z',
+        }, {
+          id: 'handoff-ack-duplicate-id',
+          eventId: 'handoff-ack-event',
+          correlationId: 'corr-1',
+          contactId: `poc:${ALIAS}`,
+          direction: 'OUTBOUND',
+          senderType: 'URBA',
+          type: 'TEXT',
+          text: 'Vou encaminhar sua conversa para a arquiteta.',
+          createdAt: '2026-08-06T12:00:01.000Z',
+        }],
+        turn: null,
+      },
+    });
+
+    expect(state[ALIAS]).toMatchObject({
+      mode: 'HUMAN',
+      ownership: 'HUMAN',
+      resumeStatus: 'SYNCHRONIZING',
+      resumeId: 'resume-123',
+      conversationVersion: 7,
+      processingState: 'HUMAN',
+      pocControls: {
+        approvePaymentProof: true,
+        recordHumanMessage: true,
+        returnToUrba: true,
+      },
+    });
+    expect(getVisibleMessages(state[ALIAS]!)).toHaveLength(1);
+    expect(hasPendingWork(state[ALIAS])).toBe(true);
+  });
+
+  it('renders top-level resume reconciliation while Urba still owns the conversation', () => {
+    const state = conversationReducer(createConversationState(), {
+      type: 'PROJECTION_RECEIVED',
+      alias: ALIAS,
+      projection: {
+        contactId: `poc:${ALIAS}`,
+        ownership: 'URBA',
+        resumeStatus: 'SYNCHRONIZING',
+        resumeId: 'resume-123',
+        controlAvailability: {
+          approvePaymentProof: false,
+          recordHumanMessage: false,
+          returnToUrba: false,
+        },
+        conversation: { mode: 'AI', version: 8 },
+        messages: [],
+        turn: null,
+      },
+    });
+
+    expect(state[ALIAS]?.processingState).toBe('RECONCILING');
+    expect(state[ALIAS]?.resumeStatus).toBe('SYNCHRONIZING');
+    expect(hasPendingWork(state[ALIAS])).toBe(true);
   });
 });

--- a/apps/poc-chat/src/state/conversationReducer.ts
+++ b/apps/poc-chat/src/state/conversationReducer.ts
@@ -3,6 +3,10 @@ import {
   parseConversationProjection,
   type CanonicalMessage,
   type ConversationMode,
+  type ConversationOwnership,
+  type PocControlAvailability,
+  type ResumeStatus,
+  type ResumeSummary,
   type TurnStatus,
   type TurnSummary,
 } from '../api/contracts';
@@ -49,6 +53,12 @@ export interface ConversationUiState {
   lastSuccessfulSyncAt: string | null;
   lastError: string | null;
   mode: ConversationMode | null;
+  ownership: ConversationOwnership | null;
+  resume: ResumeSummary | null;
+  resumeStatus: ResumeStatus | null;
+  resumeId: string | null;
+  conversationVersion: number | null;
+  pocControls: PocControlAvailability | null;
 }
 
 export type ConversationState = Record<string, ConversationUiState>;
@@ -76,6 +86,12 @@ export function createConversationUiState(): ConversationUiState {
     lastSuccessfulSyncAt: null,
     lastError: null,
     mode: null,
+    ownership: null,
+    resume: null,
+    resumeStatus: null,
+    resumeId: null,
+    conversationVersion: null,
+    pocControls: null,
   };
 }
 
@@ -110,7 +126,7 @@ export function conversationReducer(
         optimisticMessages: current.optimisticMessages.some((item) => item.eventId === action.pending.eventId)
           ? current.optimisticMessages
           : [...current.optimisticMessages, action.pending],
-        processingState: current.mode === 'HUMAN' ? 'HUMAN' : 'WAITING',
+        processingState: isHumanOwned(current) ? 'HUMAN' : 'WAITING',
         lastError: null,
       });
     case 'RETRY_STARTED':
@@ -120,7 +136,7 @@ export function conversationReducer(
         optimisticMessages: current.optimisticMessages.map((item) => item.eventId === action.eventId
           ? { ...item, attempts: action.attempts, state: 'ACCEPTING', lastError: null }
           : item),
-        processingState: current.mode === 'HUMAN' ? 'HUMAN' : 'WAITING',
+        processingState: isHumanOwned(current) ? 'HUMAN' : 'WAITING',
         lastError: null,
       });
     case 'RECEIPT_RECEIVED':
@@ -133,7 +149,7 @@ export function conversationReducer(
             state: action.status === 'BLOCKED_BY_HUMAN' ? 'HUMAN' : 'WAITING',
           }
           : item),
-        processingState: action.status === 'BLOCKED_BY_HUMAN' ? 'HUMAN' : 'WAITING',
+        processingState: isHumanOwned(current) || action.status === 'BLOCKED_BY_HUMAN' ? 'HUMAN' : 'WAITING',
         lastError: null,
       });
     case 'SEND_FAILED':
@@ -145,7 +161,7 @@ export function conversationReducer(
         optimisticMessages: current.optimisticMessages.map((item) => item.eventId === action.eventId
           ? { ...item, state: activePendingState(item.state), lastError: action.error }
           : item),
-        processingState: current.mode === 'HUMAN' ? 'HUMAN' : activeProcessingState(current.processingState),
+        processingState: isHumanOwned(current) ? 'HUMAN' : activeProcessingState(current.processingState),
         lastError: action.error,
       });
     case 'SYNC_FAILED':
@@ -176,7 +192,18 @@ export function getVisibleMessages(state: ConversationUiState): CanonicalMessage
   const optimistic = state.optimisticMessages
     .filter((pending) => !canonicalEventIds.has(pending.eventId))
     .map(optimisticMessage);
+  const seenIds = new Set<string>();
+  const seenFallbacks = new Set<string>();
   return [...state.messages, ...optimistic]
+    .filter((message) => {
+      const fallback = `${message.eventId}|${message.direction}|${message.correlationId}`;
+      if (seenIds.has(message.id) || seenFallbacks.has(fallback)) {
+        return false;
+      }
+      seenIds.add(message.id);
+      seenFallbacks.add(fallback);
+      return true;
+    })
     .map((message, index) => ({ message, index }))
     .sort((left, right) => {
       const byTime = Date.parse(left.message.createdAt) - Date.parse(right.message.createdAt);
@@ -186,7 +213,11 @@ export function getVisibleMessages(state: ConversationUiState): CanonicalMessage
 }
 
 export function hasPendingWork(state: ConversationUiState | undefined): boolean {
-  if (!state || state.processingState === 'HUMAN') {
+  if (!state) {
+    return false;
+  }
+  const resumeStatus = state.resumeStatus;
+  if (state.processingState === 'HUMAN' && !isNonTerminalResume(resumeStatus)) {
     return false;
   }
   if (state.optimisticMessages.some(isActivePending)) {
@@ -199,6 +230,12 @@ export function hasPendingWork(state: ConversationUiState | undefined): boolean 
     // responsible for making a COMPLETED projection contain its output;
     // FAILED_* and human-blocked summaries must never be polled as retries.
     return isNonTerminalTurn(state.turn.status);
+  }
+  if (resumeStatus !== null) {
+    return isNonTerminalResume(resumeStatus);
+  }
+  if (state.resume !== null) {
+    return isNonTerminalResume(state.resume.status);
   }
   return state.optimisticMessages.some(isActivePending)
     || hasUnansweredTurn(state.messages);
@@ -236,7 +273,25 @@ function reconcileProjection(
       .filter((message) => message.direction === 'OUTBOUND')
       .map((message) => message.id));
     const hasNewOutbound = [...outboundIds].some((id) => !oldOutboundIds.has(id));
-    const mode = projection.conversation.mode === 'HUMAN' ? 'HUMAN' : 'AI';
+    const mode = projection.ownership === 'HUMAN'
+      || (projection.ownership === undefined && (projection.conversation.mode === 'HUMAN'
+        || projection.conversation.ownership === 'HUMAN'))
+      ? 'HUMAN'
+      : 'AI';
+    const ownership = projection.ownership
+      ?? projection.conversation.ownership
+      ?? (mode === 'HUMAN' ? 'HUMAN' : 'URBA');
+    const resume = projection.conversation.resume ?? null;
+    const resumeStatus = projection.resumeStatus
+      ?? projection.conversation.resumeStatus
+      ?? null;
+    const resumeId = projection.resumeId !== undefined
+      ? projection.resumeId
+      : projection.conversation.resumeId ?? null;
+    const pocControls = projection.controlAvailability
+      ?? projection.conversation.controlAvailability
+      ?? projection.conversation.pocControls
+      ?? null;
     const optimisticMessages = reconcilePendingMessages(
       current.optimisticMessages,
       messages,
@@ -250,6 +305,8 @@ function reconcileProjection(
       optimisticMessages,
       mode,
       projection.turn,
+      resume,
+      resumeStatus,
       current.processingState,
     );
     return withConversation(state, alias, {
@@ -263,6 +320,12 @@ function reconcileProjection(
       lastSuccessfulSyncAt: new Date().toISOString(),
       lastError: null,
       mode,
+      ownership,
+      resume,
+      resumeStatus,
+      resumeId,
+      conversationVersion: projection.conversationVersion ?? null,
+      pocControls,
     });
   } catch {
     return withConversation(state, alias, {
@@ -382,6 +445,8 @@ function deriveProcessingState(
   optimisticMessages: PendingSend[],
   mode: ConversationMode,
   turn: TurnSummary | null,
+  resume: ResumeSummary | null,
+  resumeStatus: ResumeStatus | null,
   previous: ProcessingState,
 ): ProcessingState {
   if (mode === 'HUMAN') {
@@ -403,6 +468,30 @@ function deriveProcessingState(
       case 'RUNNING':
         return previous === 'DELAYED' ? 'DELAYED' : 'WAITING';
       case 'COMPLETED':
+        break;
+      default:
+        break;
+    }
+  }
+  const effectiveResumeStatus = resumeStatus ?? resume?.status ?? null;
+  if (effectiveResumeStatus !== null) {
+    switch (effectiveResumeStatus) {
+      case 'PENDING':
+      case 'WAITING':
+        return previous === 'DELAYED' ? 'DELAYED' : 'WAITING';
+      case 'SYNCHRONIZING':
+      case 'DECIDING':
+      case 'RECONCILING':
+        return 'RECONCILING';
+      case 'FAILED_SAFE':
+      case 'FAILED_SAFE_TO_RETRY':
+        return (resume?.retryAllowed ?? true) ? 'FAILED_SAFE_TO_RETRY' : 'FAILED_TERMINAL';
+      case 'FAILED_TERMINAL':
+        return 'FAILED_TERMINAL';
+      case 'NONE':
+      case 'IDLE':
+      case 'COMPLETED':
+      case 'RETURNED_TO_HUMAN':
         break;
       default:
         break;
@@ -460,6 +549,18 @@ function isNonTerminalTurn(status: TurnStatus): boolean {
     || status === 'RUNNING'
     || status === 'DELAYED'
     || status === 'RECONCILING';
+}
+
+function isNonTerminalResume(status: ResumeStatus | null): boolean {
+  return status === 'PENDING'
+    || status === 'SYNCHRONIZING'
+    || status === 'DECIDING'
+    || status === 'WAITING'
+    || status === 'RECONCILING';
+}
+
+function isHumanOwned(state: ConversationUiState): boolean {
+  return state.mode === 'HUMAN' || state.ownership === 'HUMAN';
 }
 
 function isActivePending(pending: PendingSend): boolean {

--- a/apps/poc-chat/src/state/conversationTracker.test.ts
+++ b/apps/poc-chat/src/state/conversationTracker.test.ts
@@ -286,4 +286,26 @@ describe('ConversationTracker', () => {
     expect(actions.some((action) => action.type === 'RECEIPT_RECEIVED')).toBe(true);
     tracker.dispose();
   });
+
+  it('does not send automation after the canonical projection assigns HUMAN ownership', async () => {
+    const api: ConversationApi = {
+      sendTextMessage: vi.fn(),
+      getConversationProjection: vi.fn().mockResolvedValue({
+        contactId: `poc:${ALIAS_A}`,
+        ownership: 'HUMAN',
+        resumeStatus: 'SYNCHRONIZING',
+        conversation: { mode: 'HUMAN', version: 1 },
+        messages: [],
+        turn: null,
+      }),
+    };
+    const { tracker } = harness(api);
+
+    await tracker.sync(ALIAS_A);
+    const receipt = await tracker.send(ALIAS_A, 'Não deve ser enviado');
+
+    expect(receipt).toBeNull();
+    expect(api.sendTextMessage).not.toHaveBeenCalled();
+    tracker.dispose();
+  });
 });

--- a/apps/poc-chat/src/state/conversationTracker.ts
+++ b/apps/poc-chat/src/state/conversationTracker.ts
@@ -62,6 +62,9 @@ export class ConversationTracker {
     occurredAt: string = new Date().toISOString(),
     eventId: string = createEventId(),
   ): Promise<TurnReceipt | null> {
+    if (isHumanOwned(this.getConversationState(contactAlias))) {
+      return null;
+    }
     const payload: SyntheticTextPayload = { eventId, type: 'TEXT', text, occurredAt };
     const pending: PendingSend = {
       eventId,
@@ -79,6 +82,9 @@ export class ConversationTracker {
 
   async retry(contactAlias: string, eventId: string): Promise<TurnReceipt | null> {
     const state = this.getConversationState(contactAlias);
+    if (isHumanOwned(state)) {
+      return null;
+    }
     const pending = state?.optimisticMessages.find((candidate) => candidate.eventId === eventId);
     const turn = state?.turn;
     if (!pending
@@ -156,6 +162,9 @@ export class ConversationTracker {
     payload: SyntheticTextPayload,
     contactAlias: string,
   ): Promise<TurnReceipt | null> {
+    if (isHumanOwned(this.getConversationState(contactAlias))) {
+      return null;
+    }
     try {
       const receipt = await this.api.sendTextMessage(contactAlias, payload);
       this.dispatch({
@@ -296,4 +305,8 @@ function sanitizeError(error: unknown): string {
     return error.message;
   }
   return 'Não foi possível acompanhar a mensagem no serviço local.';
+}
+
+function isHumanOwned(state: ConversationUiState | undefined): boolean {
+  return state?.mode === 'HUMAN' || state?.ownership === 'HUMAN';
 }

--- a/apps/poc-chat/src/styles.css
+++ b/apps/poc-chat/src/styles.css
@@ -63,6 +63,17 @@ h1, h2, p { margin-top: 0; }
 .processing-indicator { align-self: flex-start; margin: 2px 0; color: #9d8b81; font-size: 12px; font-style: italic; }
 .processing-indicator--delayed { color: #a56835; }
 .processing-indicator--reconciling { color: #7a688c; }
+.architect-controls { display: grid; gap: 10px; margin: 0 clamp(20px, 7vw, 100px) 12px; border: 1px solid #d8c6b8; border-radius: 12px; padding: 13px 14px; background: #fffaf3; color: #5b453a; }
+.architect-controls__heading h2 { margin: 0 0 4px; font-size: 13px; }
+.architect-controls__heading p { margin: 0; color: #8d7568; font-size: 11px; }
+.architect-controls__actions { display: flex; flex-wrap: wrap; align-items: flex-end; gap: 8px; }
+.architect-controls button { border: 1px solid #c78a70; border-radius: 8px; padding: 8px 10px; background: white; color: #8c3d25; font-size: 12px; font-weight: 700; }
+.architect-controls button:hover { background: #fff0e8; }
+.architect-controls__decision { display: grid; gap: 5px; min-width: min(100%, 280px); }
+.architect-controls__decision label { color: #80695c; font-size: 11px; font-weight: 700; }
+.architect-controls__decision textarea { resize: vertical; min-height: 44px; border: 1px solid #dfd2c9; border-radius: 8px; padding: 8px; background: white; color: inherit; font-size: 12px; outline: none; }
+.architect-controls__decision textarea:focus { border-color: #e4572e; box-shadow: 0 0 0 3px rgb(228 87 46 / 13%); }
+.architect-controls__error { margin: 0; color: #9c3a22; font-size: 12px; }
 .failure-state { display: flex; align-items: center; justify-content: space-between; gap: 15px; margin: 0 clamp(20px, 7vw, 100px) 12px; border: 1px solid #efc2b7; border-radius: 12px; padding: 12px 14px; background: #fff5f1; color: #783b2e; font-size: 13px; }
 .failure-state strong { display: block; margin-bottom: 3px; }
 .failure-state p { margin: 0; font-size: 12px; }
@@ -87,6 +98,6 @@ h1, h2, p { margin-top: 0; }
   .archive-button { display: none; }
   .chat-view { min-height: 600px; }
   .message-history { padding: 22px 16px; }
-  .message-composer, .failure-state { margin-left: 0; margin-right: 0; padding-left: 16px; padding-right: 16px; }
+  .message-composer, .failure-state, .architect-controls { margin-left: 0; margin-right: 0; padding-left: 16px; padding-right: 16px; }
   .message-composer__hint { display: none; }
 }

--- a/apps/urbana-connect-api/Dockerfile.poc.runtime-jar
+++ b/apps/urbana-connect-api/Dockerfile.poc.runtime-jar
@@ -1,10 +1,32 @@
-# POC runtime image: the host build is explicit so Docker does not need to
-# resolve Gradle dependencies or execute a second build inside the daemon.
+# Build from the Docker context so the POC can never reuse a stale host JAR.
+# Java 21 is intentionally kept aligned with the application runtime.
+FROM eclipse-temurin:21-jdk-jammy AS build
+
+WORKDIR /workspace/app
+
+COPY gradlew .
+COPY gradle gradle
+COPY gradle.properties .
+COPY build.gradle .
+COPY settings.gradle .
+COPY src src
+
+RUN chmod +x ./gradlew \
+    && ./gradlew --no-daemon clean bootJar
+
 FROM eclipse-temurin:21-jre-jammy
+
+ARG APP_SOURCE_REVISION=workspace-source
+ARG APP_BUILD_CREATED=unknown
+
+LABEL org.opencontainers.image.revision="${APP_SOURCE_REVISION}" \
+      org.opencontainers.image.created="${APP_BUILD_CREATED}" \
+      org.opencontainers.image.source="urbana-connect-api/Dockerfile.poc.runtime-jar" \
+      br.com.urbana.connect.build="containerized-gradle-jdk21"
 
 WORKDIR /app
 
-COPY build/libs/urbana-connect-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=build /workspace/app/build/libs/*.jar app.jar
 
 RUN useradd --system --create-home spring
 

--- a/apps/urbana-connect-api/dev-env.sh
+++ b/apps/urbana-connect-api/dev-env.sh
@@ -47,8 +47,8 @@ start_environment() {
     echo "Aguardando MongoDB ficar pronto..."
     attempt=1
     max_attempts=10
-    until docker exec urbana-connect-mongodb mongosh --eval "db.adminCommand('ping')" &> /dev/null || [ $attempt -gt $max_attempts ]; do
-        echo "Tentativa $attempt de $max_attempts. Aguardando MongoDB iniciar..."
+    until docker exec urbana-connect-mongodb mongosh --quiet --eval "const hello = db.adminCommand({hello: 1}); quit(hello.ok === 1 && hello.setName === 'rs0' && hello.isWritablePrimary === true ? 0 : 1)" &> /dev/null || [ $attempt -gt $max_attempts ]; do
+        echo "Tentativa $attempt de $max_attempts. Aguardando MongoDB iniciar o replica set..."
         sleep 3
         ((attempt++))
     done
@@ -59,8 +59,8 @@ start_environment() {
     fi
 
     echo "===================================="
-    echo "  MongoDB está pronto para uso!"
-    echo "  URI de conexão: mongodb://localhost:27017/urbana-connect"
+    echo "  MongoDB replica set está pronto para uso!"
+    echo "  URI de conexão: mongodb://localhost:27017/urbana-connect?replicaSet=rs0&retryWrites=true&retryReads=true&w=majority"
     echo "===================================="
 
     # Verifica se existe o arquivo .env.dev e sugere carregá-lo
@@ -111,7 +111,7 @@ export WHATSAPP_ACCESS_TOKEN=""
 export WHATSAPP_VERIFY_TOKEN="urbana-connect-webhook-token"
 
 # MongoDB
-export MONGODB_URI="mongodb://localhost:27017/urbana-connect"
+export MONGODB_URI="mongodb://localhost:27017/urbana-connect?replicaSet=rs0&retryWrites=true&retryReads=true&w=majority"
 
 # Admin credentials
 export ADMIN_USER="admin"
@@ -181,4 +181,4 @@ case "$1" in
         show_help
         exit 1
         ;;
-esac 
+esac

--- a/apps/urbana-connect-api/docker-compose.yml
+++ b/apps/urbana-connect-api/docker-compose.yml
@@ -1,9 +1,12 @@
-version: '3.8'
-
 services:
   mongodb:
-    image: mongo:latest
+    image: mongo:8.0
     container_name: urbana-connect-mongodb
+    hostname: mongodb
+    command:
+      - mongod
+      - --replSet=rs0
+      - --bind_ip_all
     ports:
       - "27017:27017"
     volumes:
@@ -12,12 +15,47 @@ services:
       - MONGO_INITDB_DATABASE=urbana-connect
     restart: unless-stopped
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/urbana-connect --quiet
-      interval: 10s
-      timeout: 10s
-      retries: 5
-      start_period: 40s
-      
+      test:
+        - CMD-SHELL
+        - >-
+          mongosh --quiet --host 127.0.0.1:27017/admin --eval
+          'const hello = db.adminCommand({hello: 1}); quit(
+          hello.ok === 1 && hello.setName === "rs0" &&
+          hello.isWritablePrimary === true ? 0 : 1);'
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
+
+  mongodb-rs-init:
+    image: mongo:8.0
+    restart: "no"
+    depends_on:
+      mongodb:
+        condition: service_started
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        until mongosh --quiet --host mongodb:27017/admin --eval '
+          try { quit(db.adminCommand({ping: 1}).ok === 1 ? 0 : 1); }
+          catch (error) { quit(1); }
+        '; do sleep 1; done
+
+        until mongosh --quiet --host mongodb:27017/admin --eval '
+          const hello = db.adminCommand({hello: 1});
+          if (hello.setName === "rs0" && hello.isWritablePrimary === true) {
+            quit(0);
+          }
+          try {
+            rs.initiate({
+              _id: "rs0",
+              members: [{_id: 0, host: "mongodb:27017"}]
+            });
+          } catch (error) {}
+          quit(1);
+        '; do sleep 1; done
+
   mongo-express:
     image: mongo-express:latest
     container_name: urbana-connect-mongo-express
@@ -30,9 +68,12 @@ services:
       - ME_CONFIG_BASICAUTH_PASSWORD=senha123
       - ME_CONFIG_MONGODB_ENABLE_ADMIN=true
     depends_on:
-      - mongodb
+      mongodb:
+        condition: service_healthy
+      mongodb-rs-init:
+        condition: service_completed_successfully
     restart: unless-stopped
 
 volumes:
   mongodb_data:
-    name: urbana-connect-mongodb-data 
+    name: urbana-connect-mongodb-data

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/config/MongoIndexConfiguration.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/config/MongoIndexConfiguration.java
@@ -1,0 +1,33 @@
+package br.com.urbana.connect.application.config;
+
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.MongoPersistentEntityIndexResolver;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+/** Ensures Mongo indexes declared by the persistence documents exist at startup. */
+@Configuration(proxyBeanMethods = false)
+@Profile("!test")
+public class MongoIndexConfiguration {
+
+    @Bean
+    ApplicationRunner mongoIndexInitializer(MongoTemplate mongoTemplate, MongoMappingContext mappingContext) {
+        return args -> {
+            MongoPersistentEntityIndexResolver resolver = new MongoPersistentEntityIndexResolver(mappingContext);
+
+            try {
+                mappingContext.getPersistentEntities().stream()
+                        .filter(entity -> entity.getType().isAnnotationPresent(
+                                org.springframework.data.mongodb.core.mapping.Document.class))
+                        .flatMap(entity -> resolver.resolveIndexForEntity(entity).stream())
+                        .forEach(index -> mongoTemplate.indexOps(index.getCollection()).ensureIndex(index));
+            } catch (RuntimeException exception) {
+                throw new IllegalStateException(
+                        "Mongo index provisioning failed; application startup cannot continue", exception);
+            }
+        };
+    }
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/config/MongoTransactionConfiguration.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/config/MongoTransactionConfiguration.java
@@ -1,0 +1,32 @@
+package br.com.urbana.connect.application.config;
+
+import org.springframework.boot.autoconfigure.mongo.MongoClientSettingsBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+
+/**
+ * Enables the Mongo transaction boundary used by reception persistence.
+ *
+ * <p>The URI remains responsible for selecting the replica set. The
+ * customizer keeps retry behavior enabled even when a deployment supplies a
+ * URI without the explicit retry query parameters.</p>
+ */
+@Configuration(proxyBeanMethods = false)
+@Profile("!test")
+public class MongoTransactionConfiguration {
+
+    @Bean
+    MongoTransactionManager mongoTransactionManager(MongoDatabaseFactory mongoDatabaseFactory) {
+        return new MongoTransactionManager(mongoDatabaseFactory);
+    }
+
+    @Bean
+    MongoClientSettingsBuilderCustomizer mongoClientSettingsBuilderCustomizer() {
+        return builder -> builder
+                .retryWrites(true)
+                .retryReads(true);
+    }
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/conversation/ConversationFlowService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/conversation/ConversationFlowService.java
@@ -551,7 +551,7 @@ public class ConversationFlowService {
         }
 
         try {
-            ServiceType selectedType = ServiceType.valueOf(replyId);
+            ServiceType selectedType = ServiceType.canonicalize(ServiceType.valueOf(replyId));
             return availableServices.stream()
                 .filter(service -> service.type() == selectedType)
                 .findFirst();
@@ -566,7 +566,7 @@ public class ConversationFlowService {
         return conversation.context().slotValue(ConversationSlotName.SUGGESTED_SERVICE)
             .flatMap(slotValue -> {
                 try {
-                    ServiceType selectedType = ServiceType.valueOf(slotValue);
+                    ServiceType selectedType = ServiceType.canonicalize(ServiceType.valueOf(slotValue));
                     return availableServices.stream()
                         .filter(service -> service.type() == selectedType)
                         .findFirst();

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/conversation/ConversationFlowService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/conversation/ConversationFlowService.java
@@ -553,7 +553,7 @@ public class ConversationFlowService {
         try {
             ServiceType selectedType = ServiceType.canonicalize(ServiceType.valueOf(replyId));
             return availableServices.stream()
-                .filter(service -> service.type() == selectedType)
+                .filter(service -> ServiceType.canonicalize(service.type()) == selectedType)
                 .findFirst();
         } catch (IllegalArgumentException ignored) {
             return Optional.empty();
@@ -568,7 +568,7 @@ public class ConversationFlowService {
                 try {
                     ServiceType selectedType = ServiceType.canonicalize(ServiceType.valueOf(slotValue));
                     return availableServices.stream()
-                        .filter(service -> service.type() == selectedType)
+                        .filter(service -> ServiceType.canonicalize(service.type()) == selectedType)
                         .findFirst();
                 } catch (IllegalArgumentException ignored) {
                     return Optional.empty();

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/conversation/ConversationResponseValidator.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/conversation/ConversationResponseValidator.java
@@ -102,7 +102,8 @@ public class ConversationResponseValidator {
         Set<String> availableAliases = availableServices.stream()
             .flatMap(service -> Stream.of(
                 normalize(service.name()),
-                normalize(service.type().name().replace('_', ' '))
+                normalize(service.type().name().replace('_', ' ')),
+                normalize(legacyAliasFor(service.type()))
             ))
             .filter(alias -> !alias.isBlank())
             .collect(Collectors.toSet());
@@ -159,6 +160,10 @@ public class ConversationResponseValidator {
 
     private String normalize(String value) {
         return value == null ? "" : value.toLowerCase(Locale.ROOT).trim();
+    }
+
+    private String legacyAliasFor(ServiceType type) {
+        return ServiceType.canonicalize(type) == ServiceType.DECOR_INTERIORES ? "Decor" : "";
     }
 
     private List<String> extractCapitalizedPhrases(String replyText) {

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/health/MongoConnectivityVerifier.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/health/MongoConnectivityVerifier.java
@@ -15,9 +15,15 @@ public class MongoConnectivityVerifier {
 
     public boolean isAvailable() {
         try {
-            Document result = mongoTemplate.executeCommand(new Document("ping", 1));
+            Document result = mongoTemplate.executeCommand(new Document("hello", 1));
             Number status = result.get("ok", Number.class);
-            return status != null && status.doubleValue() == 1.0d;
+            String replicaSetName = result.getString("setName");
+            Boolean writablePrimary = result.getBoolean("isWritablePrimary");
+            return status != null
+                    && status.doubleValue() == 1.0d
+                    && replicaSetName != null
+                    && !replicaSetName.isBlank()
+                    && Boolean.TRUE.equals(writablePrimary);
         } catch (RuntimeException ex) {
             return false;
         }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/CommercialPolicyService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/CommercialPolicyService.java
@@ -3,20 +3,25 @@ package br.com.urbana.connect.application.reception;
 import br.com.urbana.connect.domain.reception.model.AgentOutput;
 import br.com.urbana.connect.domain.reception.model.AgentNextAction;
 import br.com.urbana.connect.domain.reception.model.CustomerFact;
-import br.com.urbana.connect.domain.reception.model.FactConfidence;
+import br.com.urbana.connect.domain.reception.model.CustomerFactType;
 import br.com.urbana.connect.domain.reception.model.PaymentStatus;
 import br.com.urbana.connect.domain.reception.model.ReceptionConversation;
 import br.com.urbana.connect.domain.reception.model.ReceptionMode;
+import br.com.urbana.connect.domain.servicecatalog.model.AreaRule;
+import br.com.urbana.connect.domain.servicecatalog.model.ServiceCatalogItem;
 
 import java.math.BigDecimal;
 import java.text.Normalizer;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Deterministic commercial checkpoints owned by Urbana Connect.  Hermes may
@@ -26,14 +31,15 @@ public final class CommercialPolicyService {
     public static final String PREFER_NOT_TO_ANSWER = "PREFER_NOT_TO_ANSWER";
     private static final String PAYMENT_PROOF_PENDING_MESSAGE =
             "Recebi o comprovante. Agora ele aguarda validação humana; aviso assim que o pagamento for confirmado.";
-    private static final List<String> MANDATORY_ICP = List.of(
-            "PRONOUN_PREFERENCE", "FIRST_TIME_HIRING", "OCCUPATION");
+    private static final List<String> MANDATORY_ICP = CustomerFactType.icpFieldNames();
     private static final List<String> ALLOWED_PAYMENT_METHODS = List.of("PIX", "CARD");
 
     private final Map<String, ServiceFixture> catalog;
 
     public CommercialPolicyService() {
-        this(defaultCatalog().values());
+        this(ServiceCatalogItem.canonicalCatalog().stream()
+                .map(ServiceFixture::from)
+                .toList());
     }
 
     public CommercialPolicyService(Collection<ServiceFixture> catalog) {
@@ -42,7 +48,7 @@ public final class CommercialPolicyService {
         }
         Map<String, ServiceFixture> values = new LinkedHashMap<>();
         catalog.forEach(item -> values.put(normalizeService(item.serviceType()), item));
-        this.catalog = Map.copyOf(values);
+        this.catalog = Collections.unmodifiableMap(new LinkedHashMap<>(values));
     }
 
     public List<String> mandatoryIcpFields() {
@@ -51,7 +57,10 @@ public final class CommercialPolicyService {
 
     public List<String> missingIcpFields(Collection<CustomerFact> facts, Instant at) {
         return MANDATORY_ICP.stream()
-                .filter(field -> !hasConfirmedCurrent(facts, field, at))
+                .filter(field -> latestVersion(facts, field, at)
+                        .map(fact -> fact.isReusableAt(at))
+                        .map(complete -> !complete)
+                        .orElse(true))
                 .toList();
     }
 
@@ -83,40 +92,81 @@ public final class CommercialPolicyService {
 
     public ReceptionConversation selectService(ReceptionConversation conversation, String serviceType, Instant now) {
         requireConversation(conversation);
-        service(serviceType);
-        return conversation.selectService(normalizeService(serviceType), Objects.requireNonNull(now, "now"));
+        String normalized = normalizeService(serviceType);
+        service(normalized);
+        if (normalized.equalsIgnoreCase(conversation.selectedService())) {
+            return conversation;
+        }
+        return conversation.selectService(normalized, Objects.requireNonNull(now, "now"));
     }
 
     public ReceptionConversation presentTerms(ReceptionConversation conversation,
                                               Collection<CustomerFact> facts, Instant now) {
         requireConversation(conversation);
-        requireIcp(facts, now);
         if (conversation.selectedService() == null) {
             throw new IllegalStateException("service must be selected before terms");
+        }
+        service(conversation.selectedService());
+        if (conversation.termsStatus() != br.com.urbana.connect.domain.reception.model.TermsStatus.NOT_PRESENTED
+                && conversation.termsStatus() != br.com.urbana.connect.domain.reception.model.TermsStatus.DECLINED) {
+            return conversation;
         }
         return conversation.presentTerms(Objects.requireNonNull(now, "now"));
     }
 
     public ReceptionConversation acceptTerms(ReceptionConversation conversation, Instant now) {
         requireConversation(conversation);
+        if (conversation.termsStatus() == br.com.urbana.connect.domain.reception.model.TermsStatus.ACCEPTED) {
+            return conversation;
+        }
         return conversation.acceptTerms(Objects.requireNonNull(now, "now"));
+    }
+
+    public ReceptionConversation acceptTerms(ReceptionConversation conversation,
+                                              String acceptanceText,
+                                              Instant now) {
+        if (!isExplicitTermsAcceptance(acceptanceText)) {
+            throw new IllegalArgumentException("terms acceptance must be clear and textual");
+        }
+        return acceptTerms(conversation, now);
+    }
+
+    public boolean isExplicitTermsAcceptance(String acceptanceText) {
+        if (acceptanceText == null || acceptanceText.isBlank()) {
+            return false;
+        }
+        String normalized = normalizeText(acceptanceText);
+        if (normalized.contains("nao") || normalized.contains("recuso") || normalized.contains("discordo")) {
+            return false;
+        }
+        return normalized.matches(".*(?:\\b(aceito|concordo)\\b.*\\btermos\\b|"
+                + "\\bestou\\s+de\\s+acordo\\b.*\\btermos\\b).*" );
     }
 
     public ReceptionConversation preparePayment(ReceptionConversation conversation,
                                                 Collection<CustomerFact> facts,
                                                 String method, Instant now) {
         requireConversation(conversation);
-        requireIcp(facts, now);
         if (conversation.selectedService() == null) {
             throw new IllegalStateException("service must be selected before payment");
         }
         service(conversation.selectedService());
-        return conversation.preparePayment(true, normalizeMethod(method), Objects.requireNonNull(now, "now"));
+        if (conversation.paymentStatus() == PaymentStatus.PREPARED
+                || conversation.paymentStatus() == PaymentStatus.PROOF_RECEIVED
+                || conversation.paymentStatus() == PaymentStatus.CONFIRMED) {
+            return conversation;
+        }
+        String normalizedMethod = normalizeMethod(method);
+        return conversation.preparePayment(false, normalizedMethod, Objects.requireNonNull(now, "now"));
     }
 
     /** A media/document proof can only move PREPARED to PROOF_RECEIVED. */
     public ReceptionConversation receivePaymentProof(ReceptionConversation conversation, Instant now) {
         requireConversation(conversation);
+        if (conversation.paymentStatus() == PaymentStatus.PROOF_RECEIVED
+                || conversation.paymentStatus() == PaymentStatus.CONFIRMED) {
+            return conversation;
+        }
         if (conversation.paymentStatus() != PaymentStatus.PREPARED) {
             throw new IllegalStateException("payment proof requires payment status PREPARED");
         }
@@ -138,6 +188,9 @@ public final class CommercialPolicyService {
     /** Human-only approval checkpoint; not exposed as an Hermes/domain tool. */
     public ReceptionConversation approvePaymentProof(ReceptionConversation conversation, Instant now) {
         requireApprovalConversation(conversation);
+        if (conversation.paymentStatus() == PaymentStatus.CONFIRMED) {
+            return conversation;
+        }
         return conversation.confirmPayment(Objects.requireNonNull(now, "now"));
     }
 
@@ -157,16 +210,26 @@ public final class CommercialPolicyService {
     public AgentOutput reconcileOutput(AgentOutput candidate, ReceptionConversation conversation) {
         Objects.requireNonNull(candidate, "candidate");
         requireConversation(conversation);
+        if (candidate.nextAction() == AgentNextAction.AWAIT_PAYMENT_APPROVAL
+                && conversation.paymentStatus() != PaymentStatus.PROOF_RECEIVED) {
+            throw new IllegalArgumentException("payment approval cannot be awaited without proof");
+        }
+        if (candidate.nextAction() == AgentNextAction.AWAIT_PAYMENT_PROOF
+                && conversation.paymentStatus() != PaymentStatus.PREPARED) {
+            throw new IllegalArgumentException("payment proof cannot be awaited before payment preparation");
+        }
         if (conversation.paymentStatus() == PaymentStatus.PROOF_RECEIVED) {
             return new AgentOutput(PAYMENT_PROOF_PENDING_MESSAGE, AgentNextAction.AWAIT_PAYMENT_APPROVAL);
         }
         String normalized = normalizeText(candidate.message());
         if (conversation.paymentStatus() != PaymentStatus.CONFIRMED) {
-            boolean mentionsBriefing = normalized.contains("briefing");
-            boolean claimsPaymentConfirmation = normalized.contains("pagamento")
-                    && (normalized.contains("confirmad") || normalized.contains("aprova")
-                    || normalized.contains("validado") || normalized.contains("compensado"));
-            if (mentionsBriefing || (claimsPaymentConfirmation
+            boolean briefingReleaseClaim = claimsBriefingRelease(normalized)
+                    && !briefingIsExplicitlyDeferred(normalized);
+            boolean prematurePaymentInstruction = conversation.paymentStatus() != PaymentStatus.PREPARED
+                    && conversation.paymentStatus() != PaymentStatus.PROOF_RECEIVED
+                    && claimsPaymentInstruction(normalized);
+            boolean claimsPaymentConfirmation = claimsPaymentConfirmation(normalized);
+            if (briefingReleaseClaim || prematurePaymentInstruction || (claimsPaymentConfirmation
                     && !explicitlyDeniesPaymentConfirmation(normalized))) {
                 throw new IllegalArgumentException(
                         "payment confirmation and briefing cannot be claimed before human payment approval");
@@ -183,23 +246,32 @@ public final class CommercialPolicyService {
         return service(serviceType).paymentUrl();
     }
 
-    private void requireIcp(Collection<CustomerFact> facts, Instant at) {
-        if (!isIcpComplete(facts, at)) {
-            throw new IllegalStateException("complete ICP is required before commercial checkpoint: "
-                    + String.join(", ", missingIcpFields(facts, at)));
-        }
+    public String briefingUrl(String serviceType) {
+        return service(serviceType).briefingUrl();
     }
 
-    private static boolean hasConfirmedCurrent(Collection<CustomerFact> facts, String type, Instant at) {
+    public AreaRule areaRule(String serviceType) {
+        return service(serviceType).areaRule();
+    }
+
+    public boolean isAreaWithinCatalog(String serviceType, BigDecimal squareMeters) {
+        return service(serviceType).areaRule().accepts(squareMeters);
+    }
+
+    public boolean requiresArchitectAreaReview(String serviceType, BigDecimal squareMeters) {
+        return service(serviceType).areaRule().requiresArchitectReview(squareMeters);
+    }
+
+    private static Optional<CustomerFact> latestVersion(Collection<CustomerFact> facts, String type, Instant at) {
         if (facts == null || at == null) {
-            return false;
+            return Optional.empty();
         }
-        return facts.stream().filter(Objects::nonNull)
-                .anyMatch(fact -> type.equalsIgnoreCase(fact.type())
-                        && fact.confidence() == FactConfidence.CONFIRMED
-                        && fact.supersededBy() == null
-                        && fact.isCurrentAt(at)
-                        && !fact.value().isBlank());
+        return facts.stream()
+                .filter(Objects::nonNull)
+                .filter(fact -> type.equalsIgnoreCase(fact.type()))
+                .filter(fact -> fact.supersededBy() == null)
+                .filter(fact -> !fact.validFrom().isAfter(at))
+                .max(Comparator.comparing(CustomerFact::validFrom).thenComparing(CustomerFact::id));
     }
 
     private static void requireConversation(ReceptionConversation conversation) {
@@ -221,7 +293,8 @@ public final class CommercialPolicyService {
         if (serviceType == null || serviceType.isBlank()) {
             throw new IllegalArgumentException("serviceType must not be blank");
         }
-        return serviceType.trim().toUpperCase(Locale.ROOT).replace('-', '_').replace(' ', '_');
+        String normalized = serviceType.trim().toUpperCase(Locale.ROOT).replace('-', '_').replace(' ', '_');
+        return "DECOR".equals(normalized) ? "DECOR_INTERIORES" : normalized;
     }
 
     private static String normalizeText(String value) {
@@ -238,6 +311,7 @@ public final class CommercialPolicyService {
                 || normalized.contains("nao esta confirmado")
                 || normalized.contains("nao foi aprovado")
                 || normalized.contains("nao aprova")
+                || normalized.matches(".*\\b(?:nenhum|nao)\\s+pagamento\\b.*\\b(?:confirmad|aprovad|valid|compensad).*" )
                 || normalized.contains("submetido a aprovacao humana")
                 || normalized.contains("submetida a aprovacao humana")
                 || normalized.contains("aguarda aprovacao humana")
@@ -259,6 +333,44 @@ public final class CommercialPolicyService {
                 || normalized.contains("sera analisado e aprovado exclusivamente pela equipe humana");
     }
 
+    private static boolean claimsPaymentConfirmation(String normalized) {
+        return normalized.matches(".*\\bpagamento\\b\\s+(?:foi\\s+)?(?:confirmad|aprovad|validad|compensad).*")
+                || normalized.matches(".*\\b(?:confirmad|aprovad|validad|compensad)\\b\\s+(?:o\\s+)?pagamento\\b.*");
+    }
+
+    private static boolean claimsBriefingRelease(String normalized) {
+        boolean directIntroduction = normalized.matches(
+                ".*\\b(?:aqui esta|segue)\\s+(?:o\\s+)?briefing\\b.*");
+        boolean directReadyState = normalized.matches(
+                ".*\\bbriefing\\b.{0,24}\\b(?:esta|foi|ja esta|ja foi)\\s+"
+                        + "(?:pronto|liberad|disponibilizad|disponivel|enviad)\\b.*");
+        boolean directReadyLabel = normalized.matches(
+                ".*\\bbriefing\\s+(?:ja\\s+)?(?:pronto|liberad|disponibilizad|disponivel|enviad)\\b.*");
+        boolean directAccess = normalized.matches(
+                ".*\\b(?:acesse|abra|abrir|clique)\\b.{0,40}\\bbriefing\\b.*");
+        return directIntroduction || directReadyState || directReadyLabel || directAccess;
+    }
+
+    private static boolean claimsPaymentInstruction(String normalized) {
+        return normalized.matches(".*https?://\\S*(?:payment|pagamento|pix)\\S*.*")
+                || normalized.matches(".*\\b(?:link|url|chave)\\b.{0,40}\\b(?:de\\s+)?(?:pagamento|pix)\\b.*")
+                || normalized.matches(".*\\b(?:pagamento|pagar|pague)\\b.{0,40}\\b(?:link|url|chave)\\b.*");
+    }
+
+    private static boolean briefingIsExplicitlyDeferred(String normalized) {
+        return normalized.contains("apos pagamento")
+                || normalized.contains("apos o pagamento")
+                || normalized.contains("apos a confirmacao")
+                || normalized.contains("apos confirmacao")
+                || normalized.contains("depois do pagamento")
+                || normalized.contains("depois de aceitar")
+                || normalized.contains("depois do aceite")
+                || normalized.contains("apos aceitar")
+                || normalized.contains("apos o aceite")
+                || normalized.contains("quando o pagamento")
+                || normalized.contains("assim que o pagamento");
+    }
+
     private static String normalizeMethod(String method) {
         if (method == null || method.isBlank()) {
             throw new IllegalArgumentException("payment method must not be blank");
@@ -270,37 +382,53 @@ public final class CommercialPolicyService {
         return normalized;
     }
 
-    private static Map<String, ServiceFixture> defaultCatalog() {
-        Map<String, ServiceFixture> values = new LinkedHashMap<>();
-        values.put("DECOR", new ServiceFixture("DECOR", "Decor", "🛋️",
-                "Solução de decoração para ambientes de até 20m².", new BigDecimal("400.00"),
-                "https://fixtures.urbana.local/payment/decor", "https://fixtures.urbana.local/terms/decor",
-                "https://fixtures.urbana.local/briefing/decor", "Briefing DECOR — fixture local.", true));
-        values.put("DECOR_PINTURA", new ServiceFixture("DECOR_PINTURA", "Decor Pintura", "🎨",
-                "Renovação com pintura, sem quebra-quebra.", new BigDecimal("250.00"),
-                "https://fixtures.urbana.local/payment/decor-pintura", "https://fixtures.urbana.local/terms/decor-pintura",
-                "https://fixtures.urbana.local/briefing/decor-pintura", "Briefing DECOR_PINTURA — fixture local.", true));
-        values.put("DECOR_FACHADA", new ServiceFixture("DECOR_FACHADA", "Decor Fachada", "🏡",
-                "Renovação de fachadas ou muros externos.", new BigDecimal("350.00"),
-                "https://fixtures.urbana.local/payment/decor-fachada", "https://fixtures.urbana.local/terms/decor-fachada",
-                "https://fixtures.urbana.local/briefing/decor-fachada", "Briefing DECOR_FACHADA — fixture local.", true));
-        values.put("DECOR_REFORMA", new ServiceFixture("DECOR_REFORMA", "Decor Reforma", "🧱",
-                "Reforma completa de um espaço interno.", new BigDecimal("450.00"),
-                "https://fixtures.urbana.local/payment/decor-reforma", "https://fixtures.urbana.local/terms/decor-reforma",
-                "https://fixtures.urbana.local/briefing/decor-reforma", "Briefing DECOR_REFORMA — fixture local.", true));
-        return values;
-    }
-
     public record ServiceFixture(String serviceType, String name, String emoji, String description,
                                  BigDecimal price, String paymentUrl, String termsUrl,
-                                 String briefingUrl, String briefingText, boolean available) {
+                                 String briefingUrl, String briefingText, boolean available,
+                                 AreaRule areaRule, String scope, List<String> deliverables,
+                                 List<String> process, List<String> responsibilities,
+                                 List<String> exclusions, String support) {
+        public ServiceFixture(String serviceType, String name, String emoji, String description,
+                              BigDecimal price, String paymentUrl, String termsUrl,
+                              String briefingUrl, String briefingText, boolean available) {
+            this(serviceType, name, emoji, description, price, paymentUrl, termsUrl, briefingUrl,
+                    briefingText, available, AreaRule.UNLIMITED_BY_CATALOG, description,
+                    List.of(), List.of(), List.of(), List.of(), "legacy adapter");
+        }
+
+        private static ServiceFixture from(ServiceCatalogItem item) {
+            return new ServiceFixture(
+                    item.type().name(),
+                    item.name(),
+                    item.emoji(),
+                    item.scope(),
+                    item.price(),
+                    item.paymentResource(),
+                    item.termsResource(),
+                    item.briefingResource(),
+                    "Briefing " + item.type().name() + " — " + item.scope(),
+                    item.available(),
+                    item.areaRule(),
+                    item.scope(),
+                    item.deliverables(),
+                    item.process(),
+                    item.responsibilities(),
+                    item.exclusions(),
+                    item.support());
+        }
+
         public ServiceFixture {
             if (serviceType == null || serviceType.isBlank() || name == null || name.isBlank()
                     || description == null || description.isBlank() || price == null || price.signum() < 0
                     || paymentUrl == null || termsUrl == null || briefingUrl == null
-                    || briefingText == null || briefingText.isBlank()) {
-                throw new IllegalArgumentException("fixture service fields are incomplete");
+                    || briefingText == null || briefingText.isBlank() || areaRule == null
+                    || scope == null || scope.isBlank() || support == null || support.isBlank()) {
+                throw new IllegalArgumentException("catalog service fields are incomplete");
             }
+            deliverables = deliverables == null ? List.of() : List.copyOf(deliverables);
+            process = process == null ? List.of() : List.copyOf(process);
+            responsibilities = responsibilities == null ? List.of() : List.copyOf(responsibilities);
+            exclusions = exclusions == null ? List.of() : List.copyOf(exclusions);
         }
     }
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionOrchestrator.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionOrchestrator.java
@@ -1,5 +1,6 @@
 package br.com.urbana.connect.application.reception;
 
+import br.com.urbana.connect.application.reception.tools.StatefulDomainToolService;
 import br.com.urbana.connect.domain.reception.model.AgentNextAction;
 import br.com.urbana.connect.domain.reception.model.AgentOutput;
 import br.com.urbana.connect.domain.reception.model.AgentUsage;
@@ -14,13 +15,18 @@ import br.com.urbana.connect.domain.reception.model.ReceptionMode;
 import br.com.urbana.connect.domain.reception.model.ReceptionTurn;
 import br.com.urbana.connect.domain.reception.model.ReceptionTurnStatus;
 import br.com.urbana.connect.domain.reception.model.ReceptionEventIds;
+import br.com.urbana.connect.domain.reception.model.ResumeStatus;
 import br.com.urbana.connect.domain.reception.port.out.CustomerFactGateway;
 import br.com.urbana.connect.domain.reception.port.out.DomainToolInvocationGateway;
+import br.com.urbana.connect.domain.reception.port.out.HermesResumeGateway;
 import br.com.urbana.connect.domain.reception.port.out.HermesSessionsGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionConversationGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTranscriptGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTurnGateway;
 import br.com.urbana.connect.infrastructure.hermes.HermesAgentOutputParser;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +34,10 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.text.Normalizer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Comparator;
+import java.util.HexFormat;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -50,6 +60,21 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class ReceptionOrchestrator {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReceptionOrchestrator.class);
+    private static final int RESUME_CONTRACT_VERSION = 1;
+    private static final String SAFE_RESUME_FAILURE = "RESUME_UNAVAILABLE";
+    private static final String SAFE_PAYMENT_CHECKPOINT_MESSAGE =
+            "Para continuar com segurança, preciso aguardar a confirmação do pagamento pela arquiteta.";
+    private static final String SAFE_PAYMENT_PREPARATION_MESSAGE =
+            "Para continuar, escolha uma forma de pagamento: PIX ou cartão de crédito.";
+    private static final String SAFE_PAYMENT_PROOF_MESSAGE =
+            "O pagamento está preparado. Realize-o pelo link e envie o comprovante por aqui.";
+    private static final String SAFE_PAYMENT_PROOF_HANDOFF_MESSAGE =
+            "Recebi o comprovante. Vou encaminhar sua conversa para a arquiteta, que fará a validação do pagamento por aqui.";
+    private static final String SAFE_COMMERCIAL_RECOVERY_MESSAGE =
+            "Não consigo confirmar essa etapa com segurança. Posso te orientar sobre o próximo passo?";
+    private static final ObjectMapper RESUME_JSON = new ObjectMapper()
+            .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
     private static final String FAILED_RETRYABLE = "FAILED_RETRYABLE";
     private static final Duration DEFAULT_DELAY_THRESHOLD = Duration.ofSeconds(5);
     private final HermesSessionService hermes;
@@ -288,12 +313,267 @@ public final class ReceptionOrchestrator {
                     .orElseThrow(() -> new IllegalStateException("conversation does not exist"));
             ReceptionConversation approved = policy.approvePaymentProof(conversation, clock.instant());
             conversations.save(approved);
-            String eventId = "approval:" + contactId + ":" + approved.version();
-            String correlationId = UUID.randomUUID().toString();
+            String eventId = "approval:" + contactId + ":" + approved.id();
+            // The operator action is replayed by contact and conversation,
+            // never by a process-local random correlation id.
+            String correlationId = eventId;
+            if (approved.mode() == ReceptionMode.HUMAN) {
+                appendHumanDecision(approved, eventId, correlationId,
+                        "Pagamento confirmado pela arquiteta.");
+                return new TurnReceipt(eventId, correlationId, TurnStatus.BLOCKED_BY_HUMAN, null, null);
+            }
             AgentOutput output = new AgentOutput(policy.briefingFor(approved), AgentNextAction.NONE);
             appendOutbound(approved, eventId, correlationId, output.message());
             return new TurnReceipt(eventId, correlationId, TurnStatus.COMPLETED, output, null);
         });
+    }
+
+    /** Records an operator-authored HUMAN message; actor identity is backend-owned. */
+    public HumanMessageReceipt recordHumanMessage(String contactId, String idempotencyKey, String text,
+                                                  Instant occurredAt) {
+        require(contactId, "contactId");
+        require(idempotencyKey, "idempotencyKey");
+        require(text, "text");
+        Instant at = occurredAt == null ? clock.instant() : occurredAt;
+        return coordinator.serialize(contactId, () -> {
+            ReceptionConversation conversation = conversations.findByContactId(contactId)
+                    .orElseThrow(() -> new IllegalStateException("conversation does not exist"));
+            if (conversation.mode() != ReceptionMode.HUMAN) {
+                return new HumanMessageReceipt(idempotencyKey, "REJECTED", false,
+                        "A conversa está sob responsabilidade da Urba.");
+            }
+            String eventId = ReceptionEventIds.outbound("human-message:" + idempotencyKey, conversation.id());
+            Optional<ReceptionMessage> existing = transcript.findByEventId(eventId);
+            if (existing.isPresent()) {
+                return new HumanMessageReceipt(eventId, "RECORDED", true, "Mensagem humana registrada.");
+            }
+            ReceptionMessage message = new ReceptionMessage(UUID.randomUUID().toString(), eventId,
+                    "operator:" + idempotencyKey, conversation.id(), contactId,
+                    ReceptionMessageDirection.OUTBOUND, ReceptionMessageSender.HUMAN,
+                    ReceptionMessageType.TEXT, text.trim(), null, null, at);
+            transcript.appendIfAbsent(message);
+            return new HumanMessageReceipt(eventId, "RECORDED", false, "Mensagem humana registrada.");
+        });
+    }
+
+    /** Runs the PEE-103 transition while HUMAN remains authoritative until both calls succeed. */
+    public ResumeReceipt returnToUrba(String contactId, String idempotencyKey, long expectedVersion,
+                                      HermesResumeGateway resumeGateway) {
+        require(contactId, "contactId");
+        require(idempotencyKey, "idempotencyKey");
+        return coordinator.serialize(contactId,
+                () -> returnToUrbaUnderLock(contactId, idempotencyKey, expectedVersion, resumeGateway));
+    }
+
+    private ResumeReceipt returnToUrbaUnderLock(String contactId, String idempotencyKey,
+                                                long expectedVersion, HermesResumeGateway resumeGateway) {
+        ReceptionConversation conversation = conversations.findByContactId(contactId)
+                .orElseThrow(() -> new IllegalStateException("conversation does not exist"));
+        if (conversation.mode() != ReceptionMode.HUMAN) {
+            return new ResumeReceipt(conversation.resumeId(), ResumeStatus.COMPLETED, "URBA", null,
+                    true, "A conversa já está sob responsabilidade da Urba.");
+        }
+        if (expectedVersion >= 0 && expectedVersion != conversation.version()) {
+            return new ResumeReceipt(conversation.resumeId(), conversation.resumeStatus(), "HUMAN", null,
+                    false, "A conversa mudou; atualize o estado antes de tentar novamente.");
+        }
+        if (conversation.resumeIdempotencyKey() != null
+                && conversation.resumeIdempotencyKey().equals(idempotencyKey)) {
+            if (conversation.resumeStatus() == ResumeStatus.FAILED_SAFE
+                    || conversation.resumeStatus() == ResumeStatus.RETURNED_TO_HUMAN) {
+                return new ResumeReceipt(conversation.resumeId(), conversation.resumeStatus(), "HUMAN", null,
+                        true, "A retomada permanece aguardando a arquiteta.");
+            }
+            if (conversation.resumeStatus() == ResumeStatus.SYNCHRONIZING
+                    || conversation.resumeStatus() == ResumeStatus.DECIDING) {
+                return new ResumeReceipt(conversation.resumeId(), conversation.resumeStatus(), "HUMAN", null,
+                        true, "A retomada está em andamento.");
+            }
+        }
+        if (conversation.resumeStatus() == ResumeStatus.SYNCHRONIZING
+                || conversation.resumeStatus() == ResumeStatus.DECIDING) {
+            return new ResumeReceipt(conversation.resumeId(), conversation.resumeStatus(), "HUMAN", null,
+                    true, "A retomada está em andamento.");
+        }
+        if (resumeGateway == null) {
+            ReceptionConversation failed = conversations.saveExpected(
+                    conversation.failResume(SAFE_RESUME_FAILURE, clock.instant()), conversation.version());
+            return new ResumeReceipt(failed.resumeId(), failed.resumeStatus(), "HUMAN", null,
+                    false, "A conversa permanece com a arquiteta.");
+        }
+
+        List<ReceptionMessage> messages = transcript.findByConversationId(conversation.id()).stream()
+                .sorted(Comparator.comparing(ReceptionMessage::createdAt).thenComparing(ReceptionMessage::eventId))
+                .toList();
+        Instant snapshotAt = clock.instant();
+        List<CustomerFact> currentFacts = facts.findCurrentByContactId(contactId, snapshotAt).stream()
+                .filter(fact -> fact.isCurrentAt(snapshotAt))
+                .toList();
+        String resumeId = UUID.nameUUIDFromBytes((conversation.id() + ":" + idempotencyKey)
+                .getBytes(StandardCharsets.UTF_8)).toString();
+        List<HermesResumeGateway.ContextMessage> typedMessages = resumeMessages(messages);
+        String checksum = resumeChecksum(typedMessages);
+        long ownershipVersion = conversation.version();
+        ReceptionConversation synchronizing = conversations.saveExpected(conversation.beginResume(
+                resumeId, idempotencyKey, checksum, messages.size(), snapshotAt), ownershipVersion);
+        ReceptionConversation state = synchronizing;
+        try {
+            HermesSessionService.SessionResolution session = hermes.resolve(contactId);
+            HermesResumeGateway.ResumeContext context = new HermesResumeGateway.ResumeContext(
+                    RESUME_CONTRACT_VERSION, resumeId, conversation.id(), "sync:" + idempotencyKey,
+                    "FULL", synchronizing.version(), messages.size(), checksum,
+                    typedMessages, resumeFacts(currentFacts));
+            HermesResumeGateway.ContextSyncReceipt receipt = resumeGateway.synchronize(session.sessionId(), context);
+            requireCompleteContextReceipt(receipt, context);
+            state = conversations.saveExpected(synchronizing.markResumeDeciding(clock.instant()), synchronizing.version());
+            ReceptionConversation deciding = state;
+            Map<String, Object> directive = resumeDirective(deciding);
+            HermesResumeGateway.ResumeDecision decision = resumeGateway.decide(session.sessionId(),
+                    new HermesResumeGateway.ResumeCommand(RESUME_CONTRACT_VERSION, resumeId, conversation.id(),
+                            "decide:" + idempotencyKey, receipt, directive));
+            if (decision == null || decision.action() == null) {
+                ReceptionConversation human = failResumeAfterError(contactId, state, "INVALID_RESUME_DECISION");
+                return new ResumeReceipt(human.resumeId(), human.resumeStatus(), "HUMAN", null,
+                        false, "A conversa permanece com a arquiteta.");
+            }
+            if (decision.action() == HermesResumeGateway.Action.RETURN_TO_HUMAN) {
+                ReceptionConversation human = conversations.saveExpected(deciding.returnResumeToHuman(
+                        "retomada devolvida à arquiteta", clock.instant()), deciding.version());
+                return new ResumeReceipt(human.resumeId(), human.resumeStatus(), "HUMAN", null,
+                        false, "A conversa permanece com a arquiteta.");
+            }
+            if (decision.action() == HermesResumeGateway.Action.SEND_MESSAGE
+                    && !provenResumeStep(deciding, decision)) {
+                ReceptionConversation human = conversations.saveExpected(deciding.failResume(
+                        "UNPROVEN_RESUME_STEP", clock.instant()), deciding.version());
+                return new ResumeReceipt(human.resumeId(), human.resumeStatus(), "HUMAN", null,
+                        false, "A conversa permanece com a arquiteta.");
+            }
+            if (decision.action() == HermesResumeGateway.Action.SEND_MESSAGE
+                    && !safeResumeMessage(decision.message())) {
+                ReceptionConversation human = conversations.saveExpected(deciding.failResume(
+                        "UNSAFE_RESUME_MESSAGE", clock.instant()), deciding.version());
+                return new ResumeReceipt(human.resumeId(), human.resumeStatus(), "HUMAN", null,
+                        false, "A conversa permanece com a arquiteta.");
+            }
+            ReceptionConversation completed = conversations.saveExpected(deciding.completeResume(
+                    decision.action().name(), decision.message(), clock.instant()), deciding.version());
+            state = completed;
+            if (decision.action() == HermesResumeGateway.Action.SEND_MESSAGE) {
+                appendOutbound(completed, "resume:" + resumeId, resumeId, decision.message());
+            }
+            return new ResumeReceipt(completed.resumeId(), completed.resumeStatus(), "URBA",
+                    decision.message(), false, "A Urba retomou o atendimento.");
+        } catch (RuntimeException failure) {
+            LOGGER.warn("resume transition failed closed for contact {}", contactId, failure);
+            ReceptionConversation human = failResumeAfterError(contactId, state, SAFE_RESUME_FAILURE);
+            return new ResumeReceipt(human.resumeId(), human.resumeStatus(), "HUMAN", null,
+                    false, "A conversa permanece com a arquiteta.");
+        }
+    }
+
+    private ReceptionConversation failResumeAfterError(String contactId, ReceptionConversation fallback,
+                                                       String failureCode) {
+        ReceptionConversation current = conversations.findByContactId(contactId).orElse(fallback);
+        return conversations.save(current.failResume(failureCode, clock.instant()));
+    }
+
+    private static List<HermesResumeGateway.ContextMessage> resumeMessages(List<ReceptionMessage> messages) {
+        return java.util.stream.IntStream.range(0, messages.size()).mapToObj(index -> {
+            ReceptionMessage message = messages.get(index);
+            String sender = message.senderType().name();
+            String role = switch (message.senderType()) {
+                case CONTACT -> "user";
+                case URBA -> "assistant";
+                case HUMAN -> "human";
+                case SYSTEM -> "system";
+            };
+            String content = message.text() == null ? "[Conteúdo não textual]" : message.text();
+            return new HermesResumeGateway.ContextMessage(index + 1, message.eventId(), sender, role, content);
+        }).toList();
+    }
+
+    private static List<HermesResumeGateway.ContextFact> resumeFacts(List<CustomerFact> facts) {
+        return facts.stream().map(fact -> new HermesResumeGateway.ContextFact(
+                fact.type(), fact.value(), fact.confidence().name())).toList();
+    }
+
+    private static void requireCompleteContextReceipt(HermesResumeGateway.ContextSyncReceipt receipt,
+                                                       HermesResumeGateway.ResumeContext context) {
+        if (receipt == null || !Objects.equals(receipt.resumeId(), context.resumeId())
+                || !Objects.equals(receipt.lineageId(), context.lineageId())
+                || !Objects.equals(receipt.checksum(), context.checksum())
+                || receipt.coveredThroughSequence() < context.watermark()
+                || receipt.effectiveSessionId() == null || receipt.effectiveSessionId().isBlank()) {
+            throw new IllegalStateException("resume context receipt is incomplete");
+        }
+    }
+
+    /**
+     * Hermes v1 canonicalizes the ordered message projection itself. Facts are
+     * sent as context, but are intentionally outside this checksum contract.
+     */
+    private static String resumeChecksum(List<HermesResumeGateway.ContextMessage> messages) {
+        try {
+            List<Map<String, Object>> projection = java.util.stream.IntStream.range(0, messages.size())
+                    .mapToObj(index -> {
+                        HermesResumeGateway.ContextMessage message = messages.get(index);
+                        Map<String, Object> value = new LinkedHashMap<>();
+                        value.put("content", message.content());
+                        value.put("role", message.role());
+                        value.put("senderType", message.senderType());
+                        value.put("sequence", message.sequence());
+                        value.put("sourceMessageId", message.sourceMessageId());
+                        return value;
+                    }).toList();
+            byte[] canonical = RESUME_JSON.writeValueAsBytes(projection);
+            return "sha256:" + HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(canonical));
+        } catch (Exception failure) {
+            throw new IllegalStateException("resume checksum unavailable", failure);
+        }
+    }
+
+    private Map<String, Object> resumeDirective(ReceptionConversation conversation) {
+        Map<String, Object> operational = new LinkedHashMap<>();
+        operational.put("commercialStage", conversation.commercialStage().name());
+        operational.put("paymentStatus", conversation.paymentStatus().name());
+        operational.put("selectedService", conversation.selectedService());
+        operational.put("nextOperationalAction", conversation.paymentStatus() == PaymentStatus.CONFIRMED
+                ? "BRIEFING" : "NONE");
+        Map<String, Object> directive = new LinkedHashMap<>();
+        directive.put("allowedActions", List.of("SEND_MESSAGE", "WAIT", "RETURN_TO_HUMAN"));
+        directive.put("allowedNextSteps", List.of("BRIEFING", "SUPPORT", "NONE"));
+        directive.put("authorityPolicy", "HUMAN_CASE_DECISIONS_OVERRIDE_CATALOG");
+        directive.put("operationalState", operational);
+        return directive;
+    }
+
+    private static boolean safeResumeMessage(String message) {
+        if (message == null || message.isBlank() || message.length() > 2000) return false;
+        String normalized = message.toLowerCase(java.util.Locale.ROOT);
+        return List.of("system", "sistema", "tool", "ferramenta", "api", "database", "banco de dados",
+                "http", "https", "exception", "exceção", "retry", "retentativa", "idempotency",
+                "idempotência", "stack trace", "hermes", "icp", "internal", "interno",
+                "problema no sistema", "url").stream().noneMatch(normalized::contains)
+                && !normalized.matches(".*\\b(?:conversation|contact|turn|session|resume)[-_]?[a-z0-9-]+\\b.*")
+                && !normalized.matches(".*\\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\b.*");
+    }
+
+    private static boolean provenResumeStep(ReceptionConversation conversation,
+                                            HermesResumeGateway.ResumeDecision decision) {
+        return conversation.paymentStatus() == PaymentStatus.CONFIRMED
+                && conversation.selectedService() != null
+                && decision.nextStep() != null
+                && "BRIEFING".equalsIgnoreCase(decision.nextStep());
+    }
+
+    private void appendHumanDecision(ReceptionConversation conversation, String eventId,
+                                     String correlationId, String text) {
+        ReceptionMessage message = new ReceptionMessage(UUID.randomUUID().toString(),
+                ReceptionEventIds.outbound(eventId, conversation.id()), correlationId, conversation.id(),
+                conversation.contactId(), ReceptionMessageDirection.OUTBOUND, ReceptionMessageSender.HUMAN,
+                ReceptionMessageType.TEXT, text, null, null, clock.instant());
+        transcript.appendIfAbsent(message);
     }
 
     public Map<String, Object> projection(String contactId) {
@@ -319,6 +599,17 @@ public final class ReceptionOrchestrator {
         Map<String, Object> projection = new LinkedHashMap<>();
         projection.put("contactId", contactId);
         projection.put("conversation", conversation == null ? Map.of() : conversation);
+        projection.put("ownership", conversation == null || conversation.mode() == ReceptionMode.AI
+                ? "URBA" : "HUMAN");
+        projection.put("resumeStatus", conversation == null ? ResumeStatus.NONE.name()
+                : conversation.resumeStatus().name());
+        projection.put("resumeId", conversation == null ? null : conversation.resumeId());
+        projection.put("controlAvailability", conversation != null && conversation.mode() == ReceptionMode.HUMAN
+                ? Map.of("recordHumanMessage", true, "returnToUrba", true,
+                "approvePaymentProof", conversation.paymentStatus() == PaymentStatus.PROOF_RECEIVED)
+                : Map.of("recordHumanMessage", false, "returnToUrba", false,
+                "approvePaymentProof", conversation != null
+                        && conversation.paymentStatus() == PaymentStatus.PROOF_RECEIVED));
         projection.put("facts", customerFacts);
         projection.put("messages", messages);
         projection.put("turn", turns.findLatestByContactId(contactId)
@@ -395,6 +686,9 @@ public final class ReceptionOrchestrator {
         // Hermes session, acquiring a lease, invoking tools, or publishing an
         // automated outbound message.
         if (conversation.mode() == ReceptionMode.HUMAN) {
+            String acknowledgement = events.stream().anyMatch(InboundConversationEvent::isPaymentProof)
+                    ? SAFE_PAYMENT_PROOF_HANDOFF_MESSAGE : StatefulDomainToolService.HUMAN_HANDOFF_ACK;
+            ensureHandoffAck(conversation, correlationId, now, acknowledgement);
             ReceptionTurn blockedTurn = new ReceptionTurn(UUID.randomUUID().toString(), correlationId,
                     first.contactId(), "human:" + conversation.id(), inboundMessages.stream()
                             .map(ReceptionMessage::id).toList(),
@@ -524,7 +818,7 @@ public final class ReceptionOrchestrator {
             persistInteractiveServiceFact(first.contactId(), service, selection);
         }
         Optional<InboundConversationEvent> acceptance = events.stream()
-                .filter(event -> explicitTermsAcceptance(event.conversationalText())).findFirst();
+                .filter(event -> policy.isExplicitTermsAcceptance(event.conversationalText())).findFirst();
         if (initial.termsStatus() == br.com.urbana.connect.domain.reception.model.TermsStatus.PRESENTED
                 && acceptance.isPresent()) {
             beforeChat = conversations.save(policy.acceptTerms(initial, acceptance.get().occurredAt()));
@@ -535,6 +829,16 @@ public final class ReceptionOrchestrator {
             ReceptionConversation proofBase = beforeChat.paymentStatus() == PaymentStatus.PREPARED
                     ? beforeChat : conversations.findByContactId(first.contactId()).orElse(beforeChat);
             beforeChat = conversations.save(policy.receivePaymentProof(proofBase, proof.get().occurredAt()));
+            ReceptionConversation human = beforeChat.requestHumanHandoff(
+                    "comprovante de pagamento aguardando validação da arquiteta", proof.get().occurredAt());
+            if (human != beforeChat) {
+                human = conversations.save(human);
+            }
+            ensureHandoffAck(human, turn.correlationId(), clock.instant(), SAFE_PAYMENT_PROOF_HANDOFF_MESSAGE);
+            ReceptionTurn blocked = turn.blockByHuman(clock.instant());
+            turns.save(blocked);
+            metrics.recordTurn(blocked, invocations == null ? List.of() : invocations.findByTurnId(turn.id()));
+            return new TurnReceipt(last.eventId(), turn.correlationId(), TurnStatus.BLOCKED_BY_HUMAN, null, null);
         }
         String input = events.stream().map(InboundConversationEvent::conversationalText)
                 .filter(text -> text != null && !text.isBlank())
@@ -549,12 +853,6 @@ public final class ReceptionOrchestrator {
         HermesSessionsGateway.HermesChatResult chat = chatWithDelayTracking(first.contactId(),
                 new HermesSessionsGateway.HermesChatRequest(input, images, null, null, null), turn);
         ReceptionConversation canonical = conversations.findByContactId(first.contactId()).orElse(beforeChat);
-        List<CustomerFact> currentFacts = facts.findByContactId(first.contactId());
-        if (canonical.selectedService() != null
-                && canonical.termsStatus() == br.com.urbana.connect.domain.reception.model.TermsStatus.NOT_PRESENTED
-                && policy.isIcpComplete(currentFacts, last.occurredAt())) {
-            canonical = conversations.save(policy.presentTerms(canonical, currentFacts, last.occurredAt()));
-        }
         if (canonical.termsStatus() == br.com.urbana.connect.domain.reception.model.TermsStatus.PRESENTED
                 && acceptance.isPresent()) {
             canonical = conversations.save(policy.acceptTerms(canonical, acceptance.get().occurredAt()));
@@ -566,28 +864,55 @@ public final class ReceptionOrchestrator {
         // automated publication, so do not pass the agent output through the
         // commercial policy, which intentionally rejects human-mode checks.
         if (canonical.mode() == ReceptionMode.HUMAN) {
+            ensureHandoffAck(canonical, turn.correlationId(), clock.instant());
             ReceptionTurn blocked = turn.blockByHuman(clock.instant());
             turns.save(blocked);
             metrics.recordTurn(blocked, ledger);
             return new TurnReceipt(last.eventId(), turn.correlationId(), TurnStatus.BLOCKED_BY_HUMAN, null, null);
         }
-        // The normal conversation path is a transparent pass-through. The
-        // parser only unwraps a compatible legacy message envelope; it never
-        // validates, rewrites or semantically reconciles the textual response.
-        AgentOutput output = parser.parse(chat.content());
+        // Hermes still owns the phrasing, but commercial checkpoints remain
+        // authoritative. A premature briefing/payment claim is replaced with
+        // a customer-safe checkpoint instead of becoming an application
+        // failure or exposing an internal rejection.
+        AgentOutput candidate = parser.parse(chat.content());
+        AgentOutput output;
+        try {
+            output = policy.reconcileOutput(candidate, canonical);
+        } catch (IllegalArgumentException rejection) {
+            LOGGER.warn("reception_output_rejected correlationId={} reason={}",
+                    turn.correlationId(), rejection.getClass().getSimpleName());
+            output = safeOutputAfterRejection(canonical);
+        }
         ReceptionTurn currentTurn = turns.findById(turn.id()).orElse(null);
         if (currentTurn != null && (currentTurn.isTerminal()
                 || currentTurn.status() == ReceptionTurnStatus.RECONCILING)) {
             return new TurnReceipt(last.eventId(), currentTurn.correlationId(),
                     turnStatus(currentTurn.status()), currentTurn.output(), currentTurn.failureClass());
         }
-        appendOutbound(canonical, last.eventId() + ":outbound", turn.correlationId(), output.message());
+        String customerMessage = ensureInitialPresentation(canonical, output.message());
+        output = new AgentOutput(customerMessage, output.nextAction());
+        appendOutbound(canonical, last.eventId() + ":outbound", turn.correlationId(), customerMessage);
         ReceptionTurn completed = turn.complete(chat.usage(), clock.instant(), output);
         turns.save(completed);
         metrics.recordTurn(completed, ledger);
         TurnStatus status = canonical.mode() == ReceptionMode.HUMAN
                 ? TurnStatus.BLOCKED_BY_HUMAN : TurnStatus.COMPLETED;
         return new TurnReceipt(last.eventId(), turn.correlationId(), status, output, null);
+    }
+
+    private AgentOutput safeOutputAfterRejection(ReceptionConversation conversation) {
+        return switch (conversation.paymentStatus()) {
+            case PROOF_RECEIVED -> new AgentOutput(SAFE_PAYMENT_CHECKPOINT_MESSAGE,
+                    AgentNextAction.AWAIT_PAYMENT_APPROVAL);
+            case PREPARED -> new AgentOutput(SAFE_PAYMENT_PROOF_MESSAGE,
+                    AgentNextAction.AWAIT_PAYMENT_PROOF);
+            case NOT_STARTED, REJECTED -> new AgentOutput(
+                    conversation.paymentStatus() == PaymentStatus.NOT_STARTED
+                            ? SAFE_PAYMENT_PREPARATION_MESSAGE : SAFE_COMMERCIAL_RECOVERY_MESSAGE,
+                    AgentNextAction.AWAIT_CUSTOMER);
+            case CONFIRMED -> new AgentOutput(SAFE_COMMERCIAL_RECOVERY_MESSAGE,
+                    AgentNextAction.AWAIT_CUSTOMER);
+        };
     }
 
     private HermesSessionsGateway.HermesChatResult chatWithDelayTracking(
@@ -808,17 +1133,45 @@ public final class ReceptionOrchestrator {
         transcript.appendIfAbsent(message);
     }
 
-    private static boolean explicitTermsAcceptance(String text) {
-        if (text == null) return false;
-        String normalized = Normalizer.normalize(text, Normalizer.Form.NFD)
-                .replaceAll("\\p{M}+", "")
-                .toLowerCase(java.util.Locale.ROOT)
-                .trim()
-                .replaceAll("\\s+", " ");
-        if (normalized.matches(".*\\b(nao|nunca|jamais|nem)\\b.*")) {
+    /**
+     * The initial identity is a deterministic customer-facing invariant. Hermes
+     * remains responsible for the rest of the wording, so a compliant response
+     * is preserved exactly and only an omitted identity receives a short prefix.
+     */
+    private String ensureInitialPresentation(ReceptionConversation conversation, String text) {
+        boolean hasOutbound = transcript.findByConversationId(conversation.id()).stream()
+                .anyMatch(message -> message.direction() == ReceptionMessageDirection.OUTBOUND);
+        if (hasOutbound || identifiesUrbaAndUrbana(text)) {
+            return text;
+        }
+        return "Olá! Sou a Urba, assistente virtual da Urbana do Brasil. " + text;
+    }
+
+    private static boolean identifiesUrbaAndUrbana(String text) {
+        if (text == null) {
             return false;
         }
-        return normalized.matches(".*\\b(aceito|aceitar|concordo)\\b.*");
+        String normalized = Normalizer.normalize(text, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "").toLowerCase(java.util.Locale.ROOT);
+        return normalized.matches("(?s).*\\burba\\b.*")
+                && normalized.contains("urbana do brasil");
+    }
+
+    private void ensureHandoffAck(ReceptionConversation conversation, String correlationId, Instant now) {
+        ensureHandoffAck(conversation, correlationId, now, StatefulDomainToolService.HUMAN_HANDOFF_ACK);
+    }
+
+    private void ensureHandoffAck(ReceptionConversation conversation, String correlationId, Instant now,
+                                  String text) {
+        String eventId = StatefulDomainToolService.handoffAckEventId(conversation);
+        if (transcript.findByEventId(eventId).isPresent()) {
+            return;
+        }
+        ReceptionMessage ack = new ReceptionMessage(UUID.randomUUID().toString(), eventId, correlationId,
+                conversation.id(), conversation.contactId(), ReceptionMessageDirection.OUTBOUND,
+                ReceptionMessageSender.URBA, ReceptionMessageType.TEXT,
+                text, null, null, now);
+        transcript.appendIfAbsent(ack);
     }
 
     private TurnReceipt duplicateReceipt(InboundConversationEvent event, ReceptionMessage inbound) {
@@ -847,6 +1200,11 @@ public final class ReceptionOrchestrator {
             Objects.requireNonNull(status, "status");
         }
     }
+
+    public record HumanMessageReceipt(String eventId, String status, boolean duplicate, String message) { }
+
+    public record ResumeReceipt(String resumeId, ResumeStatus status, String ownership,
+                                String message, boolean duplicate, String customerMessage) { }
 
     private static void require(String value, String field) {
         if (value == null || value.isBlank()) throw new IllegalArgumentException(field + " must not be blank");

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionResponsePolicy.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionResponsePolicy.java
@@ -107,8 +107,9 @@ public final class ReceptionResponsePolicy {
         return facts.stream()
                 .filter(Objects::nonNull)
                 .filter(fact -> type.equalsIgnoreCase(fact.type()))
-                .filter(fact -> fact.supersededBy() == null && fact.isCurrentAt(at))
-                .max(Comparator.comparing(CustomerFact::validFrom));
+                .filter(fact -> fact.supersededBy() == null && !fact.validFrom().isAfter(at))
+                .max(Comparator.comparing(CustomerFact::validFrom).thenComparing(CustomerFact::id))
+                .filter(fact -> fact.isReusableAt(at));
     }
 
     /**
@@ -305,6 +306,15 @@ public final class ReceptionResponsePolicy {
                     fromIndex = end;
                 }
             }
+        }
+        if (mentions.isEmpty() && containsTerm(normalizedMessage, "decor")) {
+            commercialPolicy.services().stream()
+                    .filter(service -> "DECOR_INTERIORES".equals(service.serviceType()))
+                    .findFirst()
+                    .ifPresent(service -> {
+                        int start = normalizedMessage.indexOf("decor");
+                        mentions.add(new ServiceMention(service, start, start + "decor".length()));
+                    });
         }
         return mentions.stream()
                 .filter(mention -> mentions.stream().noneMatch(other ->

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationService.java
@@ -1,5 +1,6 @@
 package br.com.urbana.connect.application.reception;
 
+import br.com.urbana.connect.application.reception.tools.StatefulDomainToolService;
 import br.com.urbana.connect.domain.reception.model.AgentOutput;
 import br.com.urbana.connect.domain.reception.model.ReceptionConversation;
 import br.com.urbana.connect.domain.reception.model.ReceptionEventIds;
@@ -9,6 +10,7 @@ import br.com.urbana.connect.domain.reception.model.ReceptionMessageSender;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessageType;
 import br.com.urbana.connect.domain.reception.model.ReceptionTurn;
 import br.com.urbana.connect.domain.reception.model.ReceptionTurnStatus;
+import br.com.urbana.connect.domain.reception.model.ReceptionMode;
 import br.com.urbana.connect.domain.reception.port.out.HermesSessionsGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionConversationGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTranscriptGateway;
@@ -60,6 +62,22 @@ public final class ReceptionTurnReconciliationService {
                         .flatMap(message -> turns.findByInboundMessageId(message.id())).orElse(null));
         if (turn == null || turn.status() != ReceptionTurnStatus.RECONCILING) return Optional.empty();
 
+        ReceptionConversation current = conversations.findByContactId(turn.contactId()).orElse(null);
+        if (current != null && current.mode() == ReceptionMode.HUMAN) {
+            String ackEventId = StatefulDomainToolService.handoffAckEventId(current);
+            if (transcript.findByEventId(ackEventId).isEmpty()) {
+                transcript.appendIfAbsent(new ReceptionMessage(UUID.randomUUID().toString(), ackEventId,
+                        turn.correlationId(), current.id(), turn.contactId(), ReceptionMessageDirection.OUTBOUND,
+                        ReceptionMessageSender.URBA, ReceptionMessageType.TEXT,
+                        StatefulDomainToolService.HUMAN_HANDOFF_ACK, null, null, clock.instant()));
+            }
+            turns.save(turn.blockByHuman(clock.instant()));
+            if (leases != null) {
+                leases.releaseForReconciliation(turn.hermesSessionId(), turn.id());
+            }
+            return Optional.of(StatefulDomainToolService.HUMAN_HANDOFF_ACK);
+        }
+
         Checkpoint checkpoint = Checkpoint.parse(turn.historyCheckpoint()).orElse(null);
         if (checkpoint == null) return Optional.empty();
         HermesSessionsGateway.HermesHistorySnapshot snapshot = hermes.historySnapshot(turn.hermesSessionId());
@@ -80,6 +98,20 @@ public final class ReceptionTurnReconciliationService {
 
         ReceptionConversation conversation = conversations.findByContactId(turn.contactId()).orElse(null);
         if (conversation == null) return Optional.empty();
+        if (conversation.mode() == ReceptionMode.HUMAN) {
+            String ackEventId = StatefulDomainToolService.handoffAckEventId(conversation);
+            if (transcript.findByEventId(ackEventId).isEmpty()) {
+                transcript.appendIfAbsent(new ReceptionMessage(UUID.randomUUID().toString(), ackEventId,
+                        turn.correlationId(), conversation.id(), turn.contactId(), ReceptionMessageDirection.OUTBOUND,
+                        ReceptionMessageSender.URBA, ReceptionMessageType.TEXT,
+                        StatefulDomainToolService.HUMAN_HANDOFF_ACK, null, null, clock.instant()));
+            }
+            turns.save(turn.blockByHuman(clock.instant()));
+            if (leases != null) {
+                leases.releaseForReconciliation(turn.hermesSessionId(), turn.id());
+            }
+            return Optional.of(StatefulDomainToolService.HUMAN_HANDOFF_ACK);
+        }
         String eventId = ReceptionEventIds.outbound(turn.id(), turn.correlationId());
         ReceptionMessage outbound = new ReceptionMessage(UUID.randomUUID().toString(), eventId,
                 turn.correlationId(), conversation.id(), turn.contactId(), ReceptionMessageDirection.OUTBOUND,

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReturningCustomerService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReturningCustomerService.java
@@ -72,7 +72,8 @@ public final class ReturningCustomerService {
 
         Map<String, CustomerFact> latestByType = new LinkedHashMap<>();
         for (CustomerFact fact : queried) {
-            if (fact == null || !contactId.equals(fact.contactId()) || !fact.isConfirmedCurrentAt(at)) {
+            if (fact == null || !contactId.equals(fact.contactId()) || fact.supersededBy() != null
+                    || fact.validFrom().isAfter(at)) {
                 continue;
             }
             CustomerFact previous = latestByType.get(fact.type());
@@ -80,7 +81,9 @@ public final class ReturningCustomerService {
                 latestByType.put(fact.type(), fact);
             }
         }
-        return List.copyOf(latestByType.values());
+        return latestByType.values().stream()
+                .filter(fact -> fact.isReusableAt(at))
+                .toList();
     }
 
     private static final Comparator<CustomerFact> CURRENT_FACT_ORDER = Comparator

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/DomainToolInvocationUseCase.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/DomainToolInvocationUseCase.java
@@ -20,6 +20,7 @@ import java.security.MessageDigest;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
@@ -80,8 +81,10 @@ public class DomainToolInvocationUseCase {
         if (conversations != null) {
             ReceptionConversation conversation = conversations.findByContactId(lease.contactId())
                     .orElseThrow(() -> new IllegalStateException("conversation does not exist"));
-            if (conversation.mode() == ReceptionMode.HUMAN) {
-                throw new IllegalStateException("domain tools are disabled in HUMAN mode");
+            if (conversation.mode() == ReceptionMode.HUMAN
+                    && toolName != DomainToolName.REQUEST_HUMAN_HANDOFF) {
+                throw new DomainRejectionException("HUMAN_OWNS_CONVERSATION", "WAIT_FOR_HUMAN",
+                        List.of(), "A arquiteta continuará este atendimento por aqui.");
             }
         }
         String key = DomainToolInvocation.deriveIdempotencyKey(lease.turnId(), toolName, hash);
@@ -113,11 +116,20 @@ public class DomainToolInvocationUseCase {
             invocations.save(started.finish(DomainToolInvocationStatus.SUCCEEDED, "OK", payloadSnapshot,
                     clock.instant()));
             return new InvocationResult(snapshot(payloadSnapshot), key, false);
+        } catch (DomainRejectionException rejection) {
+            Object failurePayload = snapshot(rejection.toPayload());
+            invocations.save(started.finish(DomainToolInvocationStatus.REJECTED,
+                    rejection.code(), failurePayload, clock.instant()));
+            throw rejection;
         } catch (RuntimeException exception) {
-            Object failurePayload = snapshot(Map.of("error", String.valueOf(exception.getMessage())));
+            Object failurePayload = snapshot(Map.of(
+                    "code", "TEMPORARILY_UNAVAILABLE",
+                    "nextAction", "WAIT_OR_HANDOFF",
+                    "missingFields", List.of(),
+                    "customerMessage", "Não consegui concluir esta etapa agora. Posso tentar novamente ou chamar a arquiteta."));
             invocations.save(started.finish(DomainToolInvocationStatus.FAILED,
-                    exception.getClass().getSimpleName(), failurePayload, clock.instant()));
-            throw exception;
+                    "TECHNICAL_FAILURE", failurePayload, clock.instant()));
+            throw new TechnicalToolFailureException("Não consegui concluir esta etapa agora.", exception);
         }
     }
 
@@ -126,8 +138,9 @@ public class DomainToolInvocationUseCase {
             case SUCCEEDED -> new InvocationResult(snapshot(prior.resultPayload()), key, true);
             case STARTED -> throw new InvocationInProgressException(
                     "tool invocation is already in progress");
-            case FAILED, REJECTED -> throw new DurableToolFailureException(
-                    "tool invocation previously failed", prior.resultCode(), prior.resultPayload());
+            case REJECTED -> throw DomainRejectionException.from(prior.resultCode(), prior.resultPayload());
+            case FAILED -> throw new DurableToolFailureException(
+                    "Não consegui concluir esta etapa agora.", prior.resultCode(), prior.resultPayload());
         };
     }
 
@@ -145,7 +158,61 @@ public class DomainToolInvocationUseCase {
 
     public static class InvocationInProgressException extends IllegalArgumentException {
         public InvocationInProgressException(String message) {
-            super(message);
+            super("Esta etapa ainda está sendo concluída.");
+        }
+    }
+
+    public static final class DomainRejectionException extends IllegalArgumentException {
+        private final String code;
+        private final String nextAction;
+        private final List<String> missingFields;
+        private final String customerMessage;
+
+        public DomainRejectionException(String code, String nextAction,
+                                        List<String> missingFields, String customerMessage) {
+            super(customerMessage);
+            this.code = requireText(code, "BUSINESS_RULE_REJECTED");
+            this.nextAction = requireText(nextAction, "ASK_FOR_CLARIFICATION");
+            this.missingFields = missingFields == null ? List.of() : List.copyOf(missingFields);
+            this.customerMessage = requireText(customerMessage,
+                    "Preciso confirmar uma informação antes de continuar.");
+        }
+
+        public String code() { return code; }
+        public String nextAction() { return nextAction; }
+        public List<String> missingFields() { return missingFields; }
+        public String customerMessage() { return customerMessage; }
+
+        public Map<String, Object> toPayload() {
+            return Map.of("code", code, "nextAction", nextAction,
+                    "missingFields", missingFields, "customerMessage", customerMessage);
+        }
+
+        @SuppressWarnings("unchecked")
+        static DomainRejectionException from(String code, Object payload) {
+            if (payload instanceof Map<?, ?> map) {
+                Object fields = map.get("missingFields");
+                List<String> missing = fields instanceof List<?> list
+                        ? list.stream().map(String::valueOf).toList() : List.of();
+                Object replayCode = map.containsKey("code") ? map.get("code") : code;
+                Object replayAction = map.containsKey("nextAction") ? map.get("nextAction") : "ASK_FOR_CLARIFICATION";
+                Object replayMessage = map.containsKey("customerMessage") ? map.get("customerMessage")
+                        : "Preciso confirmar uma informação antes de continuar.";
+                return new DomainRejectionException(String.valueOf(replayCode),
+                        String.valueOf(replayAction), missing, String.valueOf(replayMessage));
+            }
+            return new DomainRejectionException(code, "ASK_FOR_CLARIFICATION", List.of(),
+                    "Preciso confirmar uma informação antes de continuar.");
+        }
+
+        private static String requireText(String value, String fallback) {
+            return value == null || value.isBlank() ? fallback : value;
+        }
+    }
+
+    public static final class TechnicalToolFailureException extends IllegalStateException {
+        TechnicalToolFailureException(String message, Throwable cause) {
+            super(message, cause);
         }
     }
 

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolService.java
@@ -4,19 +4,32 @@ import br.com.urbana.connect.application.reception.CommercialPolicyService;
 import br.com.urbana.connect.domain.reception.model.CustomerFact;
 import br.com.urbana.connect.domain.reception.model.CustomerFactType;
 import br.com.urbana.connect.domain.reception.model.FactConfidence;
+import br.com.urbana.connect.domain.reception.model.HumanHandoffNotification;
+import br.com.urbana.connect.domain.reception.model.IcpObservationEvent;
+import br.com.urbana.connect.domain.reception.model.PaymentStatus;
 import br.com.urbana.connect.domain.reception.model.ReceptionConversation;
 import br.com.urbana.connect.domain.reception.model.DomainToolName;
+import br.com.urbana.connect.domain.reception.model.ReceptionEventIds;
+import br.com.urbana.connect.domain.reception.model.ReceptionMessage;
+import br.com.urbana.connect.domain.reception.model.ReceptionMessageDirection;
+import br.com.urbana.connect.domain.reception.model.ReceptionMessageSender;
+import br.com.urbana.connect.domain.reception.model.ReceptionMessageType;
 import br.com.urbana.connect.domain.reception.port.out.CustomerFactGateway;
+import br.com.urbana.connect.domain.reception.port.out.HumanHandoffNotificationGateway;
+import br.com.urbana.connect.domain.reception.port.out.IcpObservationEventGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionConversationGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTranscriptGateway;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.text.Normalizer;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * The six allowlisted tools mutate only authoritative Urbana state. Hermes
@@ -24,10 +37,15 @@ import java.util.Objects;
  * access.
  */
 public final class StatefulDomainToolService implements DomainToolService {
+    private static final String NOT_INFORMED = "NÃO INFORMADO";
+    public static final String HUMAN_HANDOFF_ACK =
+            "Vou encaminhar sua conversa para a arquiteta, que continuará com você por aqui.";
     private final CommercialPolicyService policy;
     private final ReceptionConversationGateway conversations;
     private final CustomerFactGateway facts;
     private final ReceptionTranscriptGateway transcript;
+    private IcpObservationEventGateway icpObservations;
+    private HumanHandoffNotificationGateway handoffNotifications;
 
     public StatefulDomainToolService(CommercialPolicyService policy,
                                      ReceptionConversationGateway conversations,
@@ -39,10 +57,39 @@ public final class StatefulDomainToolService implements DomainToolService {
                                      ReceptionConversationGateway conversations,
                                      CustomerFactGateway facts,
                                      ReceptionTranscriptGateway transcript) {
+        this(policy, conversations, facts, transcript, null, null);
+    }
+
+    public StatefulDomainToolService(CommercialPolicyService policy,
+                                     ReceptionConversationGateway conversations,
+                                     CustomerFactGateway facts,
+                                     ReceptionTranscriptGateway transcript,
+                                     IcpObservationEventGateway icpObservations) {
+        this(policy, conversations, facts, transcript, icpObservations, null);
+    }
+
+    public StatefulDomainToolService(CommercialPolicyService policy,
+                                     ReceptionConversationGateway conversations,
+                                     CustomerFactGateway facts,
+                                     ReceptionTranscriptGateway transcript,
+                                     IcpObservationEventGateway icpObservations,
+                                     HumanHandoffNotificationGateway handoffNotifications) {
         this.policy = Objects.requireNonNull(policy, "policy");
         this.conversations = Objects.requireNonNull(conversations, "conversations");
         this.facts = Objects.requireNonNull(facts, "facts");
         this.transcript = transcript;
+        this.icpObservations = icpObservations;
+        this.handoffNotifications = handoffNotifications;
+    }
+
+    @Autowired(required = false)
+    void setIcpObservationEventGateway(IcpObservationEventGateway icpObservations) {
+        this.icpObservations = icpObservations;
+    }
+
+    @Autowired(required = false)
+    void setHumanHandoffNotificationGateway(HumanHandoffNotificationGateway handoffNotifications) {
+        this.handoffNotifications = handoffNotifications;
     }
 
     @Override
@@ -60,18 +107,112 @@ public final class StatefulDomainToolService implements DomainToolService {
         // automatable. Handoff is authoritative and disables all late tool
         // calls, including calls arriving while a stale lease remains alive.
         ReceptionConversation currentConversation = conversation(contactId);
-        if (currentConversation.mode() == br.com.urbana.connect.domain.reception.model.ReceptionMode.HUMAN) {
-            throw new IllegalStateException("domain tools are disabled in HUMAN mode");
+        if (currentConversation.mode() == br.com.urbana.connect.domain.reception.model.ReceptionMode.HUMAN
+                && toolName != DomainToolName.REQUEST_HUMAN_HANDOFF) {
+            throw new DomainToolInvocationUseCase.DomainRejectionException(
+                    "HUMAN_OWNS_CONVERSATION", "WAIT_FOR_HUMAN", List.of(),
+                    "A arquiteta continuará este atendimento por aqui.");
         }
         Map<String, Object> args = arguments == null ? Map.of() : arguments;
+        try {
+            return switch (toolName) {
+                case GET_CUSTOMER_PROFILE -> profile(contactId, context.now());
+                case UPDATE_CUSTOMER_FACT -> updateFact(contactId, args, context);
+                case LIST_AVAILABLE_SERVICES -> listServices();
+                case PREPARE_TERMS -> prepareTerms(contactId, args, context);
+                case PREPARE_PAYMENT -> preparePayment(contactId, args, context);
+                case REQUEST_HUMAN_HANDOFF -> handoff(contactId, args, context);
+            };
+        } catch (DomainToolInvocationUseCase.DomainRejectionException rejection) {
+            throw rejection;
+        } catch (IllegalArgumentException | IllegalStateException rejection) {
+            throw safeRejection(toolName, args, currentConversation, rejection);
+        }
+    }
+
+    private static DomainToolInvocationUseCase.DomainRejectionException safeRejection(
+            DomainToolName toolName, Map<String, Object> args, ReceptionConversation conversation,
+            RuntimeException rejection) {
         return switch (toolName) {
-            case GET_CUSTOMER_PROFILE -> profile(contactId, context.now());
-            case UPDATE_CUSTOMER_FACT -> updateFact(contactId, args, context);
-            case LIST_AVAILABLE_SERVICES -> listServices();
-            case PREPARE_TERMS -> prepareTerms(contactId, args, context.now());
-            case PREPARE_PAYMENT -> preparePayment(contactId, args, context);
-            case REQUEST_HUMAN_HANDOFF -> handoff(contactId, args, context.now());
+            case PREPARE_PAYMENT -> {
+                if (isMissingPaymentMethod(args) || isPaymentMethodRejection(rejection)) {
+                    yield paymentMethodRejection(isMissingPaymentMethod(args) ? List.of("method") : List.of());
+                }
+                if (isServiceSelectionRejection(rejection)) {
+                    yield serviceSelectionRejection();
+                }
+                if (conversation.termsStatus() != br.com.urbana.connect.domain.reception.model.TermsStatus.ACCEPTED
+                        && isTermsRejection(rejection)) {
+                    yield termsRejection();
+                }
+                yield new DomainToolInvocationUseCase.DomainRejectionException(
+                        "BUSINESS_RULE_REJECTED", "ASK_FOR_CLARIFICATION", List.of(),
+                        "Preciso confirmar uma informação antes de continuar.");
+            }
+            case PREPARE_TERMS -> new DomainToolInvocationUseCase.DomainRejectionException(
+                    "SERVICE_NOT_CONFIRMED", "CONFIRM_SERVICE", List.of("serviceType"),
+                    "Preciso confirmar o serviço escolhido antes de apresentar os termos.");
+            case UPDATE_CUSTOMER_FACT -> new DomainToolInvocationUseCase.DomainRejectionException(
+                    "CUSTOMER_INFORMATION_INVALID", "ASK_FOR_CLARIFICATION", List.of(),
+                    "Preciso confirmar essa informação antes de continuar.");
+            case REQUEST_HUMAN_HANDOFF -> new DomainToolInvocationUseCase.DomainRejectionException(
+                    "HANDOFF_REASON_REQUIRED", "ASK_FOR_HANDOFF_REASON", List.of("reason"),
+                    "Posso chamar a arquiteta assim que você confirmar que deseja o atendimento humano.");
+            default -> new DomainToolInvocationUseCase.DomainRejectionException(
+                    "BUSINESS_RULE_REJECTED", "ASK_FOR_CLARIFICATION", List.of(),
+                    "Preciso confirmar uma informação antes de continuar.");
         };
+    }
+
+    private static DomainToolInvocationUseCase.DomainRejectionException paymentMethodRejection(
+            List<String> missingFields) {
+        return new DomainToolInvocationUseCase.DomainRejectionException(
+                "PAYMENT_METHOD_INVALID", "ASK_FOR_PAYMENT_METHOD", missingFields,
+                "Para continuar, você prefere realizar o pagamento via PIX ou cartão de crédito?");
+    }
+
+    private static DomainToolInvocationUseCase.DomainRejectionException termsRejection() {
+        return new DomainToolInvocationUseCase.DomainRejectionException(
+                "TERMS_NOT_ACCEPTED", "ASK_FOR_CLEAR_ACCEPTANCE", List.of(),
+                "Antes do pagamento, preciso do seu aceite claro dos termos.");
+    }
+
+    private static DomainToolInvocationUseCase.DomainRejectionException serviceSelectionRejection() {
+        return new DomainToolInvocationUseCase.DomainRejectionException(
+                "SERVICE_NOT_CONFIRMED", "CONFIRM_SERVICE", List.of("serviceType"),
+                "Preciso confirmar o serviço escolhido antes de continuar.");
+    }
+
+    private static boolean isMissingPaymentMethod(Map<String, Object> args) {
+        Object method = args.get("method");
+        return method == null || method.toString().isBlank();
+    }
+
+    private static boolean isPaymentMethodRejection(RuntimeException rejection) {
+        String message = rejection.getMessage();
+        return message != null && message.toLowerCase(Locale.ROOT).contains("payment method");
+    }
+
+    private static boolean isServiceSelectionRejection(RuntimeException rejection) {
+        String message = rejection.getMessage();
+        if (message == null) {
+            return false;
+        }
+        String normalized = message.toLowerCase(Locale.ROOT);
+        return normalized.contains("service does not match")
+                || normalized.contains("service is not present")
+                || normalized.contains("service must be selected")
+                || normalized.contains("catalog item")
+                || normalized.contains("servicetype");
+    }
+
+    private static boolean isTermsRejection(RuntimeException rejection) {
+        String message = rejection.getMessage();
+        if (message == null) {
+            return false;
+        }
+        String normalized = message.toLowerCase(Locale.ROOT);
+        return normalized.contains("terms") || normalized.contains("acceptance");
     }
 
     private Map<String, Object> profile(String contactId, Instant now) {
@@ -92,16 +233,20 @@ public final class StatefulDomainToolService implements DomainToolService {
         FactConfidence confidence = requestedConfidence;
         Instant now = context.now();
         String sourceText = sourceText(context);
-        if (requestedConfidence == FactConfidence.CONFIRMED && !explicitlySupports(type, value, sourceText)) {
+        if (isNotInformedValue(value)) {
+            confidence = FactConfidence.CONFIRMED;
+        } else if (requestedConfidence == FactConfidence.CONFIRMED
+                && !explicitlySupports(type, value, sourceText)) {
             // A model cannot turn an unsupported claim into a confirmed fact.
             // Preserve the observation as tentative for a later confirmation.
             confidence = FactConfidence.TENTATIVE;
         }
         List<CustomerFact> current = facts.findCurrentByContactId(contactId, now);
+        CustomerFact newFact = new CustomerFact(contactId, type, value, confidence,
+                context.sourceMessageId(), now);
         current.stream().filter(f -> type.equalsIgnoreCase(f.type()) && f.supersededBy() == null)
-                .forEach(previous -> facts.save(previous.supersede(java.util.UUID.randomUUID().toString(), now)));
-        CustomerFact saved = facts.save(new CustomerFact(contactId, type, value, confidence,
-                context.sourceMessageId(), now));
+                .forEach(previous -> facts.save(previous.supersede(newFact.id(), now)));
+        CustomerFact saved = facts.save(newFact);
         if ("SELECTED_SERVICE".equals(type)) {
             ReceptionConversation conversation = conversation(contactId);
             conversations.save(policy.selectService(conversation, value, now));
@@ -111,18 +256,44 @@ public final class StatefulDomainToolService implements DomainToolService {
     }
 
     private Map<String, Object> listServices() {
-        return Map.of("services", policy.services().stream().map(service -> Map.of(
-                "serviceType", service.serviceType(), "name", service.name(), "description", service.description(),
-                "price", service.price().toPlainString())).toList());
+        List<Map<String, Object>> values = policy.services().stream().map(service -> {
+            Map<String, Object> value = new LinkedHashMap<>();
+            value.put("serviceType", service.serviceType());
+            value.put("name", service.name());
+            value.put("description", service.description());
+            value.put("price", service.price().toPlainString());
+            value.put("scope", service.scope());
+            value.put("areaRule", service.areaRule().description());
+            value.put("deliverables", service.deliverables());
+            value.put("process", service.process());
+            value.put("responsibilities", service.responsibilities());
+            value.put("exclusions", service.exclusions());
+            value.put("support", service.support());
+            value.put("resources", Map.of("terms", service.termsUrl(), "payment", service.paymentUrl(),
+                    "briefing", service.briefingUrl()));
+            return value;
+        }).toList();
+        return Map.of("services", values);
     }
 
-    private Map<String, Object> prepareTerms(String contactId, Map<String, Object> args, Instant now) {
+    private Map<String, Object> prepareTerms(String contactId, Map<String, Object> args,
+                                              ToolExecutionContext context) {
+        Instant now = context.now();
         ReceptionConversation conversation = conversation(contactId);
         String requested = stringArg(args, "serviceType");
+        String canonicalRequested = policy.service(requested).serviceType();
         if (conversation.selectedService() == null) {
-            conversation = conversations.save(policy.selectService(conversation, requested, now));
-        } else if (!conversation.selectedService().equalsIgnoreCase(requested)) {
+            conversation = conversations.save(policy.selectService(conversation, canonicalRequested, now));
+        } else if (!conversation.selectedService().equalsIgnoreCase(canonicalRequested)) {
             throw new IllegalStateException("service does not match the selected catalog item");
+        }
+        List<CustomerFact> currentFacts = facts.findCurrentByContactId(contactId, now);
+        boolean firstTermsPresentation = conversation.termsStatus()
+                == br.com.urbana.connect.domain.reception.model.TermsStatus.NOT_PRESENTED
+                || conversation.termsStatus()
+                == br.com.urbana.connect.domain.reception.model.TermsStatus.DECLINED;
+        if (firstTermsPresentation) {
+            recordIcpSkippedBeforeTerms(conversation, currentFacts, context);
         }
         ReceptionConversation presented = policy.presentTerms(conversation, facts.findByContactId(contactId), now);
         conversations.save(presented);
@@ -135,28 +306,123 @@ public final class StatefulDomainToolService implements DomainToolService {
         Instant now = context.now();
         ReceptionConversation conversation = conversation(contactId);
         String serviceType = stringArg(args, "serviceType");
-        if (conversation.selectedService() == null || !conversation.selectedService().equalsIgnoreCase(serviceType)) {
+        String canonicalServiceType = policy.service(serviceType).serviceType();
+        if (conversation.selectedService() == null
+                || !conversation.selectedService().equalsIgnoreCase(canonicalServiceType)) {
             throw new IllegalStateException("service does not match the selected catalog item");
         }
         if (conversation.termsStatus() == br.com.urbana.connect.domain.reception.model.TermsStatus.PRESENTED) {
             String source = sourceText(context);
-            if (!acceptsTerms(source)) {
+            if (!policy.isExplicitTermsAcceptance(source)) {
                 throw new IllegalStateException("payment requires explicit terms acceptance in the bound inbound message");
             }
             conversation = conversations.save(policy.acceptTerms(conversation, now));
         }
         ReceptionConversation prepared = policy.preparePayment(conversation, facts.findByContactId(contactId),
                 stringArg(args, "method"), now);
-        conversations.save(prepared);
-        return Map.of("status", "PREPARED", "serviceType", prepared.selectedService(),
-                "instruction", policy.paymentUrl(prepared.selectedService()));
+        if (prepared != conversation) {
+            conversations.save(prepared);
+        }
+        return paymentPreparationResult(prepared, conversation.paymentStatus());
     }
 
-    private Map<String, Object> handoff(String contactId, Map<String, Object> args, Instant now) {
+    private Map<String, Object> paymentPreparationResult(ReceptionConversation conversation,
+                                                         PaymentStatus previousStatus) {
+        if (previousStatus == PaymentStatus.NOT_STARTED || previousStatus == PaymentStatus.REJECTED) {
+            return Map.of("status", "PREPARED", "serviceType", conversation.selectedService(),
+                    "instruction", policy.paymentUrl(conversation.selectedService()),
+                    "nextAction", "AWAIT_PAYMENT_PROOF",
+                    "customerMessage", "Pagamento preparado. Realize o pagamento pelo link e envie o comprovante por aqui.");
+        }
+        return switch (conversation.paymentStatus()) {
+            case PREPARED -> Map.of("status", "ALREADY_PREPARED", "serviceType", conversation.selectedService(),
+                    "nextAction", "AWAIT_PAYMENT_PROOF",
+                    "customerMessage", "O pagamento já foi preparado. Aguardo o comprovante por aqui.");
+            case PROOF_RECEIVED -> Map.of("status", "PROOF_RECEIVED", "serviceType", conversation.selectedService(),
+                    "nextAction", "AWAIT_PAYMENT_APPROVAL",
+                    "customerMessage", "O comprovante já foi recebido e aguarda validação humana.");
+            case CONFIRMED -> Map.of("status", "CONFIRMED", "serviceType", conversation.selectedService(),
+                    "nextAction", "NONE",
+                    "customerMessage", "O pagamento já foi confirmado pela arquiteta.");
+            case NOT_STARTED, REJECTED -> Map.of("status", conversation.paymentStatus().name(),
+                    "serviceType", conversation.selectedService(), "nextAction", "NONE",
+                    "customerMessage", "Preciso confirmar essa etapa antes de continuar.");
+        };
+    }
+
+    private Map<String, Object> handoff(String contactId, Map<String, Object> args,
+                                        ToolExecutionContext context) {
         ReceptionConversation conversation = conversation(contactId);
-        ReceptionConversation human = conversation.requestHumanHandoff(stringArg(args, "reason"), now);
-        conversations.save(human);
-        return Map.of("status", "HUMAN_MODE", "reason", human.handoffReason());
+        ReceptionConversation human = conversation.requestHumanHandoff(stringArg(args, "reason"), context.now());
+        if (human != conversation) {
+            human = conversations.save(human);
+            persistHandoffNotification(human, context.lease().turnId(), context.now());
+        }
+        persistHandoffAck(human, context.lease().turnId(), context.now());
+        return Map.of("status", "TRANSFERRED", "ownership", "HUMAN",
+                "ackMessage", HUMAN_HANDOFF_ACK, "handoffId", handoffId(human));
+    }
+
+    private void recordIcpSkippedBeforeTerms(ReceptionConversation conversation,
+                                             List<CustomerFact> currentFacts,
+                                             ToolExecutionContext context) {
+        if (icpObservations == null) {
+            return;
+        }
+        List<String> missing = policy.missingIcpFields(currentFacts, context.now());
+        if (missing.isEmpty()) {
+            return;
+        }
+        String idempotencyKey = "icp-before-terms:" + conversation.id() + ":"
+                + context.lease().turnId() + ":" + conversation.selectedService();
+        IcpObservationEvent event = IcpObservationEvent.beforeTerms(conversation.id(),
+                context.lease().turnId(), conversation.selectedService(), missing, idempotencyKey,
+                context.now());
+        try {
+            icpObservations.appendIfAbsent(event);
+        } catch (RuntimeException ignored) {
+            // Observability must not turn a valid commercial continuation into
+            // a customer-visible failure. The durable tool ledger still records
+            // the successful terms transition.
+        }
+    }
+
+    private void persistHandoffNotification(ReceptionConversation human, String turnId, Instant now) {
+        if (handoffNotifications == null) {
+            return;
+        }
+        List<CustomerFact> currentFacts = facts.findCurrentByContactId(human.contactId(), now);
+        List<String> missing = policy.missingIcpFields(currentFacts, now);
+        List<String> present = policy.mandatoryIcpFields().stream()
+                .filter(field -> !missing.contains(field)).toList();
+        HumanHandoffNotification notification = HumanHandoffNotification.create(
+                handoffId(human), human.id(), turnId, human.handoffReason(), human.selectedService(),
+                human.commercialStage().name(), human.paymentStatus().name(), present, missing, now);
+        try {
+            handoffNotifications.notifyIfAbsent(notification);
+        } catch (RuntimeException ignored) {
+            // The visible acknowledgement and HUMAN ownership remain safe even
+            // when an optional notification sink is unavailable.
+        }
+    }
+
+    private void persistHandoffAck(ReceptionConversation human, String correlationId, Instant now) {
+        if (transcript == null) {
+            return;
+        }
+        transcript.appendIfAbsent(new ReceptionMessage(UUID.randomUUID().toString(), handoffAckEventId(human),
+                correlationId, human.id(), human.contactId(), ReceptionMessageDirection.OUTBOUND,
+                ReceptionMessageSender.URBA, ReceptionMessageType.TEXT, HUMAN_HANDOFF_ACK,
+                null, null, now));
+    }
+
+    public static String handoffId(ReceptionConversation human) {
+        String material = human.id() + ":" + human.version();
+        return UUID.nameUUIDFromBytes(material.getBytes(StandardCharsets.UTF_8)).toString();
+    }
+
+    public static String handoffAckEventId(ReceptionConversation human) {
+        return ReceptionEventIds.outbound("human-handoff:" + handoffId(human), human.id());
     }
 
     private ReceptionConversation conversation(String contactId) {
@@ -178,29 +444,41 @@ public final class StatefulDomainToolService implements DomainToolService {
     }
 
     private static boolean explicitlySupports(String type, String value, String source) {
+        if (isNotInformedValue(value)) {
+            return true;
+        }
         if (source == null || source.isBlank()) return false;
         String normalizedSource = normalizeEvidence(source);
         String normalizedValue = normalizeEvidence(value.replace('_', ' '));
-        if ("PRONOUN_PREFERENCE".equals(type) && normalizedValue.contains("prefer not to answer")) {
-            return normalizedSource.contains("prefiro nao responder")
-                    || normalizedSource.contains("prefiro nao informar");
-        }
-        if ("FIRST_TIME_HIRING".equals(type) && !"YES".equalsIgnoreCase(value)) {
-            return containsNegation(normalizedSource);
+        if ("FIRST_TIME_HIRING".equals(type)) {
+            if ("SIM".equals(value)) {
+                return !containsNegation(normalizedSource)
+                        && (normalizedSource.contains("primeira vez")
+                        || normalizedSource.matches(".*\\b(sim|yes|true)\\b.*"));
+            }
+            if ("NÃO".equals(value)) {
+                return containsNegation(normalizedSource)
+                        || normalizedSource.matches(".*\\b(no|false)\\b.*");
+            }
+            return false;
         }
         if ("SELECTED_SERVICE".equals(type)) {
             // A correction may negate the previous service in the same
             // sentence while positively naming the replacement service.
-            return normalizedSource.contains(normalizedValue);
+            if (normalizedSource.contains(normalizedValue)) {
+                return true;
+            }
+            // DECOR is retained only as an input alias for Decor Interiores.
+            // The persisted value is canonical, so evidence such as
+            // "Quero contratar Decor" must still support the canonical fact.
+            return "DECOR_INTERIORES".equals(value)
+                    && normalizedSource.matches(".*\\bdecor\\b.*");
         }
         if (containsNegation(normalizedSource)) {
             return false;
         }
         return switch (type) {
-            case "PRONOUN_PREFERENCE" -> normalizedSource.contains(normalizedValue.split(" ")[0]);
-            case "FIRST_TIME_HIRING" -> "YES".equalsIgnoreCase(value)
-                    && (normalizedSource.contains("primeira vez")
-                    || normalizedSource.matches(".*\\b(sim|yes)\\b.*"));
+            case "PRONOUN_PREFERENCE" -> normalizedSource.contains(normalizedValue);
             case "OCCUPATION", "NEED" -> normalizedSource.contains(normalizedValue);
             case "SELECTED_SERVICE" -> normalizedSource.contains(normalizedValue);
             default -> false;
@@ -219,42 +497,51 @@ public final class StatefulDomainToolService implements DomainToolService {
 
     private String canonicalFactValue(String type, String value) {
         return switch (type) {
-            case "PRONOUN_PREFERENCE" -> canonicalPronoun(value);
+            case "PRONOUN_PREFERENCE", "OCCUPATION" -> canonicalFreeText(value);
             case "FIRST_TIME_HIRING" -> canonicalFirstTimeHiring(value);
-            case "OCCUPATION" -> normalizeToken(value);
             case "SELECTED_SERVICE" -> canonicalService(value);
             case "NEED" -> value.trim();
             default -> value.trim();
         };
     }
 
-    private static String canonicalPronoun(String value) {
-        return switch (normalizeToken(value)) {
-            case "ELA", "ELA_DELA" -> "ELA_DELA";
-            case "ELE", "ELE_DELE" -> "ELE_DELE";
-            case "PREFIRO_NAO_RESPONDER", "PREFIRO_NAO_INFORMAR", "PREFER_NOT_TO_ANSWER" ->
-                    CommercialPolicyService.PREFER_NOT_TO_ANSWER;
-            default -> throw new IllegalArgumentException("pronoun preference is not supported: " + value);
-        };
+    private static String canonicalFreeText(String value) {
+        String trimmed = value.trim();
+        return isNotInformedValue(trimmed) ? NOT_INFORMED : trimmed;
     }
 
     private static String canonicalFirstTimeHiring(String value) {
         String normalized = normalizeToken(value);
+        if (isNotInformedValue(value)) {
+            return NOT_INFORMED;
+        }
         if (normalized.contains("NAO") || normalized.contains("NUNCA") || normalized.contains("JAMAIS")) {
-            return "NO";
+            return "NÃO";
         }
         if (normalized.contains("PRIMEIRA_VEZ")) {
-            return "YES";
+            return "SIM";
         }
         return switch (normalized) {
-            case "YES", "SIM", "TRUE", "1" -> "YES";
-            case "NO", "FALSE", "0" -> "NO";
+            case "YES", "SIM", "TRUE", "1" -> "SIM";
+            case "NO", "NAO", "NÃO", "FALSE", "0" -> "NÃO";
             default -> throw new IllegalArgumentException("first-time hiring value is not supported: " + value);
+        };
+    }
+
+    private static boolean isNotInformedValue(String value) {
+        return switch (normalizeToken(value)) {
+            case "NAO_INFORMADO", "PREFIRO_NAO_RESPONDER", "PREFIRO_NAO_INFORMAR",
+                    "PREFER_NOT_TO_ANSWER", "NAO_QUERO_INFORMAR", "NAO_QUERO_RESPONDER",
+                    "SEM_INFORMACAO" -> true;
+            default -> false;
         };
     }
 
     private String canonicalService(String value) {
         String normalized = normalizeToken(value);
+        if ("DECOR".equals(normalized)) {
+            return "DECOR_INTERIORES";
+        }
         return policy.services().stream()
                 .filter(service -> normalizeToken(service.serviceType()).equals(normalized)
                         || normalizeToken(service.name()).equals(normalized))
@@ -271,13 +558,6 @@ public final class StatefulDomainToolService implements DomainToolService {
                 .replaceAll("[^A-Z0-9]+", " ")
                 .trim()
                 .replaceAll("\\s+", "_");
-    }
-
-    private static boolean acceptsTerms(String text) {
-        if (text == null) return false;
-        String normalized = normalizeEvidence(text);
-        return !containsNegation(normalized)
-                && normalized.matches(".*\\b(aceito|aceitar|concordo)\\b.*");
     }
 
     private static String stringArg(Map<String, Object> args, String key) {

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/CustomerFact.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/CustomerFact.java
@@ -1,6 +1,7 @@
 package br.com.urbana.connect.domain.reception.model;
 
 import java.time.Instant;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -19,7 +20,7 @@ public record CustomerFact(
     public CustomerFact {
         id = require(id, "id");
         contactId = require(contactId, "contactId");
-        type = require(type, "type").toUpperCase();
+        type = require(type, "type").toUpperCase(Locale.ROOT);
         value = require(value, "value");
         confidence = Objects.requireNonNull(confidence, "confidence");
         sourceMessageId = require(sourceMessageId, "sourceMessageId");
@@ -46,11 +47,26 @@ public record CustomerFact(
     }
 
     public boolean isCurrentAt(Instant instant) {
+        if (instant == null) {
+            return false;
+        }
         return !validFrom.isAfter(instant) && (validUntil == null || instant.isBefore(validUntil));
     }
 
     public boolean isConfirmedCurrentAt(Instant instant) {
-        return confidence == FactConfidence.CONFIRMED && supersededBy == null && isCurrentAt(instant);
+        return isReusableAt(instant);
+    }
+
+    /**
+     * A fact is reusable only when it is an explicit, confirmed version that is
+     * still valid and has not been superseded. Refusals such as
+     * {@code PREFER_NOT_TO_ANSWER} remain valid non-blank values.
+     */
+    public boolean isReusableAt(Instant instant) {
+        return confidence == FactConfidence.CONFIRMED
+                && supersededBy == null
+                && isCurrentAt(instant)
+                && !value.isBlank();
     }
 
     public CustomerFact supersede(String replacementId, Instant until) {

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/CustomerFactType.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/CustomerFactType.java
@@ -1,6 +1,7 @@
 package br.com.urbana.connect.domain.reception.model;
 
 import java.util.Arrays;
+import java.util.List;
 
 public enum CustomerFactType {
     PRONOUN_PREFERENCE,
@@ -9,7 +10,22 @@ public enum CustomerFactType {
     NEED,
     SELECTED_SERVICE;
 
+    private static final List<String> ICP_FIELD_NAMES = List.of(
+            PRONOUN_PREFERENCE.name(), FIRST_TIME_HIRING.name(), OCCUPATION.name());
+
     public static boolean isAllowed(String value) {
         return value != null && Arrays.stream(values()).anyMatch(v -> v.name().equalsIgnoreCase(value));
+    }
+
+    public boolean isIcpField() {
+        return this == PRONOUN_PREFERENCE || this == FIRST_TIME_HIRING || this == OCCUPATION;
+    }
+
+    public static List<String> icpFieldNames() {
+        return ICP_FIELD_NAMES;
+    }
+
+    public static boolean isIcpField(String value) {
+        return value != null && ICP_FIELD_NAMES.stream().anyMatch(name -> name.equalsIgnoreCase(value));
     }
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/HumanHandoffNotification.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/HumanHandoffNotification.java
@@ -1,0 +1,64 @@
+package br.com.urbana.connect.domain.reception.model;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/** Internal handoff notification payload; never serialized to the customer. */
+public record HumanHandoffNotification(
+        String notificationId,
+        String idempotencyKey,
+        String conversationId,
+        String turnId,
+        String reason,
+        String serviceType,
+        String commercialStage,
+        String paymentStatus,
+        List<String> presentIcpFields,
+        List<String> missingIcpFields,
+        Instant occurredAt) {
+
+    public HumanHandoffNotification {
+        notificationId = required(notificationId, "notificationId");
+        idempotencyKey = required(idempotencyKey, "idempotencyKey");
+        conversationId = required(conversationId, "conversationId");
+        turnId = required(turnId, "turnId");
+        reason = required(reason, "reason");
+        serviceType = optional(serviceType);
+        commercialStage = optional(commercialStage);
+        paymentStatus = optional(paymentStatus);
+        presentIcpFields = copy(presentIcpFields);
+        missingIcpFields = copy(missingIcpFields);
+        occurredAt = Objects.requireNonNull(occurredAt, "occurredAt");
+    }
+
+    public static HumanHandoffNotification create(String idempotencyKey, String conversationId,
+                                                  String turnId, String reason, String serviceType,
+                                                  String commercialStage, String paymentStatus,
+                                                  List<String> presentIcpFields,
+                                                  List<String> missingIcpFields, Instant occurredAt) {
+        String notificationId = "urn:urbana:reception:handoff:"
+                + UUID.nameUUIDFromBytes(idempotencyKey.getBytes(StandardCharsets.UTF_8));
+        return new HumanHandoffNotification(notificationId, idempotencyKey, conversationId, turnId,
+                reason, serviceType, commercialStage, paymentStatus, presentIcpFields,
+                missingIcpFields, occurredAt);
+    }
+
+    private static List<String> copy(List<String> values) {
+        return values == null ? List.of() : values.stream().filter(value -> value != null && !value.isBlank())
+                .distinct().toList();
+    }
+
+    private static String optional(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private static String required(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/IcpObservationEvent.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/IcpObservationEvent.java
@@ -1,0 +1,70 @@
+package br.com.urbana.connect.domain.reception.model;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Internal-only observability for a commercial continuation that intentionally
+ * proceeded without every conversational qualification field.
+ *
+ * <p>The shape deliberately has no customer-provided value, transcript text,
+ * or fact payload. It is not a transcript message and must never be returned
+ * by a domain tool.</p>
+ */
+public record IcpObservationEvent(
+        String eventId,
+        String eventType,
+        String conversationId,
+        String turnId,
+        String serviceType,
+        List<String> missingFields,
+        String detectionPoint,
+        String idempotencyKey,
+        Instant occurredAt) {
+
+    public static final String TYPE = "ICP_SKIPPED_BEFORE_TERMS";
+    public static final String DETECTION_POINT = "PREPARE_TERMS";
+
+    public IcpObservationEvent {
+        eventId = required(eventId, "eventId");
+        eventType = required(eventType, "eventType");
+        if (!TYPE.equals(eventType)) {
+            throw new IllegalArgumentException("unsupported ICP observation event type");
+        }
+        conversationId = required(conversationId, "conversationId");
+        turnId = required(turnId, "turnId");
+        serviceType = required(serviceType, "serviceType");
+        missingFields = missingFields == null ? List.of() : missingFields.stream()
+                .map(field -> required(field, "missingField"))
+                .distinct()
+                .toList();
+        if (missingFields.isEmpty()) {
+            throw new IllegalArgumentException("missingFields must not be empty");
+        }
+        detectionPoint = required(detectionPoint, "detectionPoint");
+        if (!DETECTION_POINT.equals(detectionPoint)) {
+            throw new IllegalArgumentException("unsupported ICP observation detection point");
+        }
+        idempotencyKey = required(idempotencyKey, "idempotencyKey");
+        occurredAt = Objects.requireNonNull(occurredAt, "occurredAt");
+    }
+
+    public static IcpObservationEvent beforeTerms(String conversationId, String turnId,
+                                                  String serviceType, List<String> missingFields,
+                                                  String idempotencyKey, Instant occurredAt) {
+        String eventId = "urn:urbana:reception:icp:"
+                + UUID.nameUUIDFromBytes(idempotencyKey.getBytes(StandardCharsets.UTF_8));
+        return new IcpObservationEvent(eventId, TYPE, conversationId, turnId, serviceType,
+                missingFields, DETECTION_POINT, idempotencyKey, occurredAt);
+    }
+
+    private static String required(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/ReceptionConversation.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/ReceptionConversation.java
@@ -16,7 +16,25 @@ public record ReceptionConversation(
         String handoffReason,
         Instant createdAt,
         Instant updatedAt,
-        long version) {
+        long version,
+        ResumeStatus resumeStatus,
+        String resumeId,
+        String resumeIdempotencyKey,
+        String resumeChecksum,
+        int resumeBoundarySequence,
+        String resumeDecisionAction,
+        String resumeDecisionMessage,
+        String resumeFailureCode) {
+
+    public ReceptionConversation(String id, String contactId, ReceptionMode mode,
+                                 CommercialStage commercialStage, String selectedService,
+                                 TermsStatus termsStatus, PaymentStatus paymentStatus,
+                                 String handoffReason, Instant createdAt, Instant updatedAt,
+                                 long version) {
+        this(id, contactId, mode, commercialStage, selectedService, termsStatus, paymentStatus,
+                handoffReason, createdAt, updatedAt, version, ResumeStatus.NONE, null, null,
+                null, 0, null, null, null);
+    }
 
     public ReceptionConversation {
         id = require(id, "id");
@@ -25,6 +43,7 @@ public record ReceptionConversation(
         commercialStage = Objects.requireNonNull(commercialStage, "commercialStage");
         termsStatus = Objects.requireNonNull(termsStatus, "termsStatus");
         paymentStatus = Objects.requireNonNull(paymentStatus, "paymentStatus");
+        resumeStatus = resumeStatus == null ? ResumeStatus.NONE : resumeStatus;
         createdAt = Objects.requireNonNull(createdAt, "createdAt");
         updatedAt = Objects.requireNonNull(updatedAt, "updatedAt");
         if (version < 0) {
@@ -35,6 +54,9 @@ public record ReceptionConversation(
         }
         if (paymentStatus != PaymentStatus.NOT_STARTED && selectedService == null) {
             throw new IllegalArgumentException("payment state requires a selected service");
+        }
+        if (resumeBoundarySequence < 0) {
+            throw new IllegalArgumentException("resume boundary must be non-negative");
         }
     }
 
@@ -51,8 +73,8 @@ public record ReceptionConversation(
         return mode == ReceptionMode.HUMAN;
     }
 
-    public boolean canPreparePayment(boolean icpComplete) {
-        return mode == ReceptionMode.AI && icpComplete && selectedService != null
+    public boolean canPreparePayment(boolean ignoredIcpComplete) {
+        return mode == ReceptionMode.AI && selectedService != null
                 && termsStatus == TermsStatus.ACCEPTED;
     }
 
@@ -89,10 +111,10 @@ public record ReceptionConversation(
                 paymentStatus, handoffReason, now);
     }
 
-    public ReceptionConversation preparePayment(boolean icpComplete, String method, Instant now) {
+    public ReceptionConversation preparePayment(boolean ignoredIcpComplete, String method, Instant now) {
         require(method, "method");
-        if (!canPreparePayment(icpComplete)) {
-            throw new IllegalStateException("payment requires complete ICP, service and accepted terms");
+        if (!canPreparePayment(ignoredIcpComplete)) {
+            throw new IllegalStateException("payment requires service and accepted terms");
         }
         return copy(mode, CommercialStage.PAYMENT, selectedService, termsStatus,
                 PaymentStatus.PREPARED, handoffReason, now);
@@ -128,14 +150,79 @@ public record ReceptionConversation(
             return this;
         }
         return copy(ReceptionMode.HUMAN, commercialStage, selectedService, termsStatus,
-                paymentStatus, reason, now);
+                paymentStatus, reason, now, ResumeStatus.NONE, null, null, null, 0, null, null, null);
+    }
+
+    public ReceptionConversation beginResume(String nextResumeId, String idempotencyKey,
+                                              String checksum, int boundarySequence, Instant now) {
+        require(nextResumeId, "resumeId");
+        require(idempotencyKey, "idempotencyKey");
+        require(checksum, "resumeChecksum");
+        if (mode != ReceptionMode.HUMAN) {
+            throw new IllegalStateException("only human conversations can return to Urba");
+        }
+        if (resumeStatus != ResumeStatus.NONE && resumeStatus != ResumeStatus.FAILED_SAFE
+                && resumeStatus != ResumeStatus.RETURNED_TO_HUMAN) {
+            if (nextResumeId.equals(resumeId) && idempotencyKey.equals(resumeIdempotencyKey)) {
+                return this;
+            }
+            throw new IllegalStateException("a resume is already in progress");
+        }
+        return copy(mode, commercialStage, selectedService, termsStatus, paymentStatus, handoffReason, now,
+                ResumeStatus.SYNCHRONIZING, nextResumeId, idempotencyKey, checksum, boundarySequence,
+                null, null, null);
+    }
+
+    public ReceptionConversation markResumeDeciding(Instant now) {
+        if (resumeStatus != ResumeStatus.SYNCHRONIZING) {
+            throw new IllegalStateException("resume is not synchronized");
+        }
+        return copy(mode, commercialStage, selectedService, termsStatus, paymentStatus, handoffReason, now,
+                ResumeStatus.DECIDING, resumeId, resumeIdempotencyKey, resumeChecksum,
+                resumeBoundarySequence, null, null, null);
+    }
+
+    public ReceptionConversation completeResume(String action, String message, Instant now) {
+        if (resumeStatus != ResumeStatus.DECIDING && resumeStatus != ResumeStatus.SYNCHRONIZING) {
+            throw new IllegalStateException("resume decision is not ready");
+        }
+        return copy(ReceptionMode.AI, commercialStage, selectedService, termsStatus, paymentStatus, null, now,
+                ResumeStatus.COMPLETED, resumeId, resumeIdempotencyKey, resumeChecksum,
+                resumeBoundarySequence, action, message, null);
+    }
+
+    public ReceptionConversation failResume(String failureCode, Instant now) {
+        require(failureCode, "resumeFailureCode");
+        return copy(ReceptionMode.HUMAN, commercialStage, selectedService, termsStatus, paymentStatus,
+                handoffReason == null ? "retomada não concluída" : handoffReason, now,
+                ResumeStatus.FAILED_SAFE, resumeId, resumeIdempotencyKey, resumeChecksum,
+                resumeBoundarySequence, resumeDecisionAction, null, failureCode);
+    }
+
+    public ReceptionConversation returnResumeToHuman(String reason, Instant now) {
+        return copy(ReceptionMode.HUMAN, commercialStage, selectedService, termsStatus, paymentStatus,
+                reason, now, ResumeStatus.RETURNED_TO_HUMAN, resumeId, resumeIdempotencyKey,
+                resumeChecksum, resumeBoundarySequence, "RETURN_TO_HUMAN", null, null);
     }
 
     private ReceptionConversation copy(ReceptionMode nextMode, CommercialStage nextStage,
                                        String nextService, TermsStatus nextTerms,
                                        PaymentStatus nextPayment, String nextReason, Instant now) {
+        return copy(nextMode, nextStage, nextService, nextTerms, nextPayment, nextReason, now,
+                resumeStatus, resumeId, resumeIdempotencyKey, resumeChecksum, resumeBoundarySequence,
+                resumeDecisionAction, resumeDecisionMessage, resumeFailureCode);
+    }
+
+    private ReceptionConversation copy(ReceptionMode nextMode, CommercialStage nextStage,
+                                       String nextService, TermsStatus nextTerms,
+                                       PaymentStatus nextPayment, String nextReason, Instant now,
+                                       ResumeStatus nextResumeStatus, String nextResumeId,
+                                       String nextResumeKey, String nextChecksum, int nextBoundary,
+                                       String nextAction, String nextMessage, String nextFailure) {
         return new ReceptionConversation(id, contactId, nextMode, nextStage, nextService,
-                nextTerms, nextPayment, nextReason, createdAt, now, version + 1);
+                nextTerms, nextPayment, nextReason, createdAt, now, version + 1,
+                nextResumeStatus, nextResumeId, nextResumeKey, nextChecksum, nextBoundary,
+                nextAction, nextMessage, nextFailure);
     }
 
     private static String require(String value, String field) {

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/ResumeStatus.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/ResumeStatus.java
@@ -1,0 +1,12 @@
+package br.com.urbana.connect.domain.reception.model;
+
+/** Durable ownership-return state; HUMAN remains fail-closed until completion. */
+public enum ResumeStatus {
+    NONE,
+    PENDING,
+    SYNCHRONIZING,
+    DECIDING,
+    COMPLETED,
+    RETURNED_TO_HUMAN,
+    FAILED_SAFE
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/port/out/HermesResumeGateway.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/port/out/HermesResumeGateway.java
@@ -1,0 +1,51 @@
+package br.com.urbana.connect.domain.reception.port.out;
+
+import java.util.List;
+import java.util.Map;
+
+/** PEE-103 internal capability. Synchronization is output-free and tool-free. */
+public interface HermesResumeGateway {
+    ContextSyncReceipt synchronize(String sessionId, ResumeContext context);
+
+    ResumeDecision decide(String sessionId, ResumeCommand command);
+
+    record ContextMessage(int sequence, String sourceMessageId, String senderType, String role, String content) { }
+
+    record ContextFact(String type, String value, String confidence) { }
+
+    record ResumeContext(int contractVersion, String resumeId, String lineageId, String idempotencyKey,
+                         String mode, long cursor, int watermark, String checksum,
+                         List<ContextMessage> messages, List<ContextFact> facts) {
+        public ResumeContext(int contractVersion, String resumeId, String lineageId, String idempotencyKey,
+                             String mode, long cursor, int watermark, String checksum,
+                             List<ContextMessage> messages) {
+            this(contractVersion, resumeId, lineageId, idempotencyKey, mode, cursor, watermark, checksum,
+                    messages, List.of());
+        }
+
+        public ResumeContext {
+            messages = messages == null ? List.of() : List.copyOf(messages);
+            facts = facts == null ? List.of() : List.copyOf(facts);
+        }
+    }
+
+    record ContextSyncReceipt(String resumeId, String lineageId, String effectiveSessionId,
+                              String checksum, long cursor, int coveredThroughSequence) { }
+
+    record ResumeCommand(int contractVersion, String resumeId, String lineageId, String idempotencyKey,
+                         ContextSyncReceipt contextReceipt, Map<String, Object> directive) {
+        public ResumeCommand {
+            directive = directive == null ? Map.of() : Map.copyOf(directive);
+        }
+    }
+
+    record ResumeDecision(String resumeId, String effectiveSessionId, Action action, String nextStep,
+                          String message, List<String> evidenceMessageIds, String reasonCode,
+                          double confidence) {
+        public ResumeDecision {
+            evidenceMessageIds = evidenceMessageIds == null ? List.of() : List.copyOf(evidenceMessageIds);
+        }
+    }
+
+    enum Action { SEND_MESSAGE, WAIT, RETURN_TO_HUMAN }
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/port/out/HumanHandoffNotificationGateway.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/port/out/HumanHandoffNotificationGateway.java
@@ -1,0 +1,9 @@
+package br.com.urbana.connect.domain.reception.port.out;
+
+import br.com.urbana.connect.domain.reception.model.HumanHandoffNotification;
+
+/** Durable idempotent notification boundary for human ownership. */
+public interface HumanHandoffNotificationGateway {
+    /** Returns false when this handoff was already notified. */
+    boolean notifyIfAbsent(HumanHandoffNotification notification);
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/port/out/IcpObservationEventGateway.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/port/out/IcpObservationEventGateway.java
@@ -1,0 +1,9 @@
+package br.com.urbana.connect.domain.reception.port.out;
+
+import br.com.urbana.connect.domain.reception.model.IcpObservationEvent;
+
+/** Durable, non-transcript sink for internal ICP continuation observations. */
+public interface IcpObservationEventGateway {
+    /** Returns false when the logical observation already exists. */
+    boolean appendIfAbsent(IcpObservationEvent event);
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/port/out/ReceptionConversationGateway.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/port/out/ReceptionConversationGateway.java
@@ -8,4 +8,17 @@ public interface ReceptionConversationGateway {
     Optional<ReceptionConversation> findByContactId(String contactId);
 
     ReceptionConversation save(ReceptionConversation conversation);
+
+    /**
+     * Persists a transition only when the caller still owns the version it
+     * read. Implementations backed by a durable store should override this
+     * with an atomic compare-and-set; small in-memory adapters retain the
+     * ordinary save semantics for deterministic unit tests.
+     */
+    default ReceptionConversation saveExpected(ReceptionConversation conversation, long expectedVersion) {
+        if (conversation.version() != expectedVersion + 1) {
+            throw new IllegalArgumentException("conversation version does not follow expected version");
+        }
+        return save(conversation);
+    }
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/servicecatalog/model/AreaRule.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/servicecatalog/model/AreaRule.java
@@ -1,0 +1,41 @@
+package br.com.urbana.connect.domain.servicecatalog.model;
+
+import java.math.BigDecimal;
+
+public enum AreaRule {
+    UP_TO_20_SQM_PER_ENVIRONMENT(new BigDecimal("20.00"), "Até 20 m² por ambiente"),
+    UNLIMITED_BY_CATALOG(null, "Sem limite de m²");
+
+    private final BigDecimal maximumSquareMeters;
+    private final String description;
+
+    AreaRule(BigDecimal maximumSquareMeters, String description) {
+        this.maximumSquareMeters = maximumSquareMeters;
+        this.description = description;
+    }
+
+    public BigDecimal maximumSquareMeters() {
+        return maximumSquareMeters;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public boolean hasLimit() {
+        return maximumSquareMeters != null;
+    }
+
+    public boolean accepts(BigDecimal squareMeters) {
+        if (squareMeters == null || squareMeters.signum() < 0) {
+            return false;
+        }
+        return !hasLimit() || squareMeters.compareTo(maximumSquareMeters) <= 0;
+    }
+
+    public boolean requiresArchitectReview(BigDecimal squareMeters) {
+        return hasLimit()
+                && squareMeters != null
+                && squareMeters.compareTo(maximumSquareMeters) > 0;
+    }
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItem.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItem.java
@@ -1,6 +1,8 @@
 package br.com.urbana.connect.domain.servicecatalog.model;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
 
 public record ServiceCatalogItem(
         ServiceType type,
@@ -9,7 +11,189 @@ public record ServiceCatalogItem(
         String scenarioText,
         String presentationText,
         BigDecimal price,
-        String paymentLink,
-        String briefingLink,
+        String termsResource,
+        String paymentResource,
+        String briefingResource,
+        AreaRule areaRule,
+        String scope,
+        List<String> deliverables,
+        List<String> process,
+        List<String> responsibilities,
+        List<String> exclusions,
+        String support,
         boolean available) {
+
+    private static final List<String> COMMON_DELIVERABLES = List.of(
+            "Manual PDF",
+            "Tour Virtual",
+            "3 opções de solução",
+            "2 rodadas consolidadas");
+
+    private static final List<String> COMMON_PROCESS = List.of(
+            "briefing",
+            "pagamento integral antecipado",
+            "validação humana do comprovante",
+            "medidas, fotos e vídeos",
+            "validação dos dados pela arquiteta",
+            "agendamento pelo link de disponibilidade da arquiteta",
+            "Google Meet",
+            "produção",
+            "7 dias úteis a partir do início da produção",
+            "pausa do prazo enquanto o cliente estiver pendente de feedback ou aprovação",
+            "aprovação final explícita",
+            "entrega por e-mail do Manual PDF e do Tour Virtual",
+            "suporte de 3 meses pelo WhatsApp");
+
+    private static final List<String> COMMON_RESPONSIBILITIES = List.of(
+            "Urba: triagem, termos, pagamento, briefing e orientações gerais.",
+            "Arquiteta: validação, reunião, produção, opções, ajustes, Manual, Tour e exceções.",
+            "Cliente: aceite, pagamento, briefing, medidas, fotos, vídeos, materiais, profissionais e execução.");
+
+    private static final List<String> COMMON_EXCLUSIONS = List.of(
+            "A Urbana presta consultoria online e não executa obra ou pintura.",
+            "A Urbana especifica, mas não compra materiais nem contrata profissionais.",
+            "Estoque, preços, links de compra e disponibilidade de mobiliário não são garantidos.",
+            "Uma terceira rodada de ajustes é exceção da arquiteta e não é prometida.",
+            "O suporte não inclui visita, gestão de obra ou garantia do resultado.");
+
+    /** Compatibility constructor for existing non-canonical adapters and tests. */
+    public ServiceCatalogItem(ServiceType type,
+                              String name,
+                              String emoji,
+                              String scenarioText,
+                              String presentationText,
+                              BigDecimal price,
+                              String paymentLink,
+                              String briefingLink,
+                              boolean available) {
+        this(type, name, emoji, scenarioText, presentationText, price, null, paymentLink, briefingLink,
+                AreaRule.UNLIMITED_BY_CATALOG, scenarioText, List.of(), List.of(), List.of(), List.of(),
+                "legacy adapter", available);
+    }
+
+    public ServiceCatalogItem {
+        type = Objects.requireNonNull(type, "type");
+        requireText(name, "name");
+        requireText(emoji, "emoji");
+        requireText(scenarioText, "scenarioText");
+        requireText(presentationText, "presentationText");
+        if (price == null || price.signum() < 0) {
+            throw new IllegalArgumentException("price must be non-negative");
+        }
+        areaRule = Objects.requireNonNull(areaRule, "areaRule");
+        requireText(scope, "scope");
+        deliverables = immutableCopy(deliverables);
+        process = immutableCopy(process);
+        responsibilities = immutableCopy(responsibilities);
+        exclusions = immutableCopy(exclusions);
+        requireText(support, "support");
+    }
+
+    public String paymentLink() {
+        return paymentResource;
+    }
+
+    public String briefingLink() {
+        return briefingResource;
+    }
+
+    public String termsLink() {
+        return termsResource;
+    }
+
+    public String description() {
+        return scope;
+    }
+
+    public BigDecimal areaLimitSqm() {
+        return areaRule.maximumSquareMeters();
+    }
+
+    public boolean isFixtureResource() {
+        return isFixture(termsResource) && isFixture(paymentResource) && isFixture(briefingResource);
+    }
+
+    public static List<ServiceCatalogItem> approvedCatalog() {
+        return canonicalCatalog();
+    }
+
+    public static List<ServiceCatalogItem> canonicalCatalog() {
+        return List.of(
+                service(
+                        ServiceType.DECOR_INTERIORES,
+                        "Decor Interiores",
+                        "🛋️",
+                        "Ambiente interno com layout, mobiliário, cores, materiais e composição; sem intervenção estrutural.",
+                        new BigDecimal("400.00"),
+                        AreaRule.UP_TO_20_SQM_PER_ENVIRONMENT,
+                        "decor-interiores"),
+                service(
+                        ServiceType.DECOR_PINTURA,
+                        "Decor Pintura",
+                        "🎨",
+                        "Pintura, desenhos e especificação de tintas; não inclui layout, mobiliário nem ensino prático de pintura.",
+                        new BigDecimal("250.00"),
+                        AreaRule.UNLIMITED_BY_CATALOG,
+                        "decor-pintura"),
+                service(
+                        ServiceType.DECOR_FACHADA,
+                        "Decor Fachada",
+                        "🏡",
+                        "Fachada, muro ou parede externa; pode considerar revestimentos, portão, iluminação e paisagismo conforme decisão da arquiteta.",
+                        new BigDecimal("350.00"),
+                        AreaRule.UNLIMITED_BY_CATALOG,
+                        "decor-fachada"),
+                service(
+                        ServiceType.DECOR_REFORMA,
+                        "Decor Reforma",
+                        "🧱",
+                        "Solução para reforma interna; demandas técnicas específicas dependem de avaliação da arquiteta.",
+                        new BigDecimal("450.00"),
+                        AreaRule.UP_TO_20_SQM_PER_ENVIRONMENT,
+                        "decor-reforma"));
+    }
+
+    private static ServiceCatalogItem service(ServiceType type,
+                                              String name,
+                                              String emoji,
+                                              String scope,
+                                              BigDecimal price,
+                                              AreaRule areaRule,
+                                              String resourceKey) {
+        String area = areaRule.description();
+        String presentation = scope + " Área: " + area + ".";
+        String fixtureBase = "https://fixtures.urbana.local/";
+        return new ServiceCatalogItem(
+                type,
+                name,
+                emoji,
+                scope,
+                presentation,
+                price,
+                fixtureBase + "terms/" + resourceKey,
+                fixtureBase + "payment/" + resourceKey,
+                fixtureBase + "briefing/" + resourceKey,
+                areaRule,
+                scope,
+                COMMON_DELIVERABLES,
+                COMMON_PROCESS,
+                COMMON_RESPONSIBILITIES,
+                COMMON_EXCLUSIONS,
+                "Suporte de 3 meses após a entrega para dúvidas sobre o Manual e cores, sem visita ou gestão de obra.",
+                true);
+    }
+
+    private static List<String> immutableCopy(List<String> values) {
+        return values == null ? List.of() : List.copyOf(values);
+    }
+
+    private static void requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+    }
+
+    private static boolean isFixture(String resource) {
+        return resource != null && resource.startsWith("https://fixtures.urbana.local/");
+    }
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceType.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceType.java
@@ -1,8 +1,31 @@
 package br.com.urbana.connect.domain.servicecatalog.model;
 
+import java.util.List;
+
 public enum ServiceType {
-    DECOR,
+    DECOR_INTERIORES,
     DECOR_PINTURA,
     DECOR_FACHADA,
-    DECOR_REFORMA
+    DECOR_REFORMA,
+    /**
+     * Kept only as an input/storage compatibility symbol. It is never part of
+     * the canonical catalog and must not be presented as a service.
+     */
+    @Deprecated
+    DECOR;
+
+    public boolean isCanonical() {
+        return this != DECOR;
+    }
+
+    public static List<ServiceType> canonicalValues() {
+        return List.of(DECOR_INTERIORES, DECOR_PINTURA, DECOR_FACHADA, DECOR_REFORMA);
+    }
+
+    public static ServiceType canonicalize(ServiceType type) {
+        if (type == null) {
+            return null;
+        }
+        return type == DECOR ? DECOR_INTERIORES : type;
+    }
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/hermes/HttpHermesResumeGateway.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/hermes/HttpHermesResumeGateway.java
@@ -1,0 +1,99 @@
+package br.com.urbana.connect.infrastructure.hermes;
+
+import br.com.urbana.connect.domain.reception.port.out.HermesResumeGateway;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** HTTP adapter for the versioned PEE-103 internal resume endpoints. */
+@Component
+@ConditionalOnProperty(name = "hermes.poc.enabled", havingValue = "true")
+public final class HttpHermesResumeGateway implements HermesResumeGateway {
+    private final RestClient client;
+    private final String baseUrl;
+    private final String apiKey;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public HttpHermesResumeGateway(RestClient.Builder builder,
+                                   @Value("${hermes.sessions.base-url:http://127.0.0.1:8642}") String baseUrl,
+                                   @Value("${hermes.sessions.api-server-key:}") String apiKey) {
+        this.client = builder.build();
+        String configuredBaseUrl = baseUrl == null || baseUrl.isBlank()
+                ? "http://127.0.0.1:8642" : baseUrl.trim();
+        this.baseUrl = configuredBaseUrl.endsWith("/")
+                ? configuredBaseUrl.substring(0, configuredBaseUrl.length() - 1) : configuredBaseUrl;
+        this.apiKey = apiKey == null ? "" : apiKey;
+    }
+
+    @Override
+    public ContextSyncReceipt synchronize(String sessionId, ResumeContext context) {
+        JsonNode body = post(sessionId, "context-sync", context);
+        return new ContextSyncReceipt(text(body, "resumeId"), text(body, "lineageId"),
+                text(body, "effectiveSessionId"), text(body, "checksum"),
+                body.path("cursor").asLong(), body.path("coveredThroughSequence").asInt());
+    }
+
+    @Override
+    public ResumeDecision decide(String sessionId, ResumeCommand command) {
+        Map<String, Object> receipt = new LinkedHashMap<>();
+        receipt.put("effectiveSessionId", command.contextReceipt().effectiveSessionId());
+        receipt.put("checksum", command.contextReceipt().checksum());
+        receipt.put("cursor", command.contextReceipt().cursor());
+        receipt.put("coveredThroughSequence", command.contextReceipt().coveredThroughSequence());
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("contractVersion", command.contractVersion());
+        payload.put("resumeId", command.resumeId());
+        payload.put("lineageId", command.lineageId());
+        payload.put("idempotencyKey", command.idempotencyKey());
+        payload.put("contextReceipt", receipt);
+        payload.put("directive", command.directive());
+        JsonNode body = post(sessionId, "resume-decide", payload);
+        return new ResumeDecision(text(body, "resumeId"), text(body, "effectiveSessionId"),
+                Action.valueOf(text(body, "action")), text(body, "nextStep"),
+                body.path("message").isNull() ? null : text(body, "message"),
+                mapper.convertValue(body.path("evidenceMessageIds"),
+                        mapper.getTypeFactory().constructCollectionType(java.util.List.class, String.class)),
+                text(body, "reasonCode"), body.path("confidence").asDouble());
+    }
+
+    private JsonNode post(String sessionId, String operation, Object payload) {
+        try {
+            String body = client.post()
+                    .uri(baseUrl + "/api/internal/v1/sessions/" + sessionId.replace("/", "%2F") + "/" + operation)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                    .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)
+                    .body(payload).retrieve().body(String.class);
+            return mapper.readTree(body == null ? "{}" : body);
+        } catch (RestClientResponseException failure) {
+            throw new ResumeGatewayException("Retomada indisponível.", failure.getStatusCode().value(), failure);
+        } catch (Exception failure) {
+            throw new ResumeGatewayException("Retomada indisponível.", 0, failure);
+        }
+    }
+
+    private static String text(JsonNode node, String field) {
+        JsonNode value = node.path(field);
+        if (!value.isTextual() || value.asText().isBlank()) {
+            throw new ResumeGatewayException("Resposta de retomada inválida.", 0, null);
+        }
+        return value.asText();
+    }
+
+    public static final class ResumeGatewayException extends RuntimeException {
+        private final int status;
+        ResumeGatewayException(String message, int status, Throwable cause) {
+            super(message, cause);
+            this.status = status;
+        }
+        public int status() { return status; }
+    }
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/HumanHandoffNotificationDocument.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/HumanHandoffNotificationDocument.java
@@ -1,0 +1,28 @@
+package br.com.urbana.connect.infrastructure.persistence.mongodb.reception;
+
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@Document(collection = "reception_handoff_notifications")
+@CompoundIndex(name = "reception_handoff_notification_idempotency_unique",
+        def = "{'idempotencyKey': 1}", unique = true)
+public class HumanHandoffNotificationDocument {
+    @Id
+    private String notificationId;
+    private String idempotencyKey;
+    private String conversationId;
+    private String turnId;
+    private String reason;
+    private String serviceType;
+    private String commercialStage;
+    private String paymentStatus;
+    private List<String> presentIcpFields;
+    private List<String> missingIcpFields;
+    private Instant occurredAt;
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/IcpObservationEventDocument.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/IcpObservationEventDocument.java
@@ -1,0 +1,26 @@
+package br.com.urbana.connect.infrastructure.persistence.mongodb.reception;
+
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@Document(collection = "reception_icp_observations")
+@CompoundIndex(name = "reception_icp_observation_idempotency_unique",
+        def = "{'idempotencyKey': 1}", unique = true)
+public class IcpObservationEventDocument {
+    @Id
+    private String eventId;
+    private String eventType;
+    private String conversationId;
+    private String turnId;
+    private String serviceType;
+    private List<String> missingFields;
+    private String detectionPoint;
+    private String idempotencyKey;
+    private Instant occurredAt;
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoHumanHandoffNotificationGateway.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoHumanHandoffNotificationGateway.java
@@ -1,0 +1,47 @@
+package br.com.urbana.connect.infrastructure.persistence.mongodb.reception;
+
+import br.com.urbana.connect.domain.reception.model.HumanHandoffNotification;
+import br.com.urbana.connect.domain.reception.port.out.HumanHandoffNotificationGateway;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Component;
+
+/** Durable internal outbox record for a handoff notification. */
+@Component
+@ConditionalOnProperty(name = "hermes.poc.enabled", havingValue = "true")
+public final class MongoHumanHandoffNotificationGateway implements HumanHandoffNotificationGateway {
+    private final SpringDataHumanHandoffNotificationRepository repository;
+
+    public MongoHumanHandoffNotificationGateway(SpringDataHumanHandoffNotificationRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public boolean notifyIfAbsent(HumanHandoffNotification notification) {
+        if (repository.findById(notification.notificationId()).isPresent()) {
+            return false;
+        }
+        try {
+            repository.save(toDocument(notification));
+            return true;
+        } catch (DuplicateKeyException duplicate) {
+            return false;
+        }
+    }
+
+    private static HumanHandoffNotificationDocument toDocument(HumanHandoffNotification notification) {
+        HumanHandoffNotificationDocument document = new HumanHandoffNotificationDocument();
+        document.setNotificationId(notification.notificationId());
+        document.setIdempotencyKey(notification.idempotencyKey());
+        document.setConversationId(notification.conversationId());
+        document.setTurnId(notification.turnId());
+        document.setReason(notification.reason());
+        document.setServiceType(notification.serviceType());
+        document.setCommercialStage(notification.commercialStage());
+        document.setPaymentStatus(notification.paymentStatus());
+        document.setPresentIcpFields(notification.presentIcpFields());
+        document.setMissingIcpFields(notification.missingIcpFields());
+        document.setOccurredAt(notification.occurredAt());
+        return document;
+    }
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoIcpObservationEventGateway.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoIcpObservationEventGateway.java
@@ -1,0 +1,45 @@
+package br.com.urbana.connect.infrastructure.persistence.mongodb.reception;
+
+import br.com.urbana.connect.domain.reception.model.IcpObservationEvent;
+import br.com.urbana.connect.domain.reception.port.out.IcpObservationEventGateway;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Component;
+
+/** Mongo-backed sink for internal ICP observations, separate from the transcript. */
+@Component
+@ConditionalOnProperty(name = "hermes.poc.enabled", havingValue = "true")
+public final class MongoIcpObservationEventGateway implements IcpObservationEventGateway {
+    private final SpringDataIcpObservationEventRepository repository;
+
+    public MongoIcpObservationEventGateway(SpringDataIcpObservationEventRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public boolean appendIfAbsent(IcpObservationEvent event) {
+        if (repository.findById(event.eventId()).isPresent()) {
+            return false;
+        }
+        try {
+            repository.save(toDocument(event));
+            return true;
+        } catch (DuplicateKeyException duplicate) {
+            return false;
+        }
+    }
+
+    private static IcpObservationEventDocument toDocument(IcpObservationEvent event) {
+        IcpObservationEventDocument document = new IcpObservationEventDocument();
+        document.setEventId(event.eventId());
+        document.setEventType(event.eventType());
+        document.setConversationId(event.conversationId());
+        document.setTurnId(event.turnId());
+        document.setServiceType(event.serviceType());
+        document.setMissingFields(event.missingFields());
+        document.setDetectionPoint(event.detectionPoint());
+        document.setIdempotencyKey(event.idempotencyKey());
+        document.setOccurredAt(event.occurredAt());
+        return document;
+    }
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoReceptionConversationGateway.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoReceptionConversationGateway.java
@@ -57,7 +57,15 @@ public class MongoReceptionConversationGateway implements ReceptionConversationG
                 .set("handoffReason", conversation.handoffReason())
                 .set("createdAt", conversation.createdAt())
                 .set("updatedAt", conversation.updatedAt())
-                .set("version", conversation.version());
+                .set("version", conversation.version())
+                .set("resumeStatus", conversation.resumeStatus())
+                .set("resumeId", conversation.resumeId())
+                .set("resumeIdempotencyKey", conversation.resumeIdempotencyKey())
+                .set("resumeChecksum", conversation.resumeChecksum())
+                .set("resumeBoundarySequence", conversation.resumeBoundarySequence())
+                .set("resumeDecisionAction", conversation.resumeDecisionAction())
+                .set("resumeDecisionMessage", conversation.resumeDecisionMessage())
+                .set("resumeFailureCode", conversation.resumeFailureCode());
         ReceptionConversationDocument updated = template.findAndModify(query, update,
                 FindAndModifyOptions.options().returnNew(true), ReceptionConversationDocument.class);
         if (updated == null) {
@@ -73,12 +81,21 @@ public class MongoReceptionConversationGateway implements ReceptionConversationG
         d.setTermsStatus(value.termsStatus()); d.setPaymentStatus(value.paymentStatus());
         d.setHandoffReason(value.handoffReason()); d.setCreatedAt(value.createdAt());
         d.setUpdatedAt(value.updatedAt()); d.setVersion(value.version());
+        d.setResumeStatus(value.resumeStatus()); d.setResumeId(value.resumeId());
+        d.setResumeIdempotencyKey(value.resumeIdempotencyKey()); d.setResumeChecksum(value.resumeChecksum());
+        d.setResumeBoundarySequence(value.resumeBoundarySequence());
+        d.setResumeDecisionAction(value.resumeDecisionAction());
+        d.setResumeDecisionMessage(value.resumeDecisionMessage());
+        d.setResumeFailureCode(value.resumeFailureCode());
         return d;
     }
 
     private ReceptionConversation toDomain(ReceptionConversationDocument d) {
         return new ReceptionConversation(d.getId(), d.getContactId(), d.getMode(), d.getCommercialStage(),
                 d.getSelectedService(), d.getTermsStatus(), d.getPaymentStatus(), d.getHandoffReason(),
-                d.getCreatedAt(), d.getUpdatedAt(), d.getVersion());
+                d.getCreatedAt(), d.getUpdatedAt(), d.getVersion(),
+                d.getResumeStatus(), d.getResumeId(), d.getResumeIdempotencyKey(), d.getResumeChecksum(),
+                d.getResumeBoundarySequence(), d.getResumeDecisionAction(), d.getResumeDecisionMessage(),
+                d.getResumeFailureCode());
     }
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/ReceptionConversationDocument.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/ReceptionConversationDocument.java
@@ -3,6 +3,7 @@ package br.com.urbana.connect.infrastructure.persistence.mongodb.reception;
 import br.com.urbana.connect.domain.reception.model.CommercialStage;
 import br.com.urbana.connect.domain.reception.model.PaymentStatus;
 import br.com.urbana.connect.domain.reception.model.ReceptionMode;
+import br.com.urbana.connect.domain.reception.model.ResumeStatus;
 import br.com.urbana.connect.domain.reception.model.TermsStatus;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
@@ -27,4 +28,12 @@ public class ReceptionConversationDocument {
     private Instant createdAt;
     private Instant updatedAt;
     private long version;
+    private ResumeStatus resumeStatus;
+    private String resumeId;
+    private String resumeIdempotencyKey;
+    private String resumeChecksum;
+    private int resumeBoundarySequence;
+    private String resumeDecisionAction;
+    private String resumeDecisionMessage;
+    private String resumeFailureCode;
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/ReceptionMessageDocument.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/ReceptionMessageDocument.java
@@ -29,6 +29,7 @@ public class ReceptionMessageDocument {
     private ReceptionMessageType type;
     private String text;
     private String mediaRef;
+    @Indexed(unique = true, sparse = true)
     private String providerMessageId;
     private Instant createdAt;
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/SpringDataHumanHandoffNotificationRepository.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/SpringDataHumanHandoffNotificationRepository.java
@@ -1,0 +1,7 @@
+package br.com.urbana.connect.infrastructure.persistence.mongodb.reception;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface SpringDataHumanHandoffNotificationRepository
+        extends MongoRepository<HumanHandoffNotificationDocument, String> {
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/SpringDataIcpObservationEventRepository.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/SpringDataIcpObservationEventRepository.java
@@ -1,0 +1,7 @@
+package br.com.urbana.connect.infrastructure.persistence.mongodb.reception;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface SpringDataIcpObservationEventRepository
+        extends MongoRepository<IcpObservationEventDocument, String> {
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/MongoServiceCatalogGateway.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/MongoServiceCatalogGateway.java
@@ -18,6 +18,7 @@ public class MongoServiceCatalogGateway implements ServiceCatalogGateway {
     @Override
     public List<ServiceCatalogItem> findAll() {
         return repository.findAll().stream()
+            .filter(document -> document.getType() != ServiceType.DECOR)
             .map(this::toDomain)
             .toList();
     }
@@ -25,13 +26,14 @@ public class MongoServiceCatalogGateway implements ServiceCatalogGateway {
     @Override
     public List<ServiceCatalogItem> findAvailable() {
         return repository.findAllByAvailableTrueOrderByNameAsc().stream()
+            .filter(document -> document.getType() != ServiceType.DECOR)
             .map(this::toDomain)
             .toList();
     }
 
     @Override
     public Optional<ServiceCatalogItem> findByType(ServiceType type) {
-        return repository.findByType(type).map(this::toDomain);
+        return repository.findByType(ServiceType.canonicalize(type)).map(this::toDomain);
     }
 
     private ServiceCatalogItem toDomain(ServiceCatalogDocument document) {
@@ -42,8 +44,16 @@ public class MongoServiceCatalogGateway implements ServiceCatalogGateway {
             document.getScenarioText(),
             document.getPresentationText(),
             document.getPrice(),
-            document.getPaymentLink(),
-            document.getBriefingLink(),
+            document.getTermsResource(),
+            document.getPaymentResource(),
+            document.getBriefingResource(),
+            document.getAreaRule(),
+            document.getScope(),
+            document.getDeliverables(),
+            document.getProcess(),
+            document.getResponsibilities(),
+            document.getExclusions(),
+            document.getSupport(),
             document.isAvailable());
     }
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/ServiceCatalogDocument.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/ServiceCatalogDocument.java
@@ -1,12 +1,14 @@
 package br.com.urbana.connect.infrastructure.persistence.mongodb.servicecatalog;
 
 import br.com.urbana.connect.domain.servicecatalog.model.ServiceType;
+import br.com.urbana.connect.domain.servicecatalog.model.AreaRule;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.index.Indexed;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Data
 @Document(collection = "services")
@@ -22,7 +24,32 @@ public class ServiceCatalogDocument {
     private String scenarioText;
     private String presentationText;
     private BigDecimal price;
-    private String paymentLink;
-    private String briefingLink;
+    private String termsResource;
+    private String paymentResource;
+    private String briefingResource;
+    private AreaRule areaRule;
+    private String scope;
+    private List<String> deliverables;
+    private List<String> process;
+    private List<String> responsibilities;
+    private List<String> exclusions;
+    private String support;
     private boolean available;
+
+    /** Compatibility aliases for the previous persistence adapter contract. */
+    public String getPaymentLink() {
+        return paymentResource;
+    }
+
+    public void setPaymentLink(String paymentLink) {
+        this.paymentResource = paymentLink;
+    }
+
+    public String getBriefingLink() {
+        return briefingResource;
+    }
+
+    public void setBriefingLink(String briefingLink) {
+        this.briefingResource = briefingLink;
+    }
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/ServiceCatalogSeeder.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/ServiceCatalogSeeder.java
@@ -1,13 +1,11 @@
 package br.com.urbana.connect.infrastructure.persistence.mongodb.servicecatalog;
 
-import br.com.urbana.connect.domain.servicecatalog.model.ServiceType;
+import br.com.urbana.connect.domain.servicecatalog.model.ServiceCatalogItem;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 
-import java.math.BigDecimal;
 import java.util.List;
-import java.util.Objects;
 
 @Component
 public class ServiceCatalogSeeder implements ApplicationRunner {
@@ -20,102 +18,59 @@ public class ServiceCatalogSeeder implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) {
-        for (ServiceCatalogDocument service : initialCatalog()) {
-            repository.findByType(service.getType())
-                .map(existing -> merge(existing, service))
-                .ifPresentOrElse(repository::save, () -> repository.save(service));
+        for (ServiceCatalogDocument seed : initialCatalog()) {
+            repository.findByType(seed.getType())
+                    .map(existing -> merge(existing, seed))
+                    .ifPresentOrElse(repository::save, () -> repository.save(seed));
         }
     }
 
     private List<ServiceCatalogDocument> initialCatalog() {
-        return List.of(
-            withLinks(service(
-                ServiceType.DECOR,
-                "Decor",
-                "🛋️",
-                "Quero renovar meu espaço interno sem gastar muito, nada de quebra-quebra.",
-                "Para espaços de até 20m², temos a Decor 🛋️\n\n"
-                    + "Criamos uma solução de espaço, de acordo com seu estilo e orçamento.\n\n"
-                    + "Inclusive, se você coloca a mão na massa, para economizar, criamos uma solução faça você mesmo, com vídeos e tutoriais.",
-                new BigDecimal("400.00"),
-                true), "https://mpago.la/1TbJFYx", "https://forms.gle/W4zBPwusPZeJ2cnD7"),
-            withLinks(service(
-                ServiceType.DECOR_PINTURA,
-                "Decor Pintura",
-                "🎨",
-                "Quero renovar meu espaço com uma pintura, nada de quebra-quebra.",
-                "Para renovar gastando pouco, com tintas e estilo, temos a Decor Pintura 🎨\n\n"
-                    + "Criamos uma solução de pintura para o seu espaço, com todos os detalhes para você ou seu pintor.\n\n"
-                    + "E, se você topa colocar a mão na massa, enviamos nosso manual de pintura didático, com links e tutoriais.",
-                new BigDecimal("250.00"),
-                true), "https://mpago.la/32aNZUw", "https://forms.gle/6FWqQCxmUxVKc6xG7"),
-            withLinks(service(
-                ServiceType.DECOR_FACHADA,
-                "Decor Fachada",
-                "🏡",
-                "Quero renovar minha fachada ou muro externo sem gastar muito.",
-                "Para fachadas ou muros externos, temos a Decor Fachada 🏡\n\nCriamos uma solução de renovação para a fachada ou muro externo da sua casa ou pequeno negócio.",
-                new BigDecimal("350.00"),
-                true), "https://mpago.la/1Qeg34y", "https://forms.gle/VXEVPeNUPxKfrWxb6"),
-            service(
-                ServiceType.DECOR_REFORMA,
-                "Decor Reforma",
-                "🧱",
-                "Quero reformar meu espaço, com quebra-quebra e tudo mais.",
-                "Para uma reforma completa de um espaço, temos a Decor Reforma 🧱\n\nCriamos uma solução para reforma completa de um espaço interno, como mudança de layout, paredes, janelas, bancada, elétrica e revestimentos.",
-                new BigDecimal("450.00"),
-                false)
-        );
+        return ServiceCatalogItem.canonicalCatalog().stream()
+                .map(this::toDocument)
+                .toList();
     }
 
-    private ServiceCatalogDocument service(
-            ServiceType type,
-            String name,
-            String emoji,
-            String scenarioText,
-            String presentationText,
-            BigDecimal price,
-            boolean available) {
+    private ServiceCatalogDocument toDocument(ServiceCatalogItem item) {
         ServiceCatalogDocument document = new ServiceCatalogDocument();
-        document.setType(type);
-        document.setName(name);
-        document.setEmoji(emoji);
-        document.setScenarioText(scenarioText);
-        document.setPresentationText(presentationText);
-        document.setPrice(price);
-        document.setAvailable(available);
-        return document;
-    }
-
-    private ServiceCatalogDocument withLinks(
-            ServiceCatalogDocument document,
-            String paymentLink,
-            String briefingLink) {
-        document.setPaymentLink(paymentLink);
-        document.setBriefingLink(briefingLink);
+        document.setType(item.type());
+        document.setName(item.name());
+        document.setEmoji(item.emoji());
+        document.setScenarioText(item.scenarioText());
+        document.setPresentationText(item.presentationText());
+        document.setPrice(item.price());
+        document.setTermsResource(item.termsResource());
+        document.setPaymentResource(item.paymentResource());
+        document.setBriefingResource(item.briefingResource());
+        document.setAreaRule(item.areaRule());
+        document.setScope(item.scope());
+        document.setDeliverables(item.deliverables());
+        document.setProcess(item.process());
+        document.setResponsibilities(item.responsibilities());
+        document.setExclusions(item.exclusions());
+        document.setSupport(item.support());
+        document.setAvailable(item.available());
         return document;
     }
 
     private ServiceCatalogDocument merge(ServiceCatalogDocument existing, ServiceCatalogDocument seed) {
+        existing.setType(seed.getType());
         existing.setName(seed.getName());
         existing.setEmoji(seed.getEmoji());
         existing.setScenarioText(seed.getScenarioText());
         existing.setPresentationText(seed.getPresentationText());
         existing.setPrice(seed.getPrice());
-
-        if (isBlank(existing.getPaymentLink())) {
-            existing.setPaymentLink(seed.getPaymentLink());
-        }
-        if (isBlank(existing.getBriefingLink())) {
-            existing.setBriefingLink(seed.getBriefingLink());
-        }
-        if (!existing.isAvailable() && seed.isAvailable() && Objects.equals(existing.getPaymentLink(), seed.getPaymentLink())) {
-            existing.setAvailable(true);
-        }
+        existing.setTermsResource(seed.getTermsResource());
+        existing.setPaymentResource(seed.getPaymentResource());
+        existing.setBriefingResource(seed.getBriefingResource());
+        existing.setAreaRule(seed.getAreaRule());
+        existing.setScope(seed.getScope());
+        existing.setDeliverables(seed.getDeliverables());
+        existing.setProcess(seed.getProcess());
+        existing.setResponsibilities(seed.getResponsibilities());
+        existing.setExclusions(seed.getExclusions());
+        existing.setSupport(seed.getSupport());
+        existing.setAvailable(seed.isAvailable());
         return existing;
-    }
-
-    private boolean isBlank(String value) {
-        return value == null || value.isBlank();
     }
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/interfaces/rest/poc/ConversationSimulatorController.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/interfaces/rest/poc/ConversationSimulatorController.java
@@ -7,6 +7,7 @@ import br.com.urbana.connect.application.reception.PocReceptionIngress;
 import br.com.urbana.connect.application.reception.ReceptionMetrics;
 import br.com.urbana.connect.application.reception.ReceptionOrchestrator;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessageType;
+import br.com.urbana.connect.domain.reception.port.out.HermesResumeGateway;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,22 +45,30 @@ public class ConversationSimulatorController {
     private final ReceptionOrchestrator orchestrator;
     private final PocReceptionIngress ingress;
     private final String expectedToken;
+    private final HermesResumeGateway resumeGateway;
 
     public ConversationSimulatorController(ReceptionOrchestrator orchestrator) {
         this(orchestrator, new PocReceptionIngress(orchestrator, new MessageBatcher(),
-                new MediaNormalizationService()), "");
+                new MediaNormalizationService()), "", null);
     }
 
     public ConversationSimulatorController(ReceptionOrchestrator orchestrator, PocReceptionIngress ingress) {
-        this(orchestrator, ingress, "");
+        this(orchestrator, ingress, "", null);
     }
 
     @Autowired
     public ConversationSimulatorController(ReceptionOrchestrator orchestrator, PocReceptionIngress ingress,
-                                           @Value("${hermes.poc.api-token:}") String expectedToken) {
+                                           @Value("${hermes.poc.api-token:}") String expectedToken,
+                                           HermesResumeGateway resumeGateway) {
         this.orchestrator = orchestrator;
         this.ingress = ingress;
         this.expectedToken = expectedToken == null ? "" : expectedToken.trim();
+        this.resumeGateway = resumeGateway;
+    }
+
+    public ConversationSimulatorController(ReceptionOrchestrator orchestrator, PocReceptionIngress ingress,
+                                           String expectedToken) {
+        this(orchestrator, ingress, expectedToken, null);
     }
 
     @PostMapping("/{contactAlias}/messages")
@@ -136,6 +145,51 @@ public class ConversationSimulatorController {
         }
     }
 
+    @PostMapping("/{contactAlias}/human/messages")
+    public ResponseEntity<ReceptionOrchestrator.HumanMessageReceipt> recordHumanMessage(
+            @PathVariable String contactAlias,
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+            @Valid @RequestBody HumanOperatorMessage request) {
+        if (!authorized(authorization)) return unauthorized();
+        if (!validAlias(contactAlias) || idempotencyKey == null || idempotencyKey.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        try {
+            return ResponseEntity.ok(orchestrator.recordHumanMessage("poc:" + contactAlias,
+                    idempotencyKey.trim(), request.text(), request.occurredAt()));
+        } catch (IllegalArgumentException exception) {
+            return ResponseEntity.badRequest().build();
+        } catch (IllegalStateException exception) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+    }
+
+    @PostMapping("/{contactAlias}/ownership/urba")
+    public ResponseEntity<ReceptionOrchestrator.ResumeReceipt> returnToUrba(
+            @PathVariable String contactAlias,
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+            @Valid @RequestBody(required = false) ResumeOwnershipRequest request) {
+        if (!authorized(authorization)) return unauthorized();
+        if (!validAlias(contactAlias) || idempotencyKey == null || idempotencyKey.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        long expectedVersion = request == null || request.expectedVersion() == null
+                ? -1 : request.expectedVersion();
+        ReceptionOrchestrator.ResumeReceipt receipt = orchestrator.returnToUrba(
+                "poc:" + contactAlias, idempotencyKey.trim(), expectedVersion, resumeGateway);
+        if (receipt.status() == br.com.urbana.connect.domain.reception.model.ResumeStatus.COMPLETED
+                || receipt.duplicate()) {
+            return ResponseEntity.ok(receipt);
+        }
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(receipt);
+    }
+
+    private static boolean validAlias(String contactAlias) {
+        return contactAlias != null && CONTACT_ALIAS.matcher(contactAlias).matches();
+    }
+
     private boolean authorized(String authorization) {
         if (expectedToken.isBlank()) {
             return true;
@@ -188,4 +242,10 @@ public class ConversationSimulatorController {
             return value == null ? 0 : value.length();
         }
     }
+
+    @JsonIgnoreProperties(ignoreUnknown = false)
+    public record HumanOperatorMessage(String text, Instant occurredAt) { }
+
+    @JsonIgnoreProperties(ignoreUnknown = false)
+    public record ResumeOwnershipRequest(Long expectedVersion) { }
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/interfaces/rest/poc/DomainToolController.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/interfaces/rest/poc/DomainToolController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -52,39 +53,56 @@ public class DomainToolController {
             @RequestHeader(value = "Authorization", required = false) String authorization,
             @Valid @RequestBody(required = false) ToolRequest request) {
         if (!isAuthorized(authorization)) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ToolResponse.error("invalid internal tool token"));
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ToolResponse.error(
+                    "ACCESS_DENIED", "STOP", "Não foi possível continuar esta solicitação."));
         }
         if (request == null || request.sessionId() == null || request.sessionId().isBlank()
                 || request.principal() == null || request.principal().isBlank()) {
-            return ResponseEntity.badRequest().body(ToolResponse.error("sessionId and principal are required"));
+            return ResponseEntity.badRequest().body(ToolResponse.error(
+                    "INVALID_REQUEST", "CORRECT_INPUT", "Preciso de dados válidos para continuar."));
         }
         if (!RUNTIME_ID.matcher(request.sessionId()).matches()
                 || request.principal().length() > 128) {
-            return ResponseEntity.badRequest().body(ToolResponse.error("runtime identity is invalid"));
+            return ResponseEntity.badRequest().body(ToolResponse.error(
+                    "INVALID_REQUEST", "CORRECT_INPUT", "Preciso de dados válidos para continuar."));
         }
         if (!expectedPrincipal.equals(request.principal())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ToolResponse.error("technical principal is not allowlisted"));
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ToolResponse.error(
+                    "ACCESS_DENIED", "STOP", "Não foi possível continuar esta solicitação."));
         }
         Map<String, Object> arguments = request.arguments() == null ? Map.of() : request.arguments();
         if (arguments.size() > 32 || arguments.toString().length() > 8192) {
-            return ResponseEntity.badRequest().body(ToolResponse.error("tool arguments exceed the POC limit"));
+            return ResponseEntity.badRequest().body(ToolResponse.error(
+                    "INVALID_REQUEST", "CORRECT_INPUT", "Preciso de dados válidos para continuar."));
         }
         if (FORBIDDEN_MODEL_IDENTIFIERS.stream().anyMatch(arguments::containsKey)) {
-            return ResponseEntity.badRequest().body(ToolResponse.error("model identifiers are not accepted"));
+            return ResponseEntity.badRequest().body(ToolResponse.error(
+                    "INVALID_REQUEST", "CORRECT_INPUT", "Preciso de dados válidos para continuar."));
         }
         final DomainToolName name;
         try {
             name = DomainToolName.fromWireName(toolName);
         } catch (IllegalArgumentException exception) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ToolResponse.error("tool is not allowlisted"));
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ToolResponse.error(
+                    "ACTION_NOT_AVAILABLE", "CHOOSE_AVAILABLE_ACTION", "Essa ação não está disponível."));
         }
         try {
             var result = invocation.invoke(request.sessionId(), request.principal(), name, arguments);
-            return ResponseEntity.ok(ToolResponse.success(result.result(), result.idempotencyKey()));
+            return ResponseEntity.ok(ToolResponse.success(result.result()));
+        } catch (DomainToolInvocationUseCase.DomainRejectionException rejection) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(ToolResponse.error(new ToolError(
+                    rejection.code(), rejection.nextAction(), rejection.missingFields(), rejection.customerMessage())));
+        } catch (DomainToolInvocationUseCase.InvocationInProgressException inProgress) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(ToolResponse.error(
+                    "ACTION_IN_PROGRESS", "WAIT", "Esta etapa ainda está sendo concluída."));
         } catch (IllegalArgumentException exception) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(ToolResponse.error(safeError(exception.getMessage())));
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(ToolResponse.error(
+                    "BUSINESS_RULE_REJECTED", "ASK_FOR_CLARIFICATION",
+                    "Preciso confirmar uma informação antes de continuar."));
         } catch (RuntimeException exception) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ToolResponse.error("domain operation failed"));
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ToolResponse.error(
+                    "TEMPORARILY_UNAVAILABLE", "WAIT_OR_HANDOFF",
+                    "Não consegui concluir esta etapa agora. Posso tentar novamente ou chamar a arquiteta."));
         }
     }
 
@@ -93,29 +111,27 @@ public class DomainToolController {
                 && authorization != null && authorization.equals("Bearer " + expectedToken);
     }
 
-    private String safeError(String message) {
-        String value = message == null || message.isBlank() ? "domain operation rejected" : message;
-        String redacted = value.replaceAll(
-                "(?i)(openrouter_api_key|hermes_api_server_key|hermes_internal_tool_token|password|secret|token)"
-                        + "(\\s*[:=]\\s*)[^\\s,;]+",
-                "[REDACTED]");
-        if (expectedToken != null && !expectedToken.isBlank()) {
-            redacted = redacted.replace(expectedToken, "[REDACTED]");
-        }
-        return redacted.length() > 240 ? redacted.substring(0, 240) + "…" : redacted;
-    }
-
     @JsonIgnoreProperties(ignoreUnknown = false)
     public record ToolRequest(String sessionId, String principal, Map<String, Object> arguments) { }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public record ToolResponse(boolean ok, Object result, String error, String idempotencyKey) {
-        static ToolResponse success(Object result, String idempotencyKey) {
-            return new ToolResponse(true, result, null, idempotencyKey);
+    public record ToolError(String code, String nextAction, List<String> missingFields, String customerMessage) {
+        public ToolError {
+            missingFields = missingFields == null ? List.of() : List.copyOf(missingFields);
+        }
+    }
+
+    public record ToolResponse(boolean ok, Object result, ToolError error, String idempotencyKey) {
+        static ToolResponse success(Object result) {
+            return new ToolResponse(true, result, null, null);
         }
 
-        static ToolResponse error(String error) {
-            return new ToolResponse(false, null, error == null ? "domain operation rejected" : error, null);
+        static ToolResponse error(String code, String nextAction, String customerMessage) {
+            return error(new ToolError(code, nextAction, List.of(), customerMessage));
+        }
+
+        static ToolResponse error(ToolError error) {
+            return new ToolResponse(false, null, error, null);
         }
     }
 }

--- a/apps/urbana-connect-api/src/main/resources/application-poc.yml
+++ b/apps/urbana-connect-api/src/main/resources/application-poc.yml
@@ -3,7 +3,7 @@ spring:
     name: urbana-connect-poc
   data:
     mongodb:
-      uri: ${MONGODB_URI:mongodb://localhost:27017/urbana-connect-poc}
+      uri: ${MONGODB_URI:mongodb://localhost:27017/urbana-connect-poc?replicaSet=rs0&retryWrites=true&retryReads=true&w=majority}
       auto-index-creation: true
 
 server:

--- a/apps/urbana-connect-api/src/main/resources/application.yml
+++ b/apps/urbana-connect-api/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: urbana-connect
   data:
     mongodb:
-      uri: ${MONGODB_URI:mongodb://localhost:27017/urbana-connect}
+      uri: ${MONGODB_URI:mongodb://localhost:27017/urbana-connect?replicaSet=rs0&retryWrites=true&retryReads=true&w=majority}
   mail:
     host: ${MAIL_HOST:}
     port: ${MAIL_PORT:587}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/config/MongoIndexProvisioningIntegrationTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/config/MongoIndexProvisioningIntegrationTest.java
@@ -1,0 +1,56 @@
+package br.com.urbana.connect.application.config;
+
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = "spring.data.mongodb.auto-index-creation=false")
+@Testcontainers
+class MongoIndexProvisioningIntegrationTest {
+
+    @Container
+    static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:6.0.5");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", () -> mongoDBContainer.getReplicaSetUrl("pee104-indexes"));
+    }
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Test
+    void provisionsReceptionMessageIdentityIndexesWhenAutoCreationIsDisabled() {
+        List<Document> indexes = mongoTemplate.getCollection("reception_messages")
+                .listIndexes()
+                .into(new ArrayList<>());
+
+        Document providerMessageIdIndex = indexWithKey(indexes, "providerMessageId");
+        assertThat(providerMessageIdIndex).isNotNull();
+        assertThat(providerMessageIdIndex.getBoolean("unique", false)).isTrue();
+        assertThat(providerMessageIdIndex.getBoolean("sparse", false)).isTrue();
+
+        Document eventIdIndex = indexWithKey(indexes, "eventId");
+        assertThat(eventIdIndex).isNotNull();
+        assertThat(eventIdIndex.getBoolean("unique", false)).isTrue();
+    }
+
+    private static Document indexWithKey(List<Document> indexes, String field) {
+        return indexes.stream()
+                .filter(index -> new Document(field, 1).equals(index.get("key")))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/conversation/ConversationFlowServiceIntegrationTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/conversation/ConversationFlowServiceIntegrationTest.java
@@ -247,10 +247,10 @@ class ConversationFlowServiceIntegrationTest {
         );
 
         assertThat(updated.currentStep()).isEqualTo(ConversationStep.AWAITING_CONFIRMATION);
-        assertThat(updated.selectedService()).isEqualTo(br.com.urbana.connect.domain.servicecatalog.model.ServiceType.DECOR);
+        assertThat(updated.selectedService()).isEqualTo(br.com.urbana.connect.domain.servicecatalog.model.ServiceType.DECOR_INTERIORES);
         verify(whatsAppMessageGateway).sendServicePresentation(
             eq(phoneNumber),
-            argThat(service -> service.type() == br.com.urbana.connect.domain.servicecatalog.model.ServiceType.DECOR)
+            argThat(service -> service.type() == br.com.urbana.connect.domain.servicecatalog.model.ServiceType.DECOR_INTERIORES)
         );
     }
 
@@ -284,10 +284,10 @@ class ConversationFlowServiceIntegrationTest {
         );
 
         assertThat(updated.currentStep()).isEqualTo(ConversationStep.AWAITING_CONFIRMATION);
-        assertThat(updated.selectedService()).isEqualTo(ServiceType.DECOR);
+        assertThat(updated.selectedService()).isEqualTo(ServiceType.DECOR_INTERIORES);
         verify(whatsAppMessageGateway).sendServicePresentation(
             eq(phoneNumber),
-            argThat(service -> service.type() == ServiceType.DECOR)
+            argThat(service -> service.type() == ServiceType.DECOR_INTERIORES)
         );
     }
 
@@ -340,7 +340,7 @@ class ConversationFlowServiceIntegrationTest {
         );
 
         assertThat(updated.currentStep()).isEqualTo(ConversationStep.AWAITING_TERMS);
-        assertThat(updated.context().slotValue(ConversationSlotName.CONFIRMED_SERVICE)).contains("DECOR");
+        assertThat(updated.context().slotValue(ConversationSlotName.CONFIRMED_SERVICE)).contains("DECOR_INTERIORES");
         verify(whatsAppMessageGateway).sendTermsOfUse(phoneNumber);
     }
 
@@ -475,7 +475,7 @@ class ConversationFlowServiceIntegrationTest {
         assertThat(updated.context().paymentMethod()).isEqualTo("PIX");
         verify(whatsAppMessageGateway).sendPaymentLink(
             eq(phoneNumber),
-            argThat(service -> service.type() == br.com.urbana.connect.domain.servicecatalog.model.ServiceType.DECOR)
+            argThat(service -> service.type() == br.com.urbana.connect.domain.servicecatalog.model.ServiceType.DECOR_INTERIORES)
         );
         verify(whatsAppMessageGateway).sendClosingMessage(phoneNumber);
     }
@@ -487,7 +487,7 @@ class ConversationFlowServiceIntegrationTest {
 
         advanceToAwaitingPaymentMethod(phoneNumber, now);
         var removedService = mongoTemplate.findAndRemove(
-            Query.query(Criteria.where("type").is(br.com.urbana.connect.domain.servicecatalog.model.ServiceType.DECOR)),
+            Query.query(Criteria.where("type").is(br.com.urbana.connect.domain.servicecatalog.model.ServiceType.DECOR_INTERIORES)),
             ServiceCatalogDocument.class
         );
 
@@ -501,7 +501,7 @@ class ConversationFlowServiceIntegrationTest {
             verify(whatsAppMessageGateway).sendDirectTriageOptions(eq(phoneNumber), anyList());
             verify(whatsAppMessageGateway, times(0)).sendClosingMessage(phoneNumber);
             assertThat(output)
-                    .contains("Servico DECOR nao encontrado para enviar link de pagamento para +5583***1111");
+                    .contains("Servico DECOR_INTERIORES nao encontrado para enviar link de pagamento para +5583***1111");
         } finally {
             if (removedService != null) {
                 mongoTemplate.save(removedService);

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/conversation/ConversationResponseValidatorTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/conversation/ConversationResponseValidatorTest.java
@@ -52,6 +52,32 @@ class ConversationResponseValidatorTest {
     }
 
     @Test
+    void shouldAcceptLegacyDecorAliasWhenCanonicalCatalogContainsDecorInteriores() {
+        ResponseValidationResult result = validator.validate(
+            stepContract(),
+            new ConversationalAiReply(
+                "Decor parece a melhor opção para isso 😊",
+                ConversationalAiAction.PROPOSE_SERVICE,
+                List.of(new ConversationSlotUpdate(
+                    ConversationSlotName.SUGGESTED_SERVICE,
+                    "DECOR",
+                    ConversationSlotLevel.TENTATIVE,
+                    0.92,
+                    ConversationSlotSource.INFERRED
+                )),
+                0.92,
+                true,
+                ConversationStep.AWAITING_CONFIRMATION,
+                false,
+                null
+            ),
+            List.of(canonicalDecorInteriores())
+        );
+
+        assertThat(result.valid()).isTrue();
+    }
+
+    @Test
     void shouldRejectReplyWithMetaSpeech() {
         ResponseValidationResult result = validator.validate(
             stepContract(),
@@ -202,6 +228,20 @@ class ConversationResponseValidatorTest {
             "Apresentação Decor",
             new BigDecimal("490.00"),
             "https://pay.example/decor",
+            null,
+            true
+        );
+    }
+
+    private ServiceCatalogItem canonicalDecorInteriores() {
+        return new ServiceCatalogItem(
+            ServiceType.DECOR_INTERIORES,
+            "Decor Interiores",
+            "🛋️",
+            "Renovar espaço interno",
+            "Apresentação Decor Interiores",
+            new BigDecimal("490.00"),
+            "https://pay.example/decor-interiores",
             null,
             true
         );

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/health/MongoConnectivityVerifierTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/health/MongoConnectivityVerifierTest.java
@@ -1,0 +1,41 @@
+package br.com.urbana.connect.application.health;
+
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.argThat;
+
+class MongoConnectivityVerifierTest {
+
+    @Test
+    void shouldNotReportAvailableWhenMongoDoesNotAdvertiseAReplicaSet() {
+        MongoTemplate mongoTemplate = mock(MongoTemplate.class);
+        given(mongoTemplate.executeCommand(any(Document.class)))
+                .willReturn(new Document("ok", 1).append("isWritablePrimary", true));
+
+        MongoConnectivityVerifier verifier = new MongoConnectivityVerifier(mongoTemplate);
+
+        assertThat(verifier.isAvailable()).isFalse();
+        verify(mongoTemplate).executeCommand(argThat((Document command) -> command.containsKey("hello")));
+    }
+
+    @Test
+    void shouldReportAvailableWhenMongoAdvertisesAWritableReplicaSetPrimary() {
+        MongoTemplate mongoTemplate = mock(MongoTemplate.class);
+        given(mongoTemplate.executeCommand(any(Document.class)))
+                .willReturn(new Document("ok", 1)
+                        .append("setName", "rs0")
+                        .append("isWritablePrimary", true));
+
+        MongoConnectivityVerifier verifier = new MongoConnectivityVerifier(mongoTemplate);
+
+        assertThat(verifier.isAvailable()).isTrue();
+        verify(mongoTemplate).executeCommand(argThat((Document command) -> command.containsKey("hello")));
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/CommercialPolicyServiceTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/CommercialPolicyServiceTest.java
@@ -8,8 +8,10 @@ import br.com.urbana.connect.domain.reception.model.ReceptionConversation;
 import br.com.urbana.connect.domain.reception.model.ReceptionMode;
 import br.com.urbana.connect.domain.reception.model.CommercialStage;
 import br.com.urbana.connect.domain.reception.model.TermsStatus;
+import br.com.urbana.connect.domain.servicecatalog.model.AreaRule;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 
@@ -20,34 +22,33 @@ class CommercialPolicyServiceTest {
     private static final Instant NOW = Instant.parse("2026-08-05T12:00:00Z");
 
     @Test
-    void enforcesIcpBeforeTermsThenTermsBeforePaymentAndHumanApprovalBeforeBriefing() {
+    void allowsTermsAndPaymentWithoutOptionalIcpAndKeepsHumanApprovalBeforeBriefing() {
         CommercialPolicyService policy = new CommercialPolicyService();
         ReceptionConversation conversation = ReceptionConversation.start("contact-1", NOW);
-        List<CustomerFact> facts = List.of(
-                CustomerFact.confirmed("contact-1", "PRONOUN_PREFERENCE", "PREFER_NOT_TO_ANSWER", "m-1", NOW),
-                CustomerFact.confirmed("contact-1", "FIRST_TIME_HIRING", "YES", "m-2", NOW),
-                CustomerFact.confirmed("contact-1", "OCCUPATION", "MICROEMPREENDEDOR", "m-3", NOW));
 
-        assertThat(policy.isIcpComplete(facts, NOW)).isTrue();
-        ReceptionConversation incomplete = conversation.selectService("DECOR", NOW);
-        assertThatThrownBy(() -> policy.presentTerms(incomplete, facts.subList(0, 2), NOW))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("ICP");
+        assertThat(policy.mandatoryIcpFields())
+                .containsExactly("PRONOUN_PREFERENCE", "FIRST_TIME_HIRING", "OCCUPATION");
+        assertThat(policy.missingIcpFields(List.of(), NOW))
+                .containsExactly("PRONOUN_PREFERENCE", "FIRST_TIME_HIRING", "OCCUPATION");
+        assertThat(policy.isIcpComplete(List.of(), NOW)).isFalse();
 
-        conversation = policy.selectService(conversation, "DECOR", NOW);
-        conversation = policy.presentTerms(conversation, facts, NOW);
+        conversation = policy.selectService(conversation, "DECOR_INTERIORES", NOW);
+        conversation = policy.presentTerms(conversation, List.of(), NOW);
         assertThat(conversation.termsStatus()).isEqualTo(TermsStatus.PRESENTED);
         ReceptionConversation termsPresented = conversation;
-        assertThatThrownBy(() -> policy.preparePayment(termsPresented, facts, "PIX", NOW))
+        assertThatThrownBy(() -> policy.preparePayment(termsPresented, List.of(), "PIX", NOW))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("accepted");
 
-        conversation = policy.acceptTerms(conversation, NOW);
+        assertThatThrownBy(() -> policy.acceptTerms(termsPresented, "ok", NOW))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("clear");
+        conversation = policy.acceptTerms(conversation, "aceito os termos", NOW);
         ReceptionConversation termsAccepted = conversation;
-        assertThatThrownBy(() -> policy.preparePayment(termsAccepted, facts, "CRYPTO", NOW))
+        assertThatThrownBy(() -> policy.preparePayment(termsAccepted, List.of(), "CRYPTO", NOW))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("not approved");
-        conversation = policy.preparePayment(conversation, facts, "PIX", NOW);
+        conversation = policy.preparePayment(conversation, List.of(), "PIX", NOW);
         assertThat(conversation.paymentStatus()).isEqualTo(PaymentStatus.PREPARED);
         conversation = policy.receivePaymentProof(conversation, NOW);
         assertThat(conversation.paymentStatus()).isEqualTo(PaymentStatus.PROOF_RECEIVED);
@@ -58,7 +59,115 @@ class CommercialPolicyServiceTest {
 
         conversation = policy.approvePaymentProof(conversation, NOW);
         assertThat(conversation.paymentStatus()).isEqualTo(PaymentStatus.CONFIRMED);
-        assertThat(policy.briefingFor(conversation)).containsIgnoringCase("briefing").contains("DECOR");
+        assertThat(policy.briefingFor(conversation)).containsIgnoringCase("briefing").contains("DECOR_INTERIORES");
+    }
+
+    @Test
+    void treatsRefusalAsAnsweredAndUsesOnlyTheLatestReusableIcpVersion() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        CustomerFact preference = CustomerFact.confirmed(
+                "contact-1", "PRONOUN_PREFERENCE", CommercialPolicyService.PREFER_NOT_TO_ANSWER,
+                "m-preference", NOW);
+        CustomerFact firstHiring = CustomerFact.confirmed(
+                "contact-1", "FIRST_TIME_HIRING", "NÃO INFORMADO", "m-first", NOW);
+        CustomerFact oldOccupation = CustomerFact.confirmed(
+                "contact-1", "OCCUPATION", "ARQUITETA", "m-old", NOW.minusSeconds(30));
+        CustomerFact latestOccupation = CustomerFact.confirmed(
+                "contact-1", "OCCUPATION", "DESIGNER", "m-latest", NOW.minusSeconds(10));
+        CustomerFact supersededOccupation = oldOccupation.supersede(
+                latestOccupation.id(), latestOccupation.validFrom());
+        CustomerFact tentativeNeed = CustomerFact.tentative(
+                "contact-1", "NEED", "sala", "m-need", NOW);
+
+        assertThat(policy.missingIcpFields(
+                List.of(preference, firstHiring, supersededOccupation, latestOccupation, tentativeNeed), NOW))
+                .isEmpty();
+        assertThat(policy.isIcpComplete(
+                List.of(preference, firstHiring, supersededOccupation, latestOccupation, tentativeNeed), NOW))
+                .isTrue();
+    }
+
+    @Test
+    void tentativeLatestVersionDoesNotFallBackToAnOlderConfirmedIcpValue() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        CustomerFact oldOccupation = CustomerFact.confirmed(
+                "contact-1", "OCCUPATION", "ARQUITETA", "m-old", NOW.minusSeconds(30));
+        CustomerFact tentativeLatestOccupation = CustomerFact.tentative(
+                "contact-1", "OCCUPATION", "DESIGNER", "m-tentative", NOW.minusSeconds(10));
+
+        assertThat(policy.missingIcpFields(List.of(oldOccupation, tentativeLatestOccupation), NOW))
+                .containsExactly("PRONOUN_PREFERENCE", "FIRST_TIME_HIRING", "OCCUPATION");
+    }
+
+    @Test
+    void exposesExactlyTheFourRichCanonicalServicesWithoutLegacyDecorAlias() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+
+        assertThat(policy.services())
+                .hasSize(4)
+                .extracting(CommercialPolicyService.ServiceFixture::serviceType)
+                .containsExactly("DECOR_INTERIORES", "DECOR_PINTURA", "DECOR_FACHADA", "DECOR_REFORMA");
+        assertThat(policy.services())
+                .noneMatch(service -> "DECOR".equals(service.serviceType()));
+
+        assertThat(policy.service("DECOR_INTERIORES"))
+                .extracting(CommercialPolicyService.ServiceFixture::price,
+                        CommercialPolicyService.ServiceFixture::areaRule)
+                .containsExactly(new BigDecimal("400.00"), AreaRule.UP_TO_20_SQM_PER_ENVIRONMENT);
+        assertThat(policy.service("DECOR_PINTURA"))
+                .extracting(CommercialPolicyService.ServiceFixture::price,
+                        CommercialPolicyService.ServiceFixture::areaRule)
+                .containsExactly(new BigDecimal("250.00"), AreaRule.UNLIMITED_BY_CATALOG);
+        assertThat(policy.service("DECOR_FACHADA"))
+                .extracting(CommercialPolicyService.ServiceFixture::price,
+                        CommercialPolicyService.ServiceFixture::areaRule)
+                .containsExactly(new BigDecimal("350.00"), AreaRule.UNLIMITED_BY_CATALOG);
+        assertThat(policy.service("DECOR_REFORMA"))
+                .extracting(CommercialPolicyService.ServiceFixture::price,
+                        CommercialPolicyService.ServiceFixture::areaRule)
+                .containsExactly(new BigDecimal("450.00"), AreaRule.UP_TO_20_SQM_PER_ENVIRONMENT);
+
+        policy.services().forEach(service -> {
+            assertThat(service.deliverables())
+                    .containsExactly("Manual PDF", "Tour Virtual", "3 opções de solução", "2 rodadas consolidadas");
+            assertThat(service.process()).anyMatch(value -> value.equals("briefing"));
+            assertThat(service.process()).anyMatch(value -> value.equals("medidas, fotos e vídeos"));
+            assertThat(service.process()).anyMatch(value -> value.contains("Google Meet"));
+            assertThat(service.process()).anyMatch(value -> value.equals("produção"));
+            assertThat(service.process()).anyMatch(value -> value.contains("7 dias úteis"));
+            assertThat(service.process()).anyMatch(value -> value.contains("e-mail"));
+            assertThat(service.responsibilities()).isNotEmpty();
+            assertThat(service.exclusions()).isNotEmpty();
+            assertThat(service.support()).contains("3 meses").containsIgnoringCase("sem visita");
+            assertThat(service.termsUrl()).startsWith("https://fixtures.urbana.local/");
+            assertThat(service.paymentUrl()).startsWith("https://fixtures.urbana.local/");
+            assertThat(service.briefingUrl()).startsWith("https://fixtures.urbana.local/");
+            assertThat(service.briefingText()).contains(service.serviceType());
+        });
+
+        assertThat(policy.service("DECOR_INTERIORES").scope()).contains("layout");
+        assertThat(policy.service("DECOR_PINTURA").scope())
+                .contains("pintura", "desenhos", "tintas")
+                .doesNotContain("20 m²");
+        assertThat(policy.service("DECOR_FACHADA").scope()).containsIgnoringCase("fachada").contains("externa");
+        assertThat(policy.service("DECOR_REFORMA").scope()).containsIgnoringCase("reforma");
+    }
+
+    @Test
+    void appliesAreaRulesOnlyToInteriorsAndReformaAndRoutesExcessToArchitect() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+
+        assertThat(policy.isAreaWithinCatalog("DECOR_INTERIORES", new BigDecimal("20"))).isTrue();
+        assertThat(policy.isAreaWithinCatalog("DECOR_INTERIORES", new BigDecimal("20.01"))).isFalse();
+        assertThat(policy.requiresArchitectAreaReview("DECOR_INTERIORES", new BigDecimal("20.01"))).isTrue();
+        assertThat(policy.isAreaWithinCatalog("DECOR_REFORMA", new BigDecimal("20"))).isTrue();
+        assertThat(policy.isAreaWithinCatalog("DECOR_REFORMA", new BigDecimal("20.01"))).isFalse();
+        assertThat(policy.requiresArchitectAreaReview("DECOR_REFORMA", new BigDecimal("21"))).isTrue();
+
+        assertThat(policy.isAreaWithinCatalog("DECOR_PINTURA", new BigDecimal("1000"))).isTrue();
+        assertThat(policy.requiresArchitectAreaReview("DECOR_PINTURA", new BigDecimal("1000"))).isFalse();
+        assertThat(policy.isAreaWithinCatalog("DECOR_FACHADA", new BigDecimal("1000"))).isTrue();
+        assertThat(policy.requiresArchitectAreaReview("DECOR_FACHADA", new BigDecimal("1000"))).isFalse();
     }
 
     @Test
@@ -73,7 +182,7 @@ class CommercialPolicyServiceTest {
         assertThatThrownBy(() -> policy.reconcileOutput(requestedBriefing, conversation))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> policy.reconcileOutput(new AgentOutput(
-                "Briefing DECOR: fixture local.", AgentNextAction.AWAIT_CUSTOMER), conversation))
+                "Segue o briefing DECOR: fixture local.", AgentNextAction.AWAIT_CUSTOMER), conversation))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> policy.reconcileOutput(new AgentOutput(
                 "Pagamento confirmado.", AgentNextAction.NONE), conversation))
@@ -81,10 +190,91 @@ class CommercialPolicyServiceTest {
     }
 
     @Test
+    void doesNotTreatNegativePaymentWordingAsConfirmation() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        ReceptionConversation conversation = ReceptionConversation.start("contact-1", NOW);
+        AgentOutput candidate = new AgentOutput(
+                "Nenhum pagamento foi realizado ou confirmado.", AgentNextAction.AWAIT_CUSTOMER);
+
+        assertThat(policy.reconcileOutput(candidate, conversation)).isEqualTo(candidate);
+    }
+
+    @Test
+    void onlyAllowsWaitingForPaymentApprovalAfterProofWasReceived() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        ReceptionConversation conversation = new ReceptionConversation("conversation-1", "contact-1",
+                ReceptionMode.AI, CommercialStage.PAYMENT, "DECOR", TermsStatus.ACCEPTED,
+                PaymentStatus.NOT_STARTED, null, NOW, NOW, 1);
+
+        assertThatThrownBy(() -> policy.reconcileOutput(new AgentOutput(
+                "Vou aguardar a confirmação do pagamento.", AgentNextAction.AWAIT_PAYMENT_APPROVAL), conversation))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("proof");
+    }
+
+    @Test
+    void allowsExplainingThatBriefingComesAfterPaymentWithoutClaimingItsRelease() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        ReceptionConversation conversation = ReceptionConversation.start("contact-1", NOW);
+        AgentOutput explanation = new AgentOutput(
+                "O briefing faz parte do processo e será enviado após a confirmação do pagamento.",
+                AgentNextAction.AWAIT_CUSTOMER);
+
+        assertThat(policy.reconcileOutput(explanation, conversation)).isEqualTo(explanation);
+    }
+
+    @Test
+    void allowsRichServiceExplanationThatMentionsBriefingAndFutureDeliveryWithoutClaimingRelease() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        ReceptionConversation conversation = ReceptionConversation.start("contact-1", NOW);
+        AgentOutput explanation = new AgentOutput(
+                "A consultoria inclui briefing, análise de medidas, fotos e vídeos, reunião pelo Google Meet, "
+                        + "Manual em PDF e Tour Virtual. A entrega final é enviada por e-mail.",
+                AgentNextAction.AWAIT_CUSTOMER);
+
+        assertThat(policy.reconcileOutput(explanation, conversation)).isEqualTo(explanation);
+    }
+
+    @Test
+    void rejectsPrematurePaymentLinkAndBriefingReadyClaims() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        ReceptionConversation conversation = ReceptionConversation.start("contact-1", NOW);
+
+        assertThatThrownBy(() -> policy.reconcileOutput(new AgentOutput(
+                "Para pagar, acesse https://fixtures.urbana.local/payment/decor.",
+                AgentNextAction.AWAIT_CUSTOMER), conversation))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> policy.reconcileOutput(new AgentOutput(
+                "Seu briefing está pronto para preencher.", AgentNextAction.AWAIT_CUSTOMER), conversation))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void doesNotTreatAnUnrelatedApprovalInTheServiceExplanationAsPaymentConfirmation() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        ReceptionConversation conversation = ReceptionConversation.start("contact-1", NOW);
+        AgentOutput explanation = new AgentOutput(
+                "O pagamento é antecipado e o prazo pode pausar enquanto houver pendência de feedback ou aprovação.",
+                AgentNextAction.AWAIT_CUSTOMER);
+
+        assertThat(policy.reconcileOutput(explanation, conversation)).isEqualTo(explanation);
+    }
+
+    @Test
+    void acceptsClearTermsWithNaturalQualifiersButNotBareAcceptance() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+
+        assertThat(policy.isExplicitTermsAcceptance(
+                "Aceito claramente os termos apresentados e quero seguir com a contratação.")).isTrue();
+        assertThat(policy.isExplicitTermsAcceptance("Aceito")).isFalse();
+        assertThat(policy.isExplicitTermsAcceptance("Não aceito os termos.")).isFalse();
+    }
+
+    @Test
     void resolvesOnlyApprovedInteractiveServiceReplyIds() {
         CommercialPolicyService policy = new CommercialPolicyService();
 
-        assertThat(policy.serviceTypeForInteractiveReply("service.decor")).isEqualTo("DECOR");
+        assertThat(policy.serviceTypeForInteractiveReply("service.decor")).isEqualTo("DECOR_INTERIORES");
         assertThat(policy.serviceTypeForInteractiveReply("service.decor_reforma")).isEqualTo("DECOR_REFORMA");
         assertThatThrownBy(() -> policy.serviceTypeForInteractiveReply("service.paisagismo"))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -151,7 +341,7 @@ class CommercialPolicyServiceTest {
     }
 
     @Test
-    void allowsFutureHumanApprovalWordingReturnedByHermes() {
+    void rejectsHumanApprovalWaitReturnedByHermesBeforeProof() {
         CommercialPolicyService policy = new CommercialPolicyService();
         ReceptionConversation conversation = new ReceptionConversation("conversation-1", "contact-1",
                 ReceptionMode.AI, CommercialStage.PAYMENT, "DECOR", TermsStatus.ACCEPTED,
@@ -161,7 +351,9 @@ class CommercialPolicyServiceTest {
                         + "ainda não posso confirmar a aprovação.",
                 AgentNextAction.AWAIT_PAYMENT_APPROVAL);
 
-        assertThat(policy.reconcileOutput(candidate, conversation)).isEqualTo(candidate);
+        assertThatThrownBy(() -> policy.reconcileOutput(candidate, conversation))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("proof");
     }
 
     @Test

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/HumanHandoffServiceTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/HumanHandoffServiceTest.java
@@ -41,7 +41,7 @@ class HumanHandoffServiceTest {
     private static final Instant NOW = Instant.parse("2026-08-05T12:00:00Z");
 
     @Test
-    void humanModePersistsInboundAndBlocksWithoutCallingHermesOrPublishingOutbound() {
+    void humanModePersistsInboundPublishesTheSingleHandoffAckAndBlocksHermes() {
         HermesSessionService hermes = mock(HermesSessionService.class);
         ReceptionConversationGateway conversations = mock(ReceptionConversationGateway.class);
         CustomerFactGateway facts = mock(CustomerFactGateway.class);
@@ -65,8 +65,11 @@ class HumanHandoffServiceTest {
         assertThat(receipt.output()).isNull();
         verifyNoInteractions(hermes);
         ArgumentCaptor<ReceptionMessage> messages = ArgumentCaptor.forClass(ReceptionMessage.class);
-        verify(transcript).appendIfAbsent(messages.capture());
-        assertThat(messages.getAllValues()).allMatch(message -> message.senderType() == ReceptionMessageSender.CONTACT);
+        verify(transcript, times(2)).appendIfAbsent(messages.capture());
+        assertThat(messages.getAllValues()).extracting(ReceptionMessage::senderType)
+                .containsExactly(ReceptionMessageSender.CONTACT, ReceptionMessageSender.URBA);
+        assertThat(messages.getAllValues().get(1).text())
+                .isEqualTo(StatefulDomainToolService.HUMAN_HANDOFF_ACK);
         ArgumentCaptor<ReceptionTurn> savedTurns = ArgumentCaptor.forClass(ReceptionTurn.class);
         verify(turns).save(savedTurns.capture());
         assertThat(savedTurns.getValue().status()).isEqualTo(ReceptionTurnStatus.BLOCKED_BY_HUMAN);
@@ -88,7 +91,9 @@ class HumanHandoffServiceTest {
         Map<String, Object> result = tools.execute(DomainToolName.REQUEST_HUMAN_HANDOFF,
                 "poc:ana", Map.of("reason", "não consigo resolver"), new ToolExecutionContext(lease, NOW));
 
-        assertThat(result).containsEntry("status", "HUMAN_MODE");
+        assertThat(result).containsEntry("status", "TRANSFERRED")
+                .containsEntry("ownership", "HUMAN")
+                .containsKey("handoffId");
         ArgumentCaptor<ReceptionConversation> saved = ArgumentCaptor.forClass(ReceptionConversation.class);
         verify(conversations).save(saved.capture());
         assertThat(saved.getValue().mode()).isEqualTo(ReceptionMode.HUMAN);
@@ -141,7 +146,12 @@ class HumanHandoffServiceTest {
 
         assertThat(receipt.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.BLOCKED_BY_HUMAN);
         assertThat(receipt.output()).isNull();
-        verify(transcript).appendIfAbsent(any(ReceptionMessage.class));
+        ArgumentCaptor<ReceptionMessage> messages = ArgumentCaptor.forClass(ReceptionMessage.class);
+        verify(transcript, times(2)).appendIfAbsent(messages.capture());
+        assertThat(messages.getAllValues()).filteredOn(message -> message.senderType() == ReceptionMessageSender.URBA)
+                .singleElement().extracting(ReceptionMessage::text)
+                .isEqualTo("Vou encaminhar sua conversa para a arquiteta, que continuará com você por aqui.");
+        assertThat(messages.getAllValues()).noneMatch(message -> "Vou transferir você agora.".equals(message.text()));
         ArgumentCaptor<ReceptionTurn> saved = ArgumentCaptor.forClass(ReceptionTurn.class);
         verify(turns, times(2)).save(saved.capture());
         assertThat(saved.getAllValues().get(1).status()).isEqualTo(ReceptionTurnStatus.BLOCKED_BY_HUMAN);

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionFailureRecoveryTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionFailureRecoveryTest.java
@@ -112,7 +112,8 @@ class ReceptionFailureRecoveryTest {
                         "Oi", NOW));
 
         assertThat(retry.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.COMPLETED);
-        assertThat(retry.output().message()).isEqualTo("recovered");
+        assertThat(retry.output().message())
+                .isEqualTo("Olá! Sou a Urba, assistente virtual da Urbana do Brasil. recovered");
         verify(sessions, times(2)).chat(eq("session-1"), any());
         ArgumentCaptor<ReceptionMessage> allMessages = ArgumentCaptor.forClass(ReceptionMessage.class);
         verify(transcript, times(2)).appendIfAbsent(allMessages.capture());

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionOrchestratorTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionOrchestratorTest.java
@@ -12,6 +12,11 @@ import br.com.urbana.connect.domain.reception.model.ReceptionMessage;
 import br.com.urbana.connect.domain.reception.model.ReceptionTurn;
 import br.com.urbana.connect.domain.reception.model.ReceptionTurnStatus;
 import br.com.urbana.connect.domain.reception.model.PaymentStatus;
+import br.com.urbana.connect.domain.reception.model.ReceptionMessageSender;
+import br.com.urbana.connect.domain.reception.model.ReceptionMessageType;
+import br.com.urbana.connect.domain.reception.model.ReceptionMode;
+import br.com.urbana.connect.domain.reception.model.ResumeStatus;
+import br.com.urbana.connect.domain.reception.model.ReceptionEventIds;
 import br.com.urbana.connect.domain.reception.model.TermsStatus;
 import br.com.urbana.connect.domain.reception.model.CommercialStage;
 import br.com.urbana.connect.domain.reception.port.out.AgentSessionLinkGateway;
@@ -20,6 +25,7 @@ import br.com.urbana.connect.domain.reception.model.AgentSessionLink;
 import br.com.urbana.connect.domain.reception.port.out.CustomerFactGateway;
 import br.com.urbana.connect.domain.reception.port.out.DomainToolInvocationGateway;
 import br.com.urbana.connect.domain.reception.port.out.HermesSessionsGateway;
+import br.com.urbana.connect.domain.reception.port.out.HermesResumeGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionConversationGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTranscriptGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTurnGateway;
@@ -53,7 +59,7 @@ class ReceptionOrchestratorTest {
     private static final Instant NOW = Instant.parse("2026-08-05T12:00:00Z");
 
     @Test
-    void persistsInboundBeforeDispatchAndPublishesHermesTextVerbatim() {
+    void persistsInboundBeforeDispatchAndAddsIdentityOnlyToTheFirstHermesResponse() {
         MemoryConversation conversations = new MemoryConversation();
         MemoryTranscript transcript = new MemoryTranscript();
         MemoryTurns turns = new MemoryTurns();
@@ -72,13 +78,14 @@ class ReceptionOrchestratorTest {
                 "event-1", "poc:ana", br.com.urbana.connect.domain.reception.model.ReceptionMessageType.TEXT,
                 inboundText, NOW));
 
+        String expectedFirstResponse = "Olá! Sou a Urba, assistente virtual da Urbana do Brasil. " + hermesText;
         assertThat(receipt.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.COMPLETED);
-        assertThat(receipt.output().message()).isEqualTo(hermesText);
+        assertThat(receipt.output().message()).isEqualTo(expectedFirstResponse);
         assertThat(transcript.messages).extracting(ReceptionMessage::direction)
                 .containsExactlyInAnyOrder(ReceptionMessageDirection.INBOUND, ReceptionMessageDirection.OUTBOUND);
         assertThat(transcript.messages).filteredOn(message ->
                 message.direction() == ReceptionMessageDirection.OUTBOUND)
-                .singleElement().extracting(ReceptionMessage::text).isEqualTo(hermesText);
+                .singleElement().extracting(ReceptionMessage::text).isEqualTo(expectedFirstResponse);
         assertThat(transcript.messages).filteredOn(message ->
                 message.direction() == ReceptionMessageDirection.INBOUND)
                 .singleElement().extracting(ReceptionMessage::text).isEqualTo(inboundText);
@@ -88,8 +95,46 @@ class ReceptionOrchestratorTest {
                 .projection("poc:ana").get("messages");
         assertThat(projectedMessages).filteredOn(message ->
                 message.direction() == ReceptionMessageDirection.OUTBOUND)
-                .singleElement().extracting(ReceptionMessage::text).isEqualTo(hermesText);
+                .singleElement().extracting(ReceptionMessage::text).isEqualTo(expectedFirstResponse);
         assertThat(sessions.chatCalls).isEqualTo(1);
+    }
+
+    @Test
+    void identifiesUrbaAndUrbanaDoBrasilInTheFirstOutboundWhenHermesOmitsTheIntroduction() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryTranscript transcript = new MemoryTranscript();
+        ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(
+                new HermesSessionService(new FakeSessions("Olá, Emanuel! Como posso ajudar?"), new MemoryLinks()),
+                conversations, new MemoryFacts(), transcript, new MemoryTurns(), new CommercialPolicyService(),
+                new ReceptionTurnCoordinator(), java.time.Clock.fixed(NOW, java.time.ZoneOffset.UTC));
+
+        ReceptionOrchestrator.TurnReceipt receipt = orchestrator.process(new InboundConversationEvent(
+                "first-message", "poc:emanuel", ReceptionMessageType.TEXT, "Olá", NOW));
+
+        assertThat(receipt.output().message())
+                .contains("Urba")
+                .contains("Urbana do Brasil")
+                .endsWith("Olá, Emanuel! Como posso ajudar?");
+        assertThat(transcript.messages).filteredOn(message ->
+                message.direction() == ReceptionMessageDirection.OUTBOUND)
+                .singleElement().extracting(ReceptionMessage::text)
+                .isEqualTo(receipt.output().message());
+    }
+
+    @Test
+    void doesNotDuplicateTheFirstIntroductionWhenHermesAlreadyIdentifiesUrbaAndUrbanaDoBrasil() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryTranscript transcript = new MemoryTranscript();
+        String hermesText = "Olá! Sou a Urba, assistente virtual da Urbana do Brasil. Como posso ajudar?";
+        ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(
+                new HermesSessionService(new FakeSessions(hermesText), new MemoryLinks()), conversations,
+                new MemoryFacts(), transcript, new MemoryTurns(), new CommercialPolicyService(),
+                new ReceptionTurnCoordinator(), java.time.Clock.fixed(NOW, java.time.ZoneOffset.UTC));
+
+        ReceptionOrchestrator.TurnReceipt receipt = orchestrator.process(new InboundConversationEvent(
+                "first-message-already-identified", "poc:emanuel", ReceptionMessageType.TEXT, "Olá", NOW));
+
+        assertThat(receipt.output().message()).isEqualTo(hermesText);
     }
 
     @Test
@@ -115,9 +160,10 @@ class ReceptionOrchestratorTest {
         assertThat(transcript.messages).filteredOn(message ->
                 message.direction() == ReceptionMessageDirection.OUTBOUND)
                 .extracting(ReceptionMessage::text)
-                .containsExactly("Resposta textual do Hermes", "Resposta textual do Hermes", "Resposta textual do Hermes")
-                .allMatch(text -> !text.contains("Olá! Sou a Urba")
-                        && !text.contains("Não consigo confirmar"));
+                .containsExactly(
+                        "Olá! Sou a Urba, assistente virtual da Urbana do Brasil. Resposta textual do Hermes",
+                        "Resposta textual do Hermes",
+                        "Resposta textual do Hermes");
         assertThat(sessions.chatCalls).isEqualTo(3);
     }
 
@@ -147,7 +193,57 @@ class ReceptionOrchestratorTest {
     }
 
     @Test
-    void presentsTermsAfterACompleteIcpAndApprovedServiceArePersisted() {
+    void doesNotTreatBareAcceptanceAsAContractualTermsAcceptance() {
+        MemoryConversation conversations = new MemoryConversation();
+        conversations.value = new ReceptionConversation("conversation-1", "poc:ana",
+                br.com.urbana.connect.domain.reception.model.ReceptionMode.AI,
+                CommercialStage.TERMS, "DECOR", TermsStatus.PRESENTED,
+                PaymentStatus.NOT_STARTED, null, NOW, NOW, 1);
+        ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(
+                new HermesSessionService(new FakeSessions("Ainda preciso do aceite claro"), new MemoryLinks()),
+                conversations, new MemoryFacts(), new MemoryTranscript(), new MemoryTurns(),
+                new CommercialPolicyService(), new ReceptionTurnCoordinator(),
+                java.time.Clock.fixed(NOW, java.time.ZoneOffset.UTC));
+
+        orchestrator.process(new InboundConversationEvent(
+                "terms-ambiguous", "poc:ana", br.com.urbana.connect.domain.reception.model.ReceptionMessageType.TEXT,
+                "Aceito", NOW));
+
+        assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.PRESENTED);
+        assertThat(conversations.value.paymentStatus()).isEqualTo(PaymentStatus.NOT_STARTED);
+    }
+
+    @Test
+    void neverPublishesPaymentApprovalAfterARejectedClaimWhenNoProofWasReceived() {
+        MemoryConversation conversations = new MemoryConversation();
+        conversations.value = new ReceptionConversation("conversation-1", "poc:ana",
+                ReceptionMode.AI, CommercialStage.PAYMENT, "DECOR", TermsStatus.ACCEPTED,
+                PaymentStatus.NOT_STARTED, null, NOW, NOW, 1);
+        MemoryTranscript transcript = new MemoryTranscript();
+        ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(
+                new HermesSessionService(new FakeSessions("Pagamento confirmado."), new MemoryLinks()),
+                conversations, new MemoryFacts(), transcript, new MemoryTurns(),
+                new CommercialPolicyService(), new ReceptionTurnCoordinator(),
+                java.time.Clock.fixed(NOW, java.time.ZoneOffset.UTC));
+
+        ReceptionOrchestrator.TurnReceipt receipt = orchestrator.process(new InboundConversationEvent(
+                "premature-payment", "poc:ana", ReceptionMessageType.TEXT,
+                "Quero continuar", NOW));
+
+        assertThat(receipt.output().nextAction())
+                .isNotEqualTo(br.com.urbana.connect.domain.reception.model.AgentNextAction.AWAIT_PAYMENT_APPROVAL)
+                .isEqualTo(br.com.urbana.connect.domain.reception.model.AgentNextAction.AWAIT_CUSTOMER);
+        assertThat(receipt.output().message()).doesNotContainIgnoringCase(
+                "aguardar a confirmação do pagamento", "sistema", "ferramenta", "loop", "código");
+        assertThat(conversations.value.paymentStatus()).isEqualTo(PaymentStatus.NOT_STARTED);
+        assertThat(transcript.messages).filteredOn(message ->
+                message.direction() == ReceptionMessageDirection.OUTBOUND)
+                .singleElement().extracting(ReceptionMessage::text)
+                .isEqualTo(receipt.output().message());
+    }
+
+    @Test
+    void keepsTermsNotPresentedAfterAnInformativeTurnEvenWithASelectedService() {
         MemoryConversation conversations = new MemoryConversation();
         conversations.value = new ReceptionConversation("conversation-1", "poc:ana",
                 br.com.urbana.connect.domain.reception.model.ReceptionMode.AI, CommercialStage.ICP,
@@ -170,7 +266,7 @@ class ReceptionOrchestratorTest {
                 "Decor", NOW));
 
         assertThat(receipt.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.COMPLETED);
-        assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.PRESENTED);
+        assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.NOT_PRESENTED);
     }
 
     @Test
@@ -189,8 +285,10 @@ class ReceptionOrchestratorTest {
                 "non-prospect-1", "poc:ana", br.com.urbana.connect.domain.reception.model.ReceptionMessageType.TEXT,
                 "Quem está respondendo por aqui?", NOW));
 
+        String expectedFirstResponse =
+                "Olá! Sou a Urba, assistente virtual da Urbana do Brasil. Hermes handled the identity question";
         assertThat(receipt.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.COMPLETED);
-        assertThat(receipt.output().message()).isEqualTo("Hermes handled the identity question");
+        assertThat(receipt.output().message()).isEqualTo(expectedFirstResponse);
         assertThat(sessions.chatCalls).isEqualTo(1);
         assertThat(sessions.createdSessions).isEqualTo(1);
         assertThat(facts.saveCalls).isZero();
@@ -220,7 +318,8 @@ class ReceptionOrchestratorTest {
                 "non-prospect-3", "poc:ana", br.com.urbana.connect.domain.reception.model.ReceptionMessageType.TEXT,
                 "É uma parceria institucional.", NOW.plusSeconds(10)));
 
-        assertThat(identity.output().message()).isEqualTo("Hermes owns this conversation");
+        assertThat(identity.output().message())
+                .isEqualTo("Olá! Sou a Urba, assistente virtual da Urbana do Brasil. Hermes owns this conversation");
         assertThat(probe.output().message()).isEqualTo("Hermes owns this conversation");
         assertThat(handoff.output().message()).isEqualTo("Hermes owns this conversation");
         assertThat(sessions.chatCalls).isEqualTo(3);
@@ -246,11 +345,13 @@ class ReceptionOrchestratorTest {
                 "oi", NOW));
 
         assertThat(receipt.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.COMPLETED);
-        assertThat(receipt.output().message()).isEqualTo("not-json");
+        assertThat(receipt.output().message())
+                .isEqualTo("Olá! Sou a Urba, assistente virtual da Urbana do Brasil. not-json");
         assertThat(conversations.value.mode()).isEqualTo(br.com.urbana.connect.domain.reception.model.ReceptionMode.AI);
         assertThat(transcript.messages).filteredOn(message ->
                 message.direction() == ReceptionMessageDirection.OUTBOUND)
-                .singleElement().extracting(ReceptionMessage::text).isEqualTo("not-json");
+                .singleElement().extracting(ReceptionMessage::text)
+                .isEqualTo("Olá! Sou a Urba, assistente virtual da Urbana do Brasil. not-json");
     }
 
     @Test
@@ -278,7 +379,7 @@ class ReceptionOrchestratorTest {
     }
 
     @Test
-    void proofWaitsForHumanApprovalAndOnlyThenReleasesTheSelectedServiceBriefing() {
+    void proofTransfersToHumanAndOnlyApprovalRecordsThePaymentDecision() {
         MemoryConversation conversations = new MemoryConversation();
         conversations.value = new ReceptionConversation("conversation-1", "poc:ana",
                 br.com.urbana.connect.domain.reception.model.ReceptionMode.AI, CommercialStage.PAYMENT,
@@ -293,14 +394,209 @@ class ReceptionOrchestratorTest {
         ReceptionOrchestrator.TurnReceipt proof = orchestrator.process(new InboundConversationEvent(
                 "proof-1", "poc:ana", br.com.urbana.connect.domain.reception.model.ReceptionMessageType.PAYMENT_PROOF,
                 null, null, "poc/payment-proof-fixture.png", null, NOW, null));
-        ReceptionOrchestrator.TurnReceipt approval = orchestrator.approvePaymentProof("poc:ana");
 
-        assertThat(proof.output().message()).isEqualTo("recovered");
-        assertThat(proof.output().nextAction()).isEqualTo(br.com.urbana.connect.domain.reception.model.AgentNextAction.NONE);
+        assertThat(proof.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.BLOCKED_BY_HUMAN);
+        assertThat(proof.output()).isNull();
+        assertThat(conversations.value.mode()).isEqualTo(br.com.urbana.connect.domain.reception.model.ReceptionMode.HUMAN);
+        assertThat(transcript.messages).filteredOn(message ->
+                message.direction() == ReceptionMessageDirection.OUTBOUND)
+                .singleElement()
+                .extracting(ReceptionMessage::text)
+                .asString()
+                .contains("Recebi o comprovante", "arquiteta")
+                .doesNotContainIgnoringCase("briefing")
+                .doesNotContainIgnoringCase("sistema")
+                .doesNotContainIgnoringCase("exception");
+
+        ReceptionOrchestrator.TurnReceipt approval = orchestrator.approvePaymentProof("poc:ana");
+        ReceptionOrchestrator.TurnReceipt replay = orchestrator.approvePaymentProof("poc:ana");
+
+        assertThat(approval.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.BLOCKED_BY_HUMAN);
+        assertThat(approval.output()).isNull();
         assertThat(conversations.value.paymentStatus()).isEqualTo(PaymentStatus.CONFIRMED);
-        assertThat(approval.output().message()).contains("DECOR");
-        assertThat(sessions.chatCalls).isEqualTo(1);
-        assertThat(sessions.lastInput).isEmpty();
+        assertThat(replay.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.BLOCKED_BY_HUMAN);
+        assertThat(replay.output()).isNull();
+        assertThat(sessions.chatCalls).isEqualTo(0);
+        assertThat(sessions.lastInput).isNull();
+        assertThat(transcript.messages).filteredOn(message ->
+                message.direction() == ReceptionMessageDirection.OUTBOUND)
+                .hasSize(2);
+        assertThat(transcript.messages).filteredOn(message ->
+                message.senderType() == ReceptionMessageSender.HUMAN)
+                .singleElement()
+                .extracting(ReceptionMessage::text)
+                .isEqualTo("Pagamento confirmado pela arquiteta.");
+    }
+
+    @Test
+    void recordsBackendControlledHumanMessagesExactlyOnceAndExposesSafeControls() {
+        MemoryConversation conversations = new MemoryConversation();
+        conversations.value = ReceptionConversation.start("conversation-1", "poc:ana", NOW)
+                .requestHumanHandoff("cliente pediu uma pessoa", NOW);
+        MemoryTranscript transcript = new MemoryTranscript();
+        ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(
+                new HermesSessionService(new FakeSessions("unused"), new MemoryLinks()), conversations,
+                new MemoryFacts(), transcript, new MemoryTurns(), new CommercialPolicyService(),
+                new ReceptionTurnCoordinator(), Clock.fixed(NOW, ZoneOffset.UTC));
+
+        ReceptionOrchestrator.HumanMessageReceipt first = orchestrator.recordHumanMessage(
+                "poc:ana", "operator-message-1", "Decisão da arquiteta", NOW);
+        ReceptionOrchestrator.HumanMessageReceipt replay = orchestrator.recordHumanMessage(
+                "poc:ana", "operator-message-1", "texto diferente não substitui o original", NOW.plusSeconds(1));
+
+        assertThat(first.duplicate()).isFalse();
+        assertThat(replay.duplicate()).isTrue();
+        assertThat(transcript.messages).filteredOn(message -> message.senderType() == ReceptionMessageSender.HUMAN)
+                .singleElement()
+                .satisfies(message -> {
+                    assertThat(message.text()).isEqualTo("Decisão da arquiteta");
+                    assertThat(message.direction()).isEqualTo(ReceptionMessageDirection.OUTBOUND);
+                });
+        Map<String, Object> projection = orchestrator.projection("poc:ana");
+        assertThat(projection).containsEntry("ownership", "HUMAN")
+                .containsEntry("resumeStatus", ResumeStatus.NONE.name());
+        Map<?, ?> controls = (Map<?, ?>) projection.get("controlAvailability");
+        assertThat(controls.get("recordHumanMessage")).isEqualTo(true);
+        assertThat(controls.get("returnToUrba")).isEqualTo(true);
+    }
+
+    @Test
+    void synchronizesTheCompleteTypedBoundaryBeforeReturningToUrbaAndReplaysAsANoop() {
+        MemoryConversation conversations = new MemoryConversation();
+        ReceptionConversation human = ReceptionConversation.start("conversation-1", "poc:ana", NOW)
+                .requestHumanHandoff("cliente pediu uma pessoa", NOW);
+        conversations.value = human;
+        MemoryTranscript transcript = new MemoryTranscript();
+        transcript.messages.add(new ReceptionMessage("contact-message", "contact-event", "turn-1",
+                human.id(), human.contactId(), ReceptionMessageDirection.INBOUND,
+                ReceptionMessageSender.CONTACT, ReceptionMessageType.TEXT, "Olá", null, null, NOW));
+        transcript.messages.add(new ReceptionMessage("urba-message", ReceptionEventIds.outbound("urba-1", "turn-1"),
+                "turn-1", human.id(), human.contactId(), ReceptionMessageDirection.OUTBOUND,
+                ReceptionMessageSender.URBA, ReceptionMessageType.TEXT, "Como posso ajudar?", null, null,
+                NOW.plusSeconds(1)));
+        transcript.messages.add(new ReceptionMessage("human-message", ReceptionEventIds.outbound("human-1", "operator-1"),
+                "operator-1", human.id(), human.contactId(), ReceptionMessageDirection.OUTBOUND,
+                ReceptionMessageSender.HUMAN, ReceptionMessageType.TEXT, "A arquiteta decidiu aguardar.", null, null,
+                NOW.plusSeconds(2)));
+        transcript.messages.add(new ReceptionMessage("system-message", ReceptionEventIds.outbound("system-1", "turn-1"),
+                "turn-1", human.id(), human.contactId(), ReceptionMessageDirection.OUTBOUND,
+                ReceptionMessageSender.SYSTEM, ReceptionMessageType.TEXT, "Decisão registrada.", null, null,
+                NOW.plusSeconds(3)));
+        MemoryFacts facts = new MemoryFacts();
+        facts.values.add(CustomerFact.confirmed("poc:ana", "OCCUPATION", "DESIGNER",
+                "contact-event", NOW));
+        CapturingResumeGateway resume = new CapturingResumeGateway(HermesResumeGateway.Action.WAIT, null);
+        ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(
+                new HermesSessionService(new FakeSessions("unused"), new MemoryLinks()), conversations,
+                facts, transcript, new MemoryTurns(), new CommercialPolicyService(),
+                new ReceptionTurnCoordinator(), Clock.fixed(NOW, ZoneOffset.UTC));
+
+        ReceptionOrchestrator.ResumeReceipt first = orchestrator.returnToUrba(
+                "poc:ana", "return-1", human.version(), resume);
+        ReceptionOrchestrator.ResumeReceipt replay = orchestrator.returnToUrba(
+                "poc:ana", "return-1", -1, resume);
+
+        assertThat(first.status()).isEqualTo(ResumeStatus.COMPLETED);
+        assertThat(first.ownership()).isEqualTo("URBA");
+        assertThat(replay.duplicate()).isTrue();
+        assertThat(replay.ownership()).isEqualTo("URBA");
+        assertThat(resume.syncCalls).isEqualTo(1);
+        assertThat(resume.decideCalls).isEqualTo(1);
+        assertThat(resume.context.messages()).extracting(HermesResumeGateway.ContextMessage::senderType)
+                .containsExactly("CONTACT", "URBA", "HUMAN", "SYSTEM");
+        assertThat(resume.context.messages()).extracting(HermesResumeGateway.ContextMessage::sourceMessageId)
+                .containsExactly("contact-event", transcript.messages.get(1).eventId(),
+                        transcript.messages.get(2).eventId(), transcript.messages.get(3).eventId());
+        assertThat(resume.context.facts()).singleElement().satisfies(fact -> {
+            assertThat(fact.type()).isEqualTo("OCCUPATION");
+            assertThat(fact.value()).isEqualTo("DESIGNER");
+            assertThat(fact.confidence()).isEqualTo("CONFIRMED");
+        });
+        assertThat(resume.context.checksum())
+                .isEqualTo("sha256:bd10553fa1a867f9461c8655037f8306e94845672e34a780c4696ae56d533416");
+        assertThat(conversations.value.mode()).isEqualTo(br.com.urbana.connect.domain.reception.model.ReceptionMode.AI);
+        assertThat(conversations.value.resumeStatus()).isEqualTo(ResumeStatus.COMPLETED);
+        assertThat(transcript.messages).hasSize(4);
+    }
+
+    @Test
+    void persistsResumeDecisionBeforeProactiveMessageAndFailsClosedOnGatewayError() {
+        MemoryConversation conversations = new MemoryConversation();
+        ReceptionConversation human = new ReceptionConversation("conversation-1", "poc:ana", ReceptionMode.HUMAN,
+                CommercialStage.BRIEFING, "DECOR_INTERIORES", TermsStatus.ACCEPTED,
+                PaymentStatus.CONFIRMED, "cliente pediu uma pessoa", NOW, NOW, 0);
+        conversations.value = human;
+        MemoryTranscript transcript = new MemoryTranscript();
+        transcript.messages.add(new ReceptionMessage("contact-message", "contact-event", "turn-1",
+                human.id(), human.contactId(), ReceptionMessageDirection.INBOUND,
+                ReceptionMessageSender.CONTACT, ReceptionMessageType.TEXT, "Olá", null, null, NOW));
+        transcript.beforeAppend = () -> assertThat(conversations.value.resumeStatus())
+                .isEqualTo(ResumeStatus.COMPLETED);
+        CapturingResumeGateway send = new CapturingResumeGateway(
+                HermesResumeGateway.Action.SEND_MESSAGE, "Retomamos o atendimento por aqui.");
+        send.nextStep = "BRIEFING";
+        ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(
+                new HermesSessionService(new FakeSessions("unused"), new MemoryLinks()), conversations,
+                new MemoryFacts(), transcript, new MemoryTurns(), new CommercialPolicyService(),
+                new ReceptionTurnCoordinator(), Clock.fixed(NOW, ZoneOffset.UTC));
+
+        ReceptionOrchestrator.ResumeReceipt sent = orchestrator.returnToUrba(
+                "poc:ana", "return-send", human.version(), send);
+
+        assertThat(sent.ownership()).isEqualTo("URBA");
+        assertThat(transcript.messages).filteredOn(message -> message.direction() == ReceptionMessageDirection.OUTBOUND)
+                .singleElement().extracting(ReceptionMessage::text)
+                .isEqualTo("Retomamos o atendimento por aqui.");
+
+        MemoryConversation failedConversations = new MemoryConversation();
+        ReceptionConversation failedHuman = ReceptionConversation.start("conversation-2", "poc:bia", NOW)
+                .requestHumanHandoff("cliente pediu uma pessoa", NOW);
+        failedConversations.value = failedHuman;
+        MemoryTranscript failedTranscript = new MemoryTranscript();
+        failedTranscript.messages.add(new ReceptionMessage("contact-message-2", "contact-event-2", "turn-2",
+                failedHuman.id(), failedHuman.contactId(), ReceptionMessageDirection.INBOUND,
+                ReceptionMessageSender.CONTACT, ReceptionMessageType.TEXT, "Olá", null, null, NOW));
+        ReceptionOrchestrator failedOrchestrator = new ReceptionOrchestrator(
+                new HermesSessionService(new FakeSessions("unused"), new MemoryLinks()), failedConversations,
+                new MemoryFacts(), failedTranscript, new MemoryTurns(), new CommercialPolicyService(),
+                new ReceptionTurnCoordinator(), Clock.fixed(NOW, ZoneOffset.UTC));
+        CapturingResumeGateway unavailable = new CapturingResumeGateway(HermesResumeGateway.Action.WAIT, null);
+        unavailable.failSync = true;
+
+        ReceptionOrchestrator.ResumeReceipt safe = failedOrchestrator.returnToUrba(
+                "poc:bia", "return-fail", failedHuman.version(), unavailable);
+
+        assertThat(safe.ownership()).isEqualTo("HUMAN");
+        assertThat(safe.status()).isEqualTo(ResumeStatus.FAILED_SAFE);
+        assertThat(failedConversations.value.mode()).isEqualTo(
+                br.com.urbana.connect.domain.reception.model.ReceptionMode.HUMAN);
+        assertThat(failedTranscript.messages).hasSize(1);
+    }
+
+    @Test
+    void keepsHumanOwnershipWhenHermesDoesNotAcknowledgeTheCompleteContext() {
+        MemoryConversation conversations = new MemoryConversation();
+        ReceptionConversation human = ReceptionConversation.start("conversation-incomplete", "poc:bia", NOW)
+                .requestHumanHandoff("cliente pediu uma pessoa", NOW);
+        conversations.value = human;
+        MemoryTranscript transcript = new MemoryTranscript();
+        transcript.messages.add(new ReceptionMessage("contact-message-incomplete", "contact-event-incomplete",
+                "turn-incomplete", human.id(), human.contactId(), ReceptionMessageDirection.INBOUND,
+                ReceptionMessageSender.CONTACT, ReceptionMessageType.TEXT, "Olá", null, null, NOW));
+        CapturingResumeGateway incomplete = new CapturingResumeGateway(HermesResumeGateway.Action.WAIT, null);
+        incomplete.incompleteReceipt = true;
+        ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(
+                new HermesSessionService(new FakeSessions("unused"), new MemoryLinks()), conversations,
+                new MemoryFacts(), transcript, new MemoryTurns(), new CommercialPolicyService(),
+                new ReceptionTurnCoordinator(), Clock.fixed(NOW, ZoneOffset.UTC));
+
+        ReceptionOrchestrator.ResumeReceipt receipt = orchestrator.returnToUrba(
+                "poc:bia", "return-incomplete", human.version(), incomplete);
+
+        assertThat(receipt.ownership()).isEqualTo("HUMAN");
+        assertThat(receipt.status()).isEqualTo(ResumeStatus.FAILED_SAFE);
+        assertThat(incomplete.decideCalls).isZero();
+        assertThat(conversations.value.mode()).isEqualTo(ReceptionMode.HUMAN);
     }
 
     @Test
@@ -339,7 +635,7 @@ class ReceptionOrchestratorTest {
                 "Decor", null, null, "service.decor", NOW, null));
 
         verify(facts).save(argThat(fact -> fact.type().equals("SELECTED_SERVICE")
-                && fact.value().equals("DECOR")
+                && fact.value().equals("DECOR_INTERIORES")
                 && fact.confidence() == br.com.urbana.connect.domain.reception.model.FactConfidence.CONFIRMED
                 && fact.sourceMessageId().equals("service-choice")));
     }
@@ -367,7 +663,8 @@ class ReceptionOrchestratorTest {
         ReceptionOrchestrator.TurnReceipt duplicate = restarted.process(event);
 
         assertThat(duplicate.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.DUPLICATE);
-        assertThat(duplicate.output().message()).isEqualTo("ok");
+        assertThat(duplicate.output().message())
+                .isEqualTo("Olá! Sou a Urba, assistente virtual da Urbana do Brasil. ok");
     }
 
     @Test
@@ -415,7 +712,8 @@ class ReceptionOrchestratorTest {
                 "oi", NOW));
 
         assertThat(receipt.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.COMPLETED);
-        assertThat(receipt.output().message()).isEqualTo("recovered");
+        assertThat(receipt.output().message())
+                .isEqualTo("Olá! Sou a Urba, assistente virtual da Urbana do Brasil. recovered");
         assertThat(sessions.chatCalls).isEqualTo(1);
         assertThat(transcript.messages).extracting(ReceptionMessage::direction)
                 .containsExactly(ReceptionMessageDirection.INBOUND, ReceptionMessageDirection.OUTBOUND);
@@ -425,7 +723,7 @@ class ReceptionOrchestratorTest {
     }
 
     @Test
-    void allowsOperatorPaymentApprovalAfterHumanHandoff() {
+    void allowsOperatorPaymentApprovalAfterHumanHandoffWithoutReactivatingAutomation() {
         MemoryConversation conversations = new MemoryConversation();
         conversations.value = new ReceptionConversation("conversation-human-payment", "poc:ana",
                 br.com.urbana.connect.domain.reception.model.ReceptionMode.HUMAN,
@@ -438,8 +736,8 @@ class ReceptionOrchestratorTest {
 
         ReceptionOrchestrator.TurnReceipt receipt = orchestrator.approvePaymentProof("poc:ana");
 
-        assertThat(receipt.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.COMPLETED);
-        assertThat(receipt.output().message()).contains("DECOR");
+        assertThat(receipt.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.BLOCKED_BY_HUMAN);
+        assertThat(receipt.output()).isNull();
         assertThat(conversations.value.mode()).isEqualTo(
                 br.com.urbana.connect.domain.reception.model.ReceptionMode.HUMAN);
         assertThat(conversations.value.paymentStatus()).isEqualTo(PaymentStatus.CONFIRMED);
@@ -770,6 +1068,42 @@ class ReceptionOrchestratorTest {
         @Override public List<HermesHistoryMessage> history(String sessionId) { return List.of(); }
     }
 
+    private static final class CapturingResumeGateway implements HermesResumeGateway {
+        private final HermesResumeGateway.Action action;
+        private final String message;
+        int syncCalls;
+        int decideCalls;
+        boolean failSync;
+        boolean incompleteReceipt;
+        String nextStep = "NONE";
+        ResumeContext context;
+
+        private CapturingResumeGateway(HermesResumeGateway.Action action, String message) {
+            this.action = action;
+            this.message = message;
+        }
+
+        @Override
+        public ContextSyncReceipt synchronize(String sessionId, ResumeContext context) {
+            syncCalls++;
+            this.context = context;
+            if (failSync) {
+                throw new IllegalStateException("provider failure must not cross boundary");
+            }
+            return new ContextSyncReceipt(context.resumeId(), context.lineageId(), sessionId,
+                    context.checksum(), context.cursor(), incompleteReceipt
+                            ? Math.max(0, context.watermark() - 1) : context.watermark());
+        }
+
+        @Override
+        public ResumeDecision decide(String sessionId, ResumeCommand command) {
+            decideCalls++;
+            return new ResumeDecision(command.resumeId(), sessionId, action, nextStep, message,
+                    context.messages().stream().map(ContextMessage::sourceMessageId).toList(),
+                    action.name(), 1.0);
+        }
+    }
+
     private static final class CapturingSessions extends FakeSessions {
         String lastInput;
         CapturingSessions() {
@@ -824,14 +1158,24 @@ class ReceptionOrchestratorTest {
     private static final class MemoryFacts implements CustomerFactGateway {
         int findCalls;
         int saveCalls;
-        @Override public List<CustomerFact> findCurrentByContactId(String contactId, Instant at) { findCalls++; return List.of(); }
-        @Override public List<CustomerFact> findByContactId(String contactId) { findCalls++; return List.of(); }
+        final List<CustomerFact> values = new ArrayList<>();
+        @Override public List<CustomerFact> findCurrentByContactId(String contactId, Instant at) {
+            findCalls++;
+            return values.stream().filter(fact -> fact.contactId().equals(contactId)
+                    && fact.isCurrentAt(at)).toList();
+        }
+        @Override public List<CustomerFact> findByContactId(String contactId) {
+            findCalls++;
+            return values.stream().filter(fact -> fact.contactId().equals(contactId)).toList();
+        }
         @Override public CustomerFact save(CustomerFact fact) { saveCalls++; return fact; }
     }
     private static final class MemoryTranscript implements ReceptionTranscriptGateway {
         final List<ReceptionMessage> messages = new ArrayList<>();
+        Runnable beforeAppend = () -> { };
         @Override public boolean appendIfAbsent(ReceptionMessage message) {
             if (findByEventId(message.eventId()).isPresent()) return false;
+            beforeAppend.run();
             messages.add(message); return true;
         }
         @Override public Optional<ReceptionMessage> findByEventId(String eventId) { return messages.stream().filter(m -> m.eventId().equals(eventId)).findFirst(); }

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionResponsePolicyTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionResponsePolicyTest.java
@@ -58,6 +58,25 @@ class ReceptionResponsePolicyTest {
         assertThat(rejected.output().message()).doesNotContainIgnoringCase("arquiteta");
     }
 
+    @Test
+    void doesNotExposeTentativeOrStaleFactsAsCurrentReusableProfileValues() {
+        CustomerFact tentativePronoun = CustomerFact.tentative(
+                "contact-1", "PRONOUN_PREFERENCE", "ELA_DELA", "message-tentative", NOW);
+        CustomerFact oldOccupation = CustomerFact.confirmed(
+                "contact-1", "OCCUPATION", "ARQUITETA", "message-old", NOW.minusSeconds(30));
+        CustomerFact tentativeLatestOccupation = CustomerFact.tentative(
+                "contact-1", "OCCUPATION", "DESIGNER", "message-latest", NOW.minusSeconds(10));
+        CustomerFact staleOccupation = new CustomerFact(
+                "occupation-stale", "contact-1", "OCCUPATION", "ARQUITETA",
+                br.com.urbana.connect.domain.reception.model.FactConfidence.CONFIRMED,
+                "message-stale", NOW.minusSeconds(30), NOW.minusSeconds(1), null);
+
+        assertThat(policy.currentFact(List.of(tentativePronoun), "PRONOUN_PREFERENCE", NOW)).isEmpty();
+        assertThat(policy.currentFact(List.of(staleOccupation), "OCCUPATION", NOW)).isEmpty();
+        assertThat(policy.currentFact(
+                List.of(oldOccupation, tentativeLatestOccupation), "OCCUPATION", NOW)).isEmpty();
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
             "Temos o serviço de Paisagismo por R$ 99,00.",

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationTest.java
@@ -132,6 +132,47 @@ class ReceptionTurnReconciliationTest {
                 message.direction() == ReceptionMessageDirection.OUTBOUND).hasSize(1);
     }
 
+    @Test
+    void handoffAckWinsOverLateHermesTextDuringReconciliation() {
+        MemoryTurns turns = new MemoryTurns();
+        ReceptionTurn turn = ReceptionTurn.queued("turn-human", "corr-human", "poc:ana", "session-1",
+                        List.of("message-human"), NOW, "cursor-1|1")
+                .start(NOW)
+                .reconcile("HERMES_TIMEOUT_AFTER_DISPATCH", NOW.plusSeconds(1));
+        turns.save(turn);
+        MemoryConversation conversations = new MemoryConversation();
+        conversations.value = ReceptionConversation.start("conversation-human", "poc:ana", NOW)
+                .requestHumanHandoff("cliente pediu uma pessoa", NOW.plusSeconds(1));
+        MemoryTranscript transcript = new MemoryTranscript();
+        transcript.messages.add(new ReceptionMessage("message-human", "event-human", "corr-human",
+                "conversation-human", "poc:ana", ReceptionMessageDirection.INBOUND,
+                ReceptionMessageSender.CONTACT, ReceptionMessageType.TEXT, "quero uma pessoa", null, null, NOW));
+        HermesSessionsGateway sessions = new HermesSessionsGateway() {
+            @Override public String createSession(String contactId) { return "session-1"; }
+            @Override public HermesChatResult chat(String sessionId, HermesChatRequest request) {
+                throw new AssertionError("must not dispatch");
+            }
+            @Override public List<HermesHistoryMessage> history(String sessionId) { return List.of(); }
+            @Override public HermesHistorySnapshot historySnapshot(String sessionId) {
+                return new HermesHistorySnapshot("cursor-2", List.of(
+                        new HermesHistoryMessage("user", "quero uma pessoa"),
+                        new HermesHistoryMessage("assistant", "o sistema está indisponível; tente retry")));
+            }
+        };
+        ReceptionTurnReconciliationService service = new ReceptionTurnReconciliationService(
+                new HermesSessionService(sessions, new EmptyLinks()), conversations, transcript, turns,
+                Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC));
+
+        assertThat(service.reconcile("turn-human"))
+                .contains("Vou encaminhar sua conversa para a arquiteta, que continuará com você por aqui.");
+        assertThat(turns.value.status().name()).isEqualTo("BLOCKED_BY_HUMAN");
+        assertThat(transcript.messages).noneMatch(message -> message.text() != null
+                && message.text().contains("sistema está indisponível"));
+        assertThat(transcript.messages).filteredOn(message -> message.senderType() == ReceptionMessageSender.URBA)
+                .singleElement().extracting(ReceptionMessage::text)
+                .isEqualTo("Vou encaminhar sua conversa para a arquiteta, que continuará com você por aqui.");
+    }
+
     private static final class EmptyLinks implements AgentSessionLinkGateway {
         @Override public Optional<br.com.urbana.connect.domain.reception.model.AgentSessionLink> findActiveByContactId(String contactId) { return Optional.empty(); }
         @Override public Optional<br.com.urbana.connect.domain.reception.model.AgentSessionLink> findBySessionId(String sessionId) { return Optional.empty(); }

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReturningCustomerServiceTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReturningCustomerServiceTest.java
@@ -70,6 +70,38 @@ class ReturningCustomerServiceTest {
     }
 
     @Test
+    void doesNotReuseAnOlderConfirmedValueWhenTheLatestExplicitVersionIsTentative() {
+        CustomerFact oldOccupation = CustomerFact.confirmed(
+                "contact-1", "OCCUPATION", "ARQUITETA", "message-old", NOW.minusSeconds(30));
+        CustomerFact tentativeLatestOccupation = CustomerFact.tentative(
+                "contact-1", "OCCUPATION", "DESIGNER", "message-tentative", NOW.minusSeconds(10));
+        MemoryFacts gateway = new MemoryFacts(List.of(oldOccupation, tentativeLatestOccupation));
+
+        ReturningCustomerService.Projection projection = service(gateway).project("contact-1", NOW);
+
+        assertThat(projection.facts()).isEmpty();
+        assertThat(projection.missingIcpFields())
+                .containsExactly("PRONOUN_PREFERENCE", "FIRST_TIME_HIRING", "OCCUPATION");
+    }
+
+    @Test
+    void latestExplicitNotInformedVersionReplacesOlderValueWithoutDeletingHistory() {
+        CustomerFact oldOccupation = CustomerFact.confirmed(
+                "contact-1", "OCCUPATION", "ARQUITETA", "message-old", NOW.minusSeconds(30));
+        CustomerFact latestNotInformed = CustomerFact.confirmed(
+                "contact-1", "OCCUPATION", "NÃO INFORMADO", "message-refusal", NOW.minusSeconds(10));
+        CustomerFact supersededOld = oldOccupation.supersede(latestNotInformed.id(), latestNotInformed.validFrom());
+        MemoryFacts gateway = new MemoryFacts(List.of(supersededOld, latestNotInformed));
+
+        ReturningCustomerService.Projection projection = service(gateway).project("contact-1", NOW);
+
+        assertThat(projection.facts()).containsExactly(latestNotInformed);
+        assertThat(projection.missingIcpFields())
+                .containsExactly("PRONOUN_PREFERENCE", "FIRST_TIME_HIRING");
+        assertThat(gateway.allFacts).contains(supersededOld);
+    }
+
+    @Test
     void keepsCorrectedFactHistoryAndNeverExposesTheSentinelContact() {
         CustomerFact originalOccupation = CustomerFact.confirmed(
                 "contact-1", "OCCUPATION", "ARQUITETA", "message-original", NOW.minusSeconds(30));

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/DomainToolInvocationUseCaseTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/DomainToolInvocationUseCaseTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -252,36 +251,18 @@ class DomainToolInvocationUseCaseTest {
         DomainToolInvocationUseCase useCase = new DomainToolInvocationUseCase(leases, invocations, tool,
                 Clock.fixed(NOW, ZoneOffset.UTC));
         ExecutorService executor = Executors.newFixedThreadPool(2);
-        CountDownLatch start = new CountDownLatch(1);
         Future<DomainToolInvocationUseCase.InvocationResult> first = executor.submit(() -> {
-            await(start);
             return useCase.invoke("session-1", "hermes-urbana-domain", DomainToolName.PREPARE_TERMS,
                     Map.of("serviceType", "DECOR"));
         });
-        Future<DomainToolInvocationUseCase.InvocationResult> second = executor.submit(() -> {
-            await(start);
-            return useCase.invoke("session-1", "hermes-urbana-domain", DomainToolName.PREPARE_TERMS,
-                    Map.of("serviceType", "DECOR"));
-        });
-        start.countDown();
         assertThat(firstExecutionEntered.await(2, TimeUnit.SECONDS)).isTrue();
-        releaseFirstExecution.countDown();
 
-        int successful = 0;
-        int inProgress = 0;
-        for (Future<DomainToolInvocationUseCase.InvocationResult> future : List.of(first, second)) {
-            try {
-                var result = future.get(2, TimeUnit.SECONDS);
-                successful++;
-                assertThat(result.result()).isEqualTo(Map.of("status", "OK"));
-            } catch (ExecutionException exception) {
-                assertThat(exception.getCause())
-                        .isInstanceOf(DomainToolInvocationUseCase.InvocationInProgressException.class);
-                inProgress++;
-            }
-        }
-        assertThat(successful).isEqualTo(1);
-        assertThat(inProgress).isEqualTo(1);
+        assertThatThrownBy(() -> useCase.invoke("session-1", "hermes-urbana-domain",
+                DomainToolName.PREPARE_TERMS, Map.of("serviceType", "DECOR")))
+                .isInstanceOf(DomainToolInvocationUseCase.InvocationInProgressException.class);
+
+        releaseFirstExecution.countDown();
+        assertThat(first.get(2, TimeUnit.SECONDS).result()).isEqualTo(Map.of("status", "OK"));
         assertThat(executions).hasValue(1);
         executor.shutdownNow();
     }

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/DomainToolInvocationUseCaseTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/DomainToolInvocationUseCaseTest.java
@@ -187,8 +187,9 @@ class DomainToolInvocationUseCaseTest {
                 Clock.fixed(NOW, ZoneOffset.UTC));
 
         assertThatThrownBy(() -> useCase.invoke("session-1", "hermes-urbana-domain", DomainToolName.PREPARE_TERMS,
-                Map.of("serviceType", "DECOR"))).isInstanceOf(IllegalStateException.class)
-                .hasMessage("fixture rejected");
+                Map.of("serviceType", "DECOR")))
+                .isInstanceOf(DomainToolInvocationUseCase.TechnicalToolFailureException.class)
+                .hasMessage("Não consegui concluir esta etapa agora.");
         String key = invocations.lastKey();
 
         assertThatThrownBy(() -> useCase.invoke("session-1", "hermes-urbana-domain", DomainToolName.PREPARE_TERMS,
@@ -196,12 +197,42 @@ class DomainToolInvocationUseCaseTest {
                 .isInstanceOf(DomainToolInvocationUseCase.DurableToolFailureException.class)
                 .satisfies(error -> {
                     var failure = (DomainToolInvocationUseCase.DurableToolFailureException) error;
-                    assertThat(failure.resultCode()).isEqualTo("IllegalStateException");
-                    assertThat(failure.resultPayload()).isEqualTo(Map.of("error", "fixture rejected"));
+                    assertThat(failure.resultCode()).isEqualTo("TECHNICAL_FAILURE");
+                    assertThat(failure.resultPayload().toString())
+                            .doesNotContain("fixture rejected", "IllegalStateException", "stack");
                 });
         assertThat(executions).hasValue(1);
         assertThat(invocations.findByIdempotencyKey(key).orElseThrow().status())
                 .isEqualTo(DomainToolInvocationStatus.FAILED);
+    }
+
+    @Test
+    void persistsAndReplaysStructuredBusinessRejectionWithoutExecutingAgain() {
+        FakeLeaseGateway leaseGateway = new FakeLeaseGateway();
+        ActiveTurnLeaseService leases = activeLease(leaseGateway);
+        FakeInvocationGateway invocations = new FakeInvocationGateway();
+        AtomicInteger executions = new AtomicInteger();
+        DomainToolService tool = (name, contact, args) -> {
+            executions.incrementAndGet();
+            throw new DomainToolInvocationUseCase.DomainRejectionException(
+                    "TERMS_NOT_ACCEPTED", "ASK_FOR_CLEAR_ACCEPTANCE", List.of(),
+                    "Antes do pagamento, preciso do seu aceite claro dos termos.");
+        };
+        DomainToolInvocationUseCase useCase = new DomainToolInvocationUseCase(leases, invocations, tool,
+                Clock.fixed(NOW, ZoneOffset.UTC));
+
+        for (int attempt = 0; attempt < 2; attempt++) {
+            assertThatThrownBy(() -> useCase.invoke("session-1", "hermes-urbana-domain",
+                    DomainToolName.PREPARE_PAYMENT, Map.of("serviceType", "DECOR", "method", "PIX")))
+                    .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
+                    .satisfies(error -> assertThat(
+                            ((DomainToolInvocationUseCase.DomainRejectionException) error).nextAction())
+                            .isEqualTo("ASK_FOR_CLEAR_ACCEPTANCE"));
+        }
+
+        assertThat(executions).hasValue(1);
+        assertThat(invocations.values.values()).singleElement()
+                .extracting(DomainToolInvocation::status).isEqualTo(DomainToolInvocationStatus.REJECTED);
     }
 
     @Test
@@ -281,8 +312,13 @@ class DomainToolInvocationUseCaseTest {
         assertThatThrownBy(() -> useCase.invoke("session-1", "hermes-urbana-domain",
                 DomainToolName.UPDATE_CUSTOMER_FACT,
                 Map.of("factType", "OCCUPATION", "value", "DESIGNER")))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("HUMAN");
+                .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
+                .satisfies(error -> {
+                    DomainToolInvocationUseCase.DomainRejectionException rejection =
+                            (DomainToolInvocationUseCase.DomainRejectionException) error;
+                    assertThat(rejection.code()).isEqualTo("HUMAN_OWNS_CONVERSATION");
+                    assertThat(rejection.customerMessage()).doesNotContain("HUMAN");
+                });
         assertThat(executions).hasValue(0);
         assertThat(invocations.values).isEmpty();
     }
@@ -317,8 +353,13 @@ class DomainToolInvocationUseCaseTest {
 
         assertThatThrownBy(() -> useCase.invoke("session-1", "hermes-urbana-domain",
                 DomainToolName.PREPARE_TERMS, arguments))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("HUMAN");
+                .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
+                .satisfies(error -> {
+                    DomainToolInvocationUseCase.DomainRejectionException rejection =
+                            (DomainToolInvocationUseCase.DomainRejectionException) error;
+                    assertThat(rejection.code()).isEqualTo("HUMAN_OWNS_CONVERSATION");
+                    assertThat(rejection.customerMessage()).doesNotContain("HUMAN");
+                });
         assertThat(executions).hasValue(1);
     }
 

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolServiceTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolServiceTest.java
@@ -6,6 +6,8 @@ import br.com.urbana.connect.domain.reception.model.ActiveTurnLeaseStatus;
 import br.com.urbana.connect.domain.reception.model.CustomerFact;
 import br.com.urbana.connect.domain.reception.model.DomainToolName;
 import br.com.urbana.connect.domain.reception.model.FactConfidence;
+import br.com.urbana.connect.domain.reception.model.IcpObservationEvent;
+import br.com.urbana.connect.domain.reception.model.HumanHandoffNotification;
 import br.com.urbana.connect.domain.reception.model.ReceptionConversation;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessage;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessageDirection;
@@ -13,7 +15,10 @@ import br.com.urbana.connect.domain.reception.model.ReceptionMessageSender;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessageType;
 import br.com.urbana.connect.domain.reception.model.ReceptionTurnStatus;
 import br.com.urbana.connect.domain.reception.model.TermsStatus;
+import br.com.urbana.connect.domain.reception.model.PaymentStatus;
 import br.com.urbana.connect.domain.reception.port.out.CustomerFactGateway;
+import br.com.urbana.connect.domain.reception.port.out.IcpObservationEventGateway;
+import br.com.urbana.connect.domain.reception.port.out.HumanHandoffNotificationGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionConversationGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTranscriptGateway;
 import org.junit.jupiter.api.Test;
@@ -24,9 +29,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 class StatefulDomainToolServiceTest {
     private static final Instant NOW = Instant.parse("2026-08-05T12:00:00Z");
@@ -79,6 +89,34 @@ class StatefulDomainToolServiceTest {
     }
 
     @Test
+    void supersedesThePreviousFactWithTheRealIdOfTheReplacementAndKeepsCurrentReadsConsistent() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        conversations.value = ReceptionConversation.start("contact-1", NOW);
+        transcript.messages.put("message-occupation-1", message("message-occupation-1", "Sou designer."));
+        transcript.messages.put("message-occupation-2", message("message-occupation-2", "Sou arquiteto."));
+        StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, facts, transcript);
+
+        tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "OCCUPATION", "value", "DESIGNER", "confidence", "CONFIRMED"),
+                context("message-occupation-1"));
+        tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "OCCUPATION", "value", "ARQUITETO", "confidence", "CONFIRMED"),
+                context("message-occupation-2"));
+
+        CustomerFact previous = facts.values.stream()
+                .filter(fact -> "DESIGNER".equals(fact.value())).findFirst().orElseThrow();
+        CustomerFact replacement = facts.values.stream()
+                .filter(fact -> "ARQUITETO".equals(fact.value())).findFirst().orElseThrow();
+        assertThat(previous.supersededBy()).isEqualTo(replacement.id());
+        assertThat(facts.findCurrentByContactId("contact-1", NOW))
+                .containsExactly(replacement)
+                .allSatisfy(fact -> assertThat(fact.supersededBy()).isNull());
+    }
+
+    @Test
     void normalizesCommonModelLabelsToTheCanonicalFactTypes() {
         MemoryConversation conversations = new MemoryConversation();
         MemoryFacts facts = new MemoryFacts();
@@ -91,14 +129,16 @@ class StatefulDomainToolServiceTest {
                 conversations, facts, transcript);
 
         tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
-                Map.of("factType", "PRONOMES", "value", "ELA_DELA", "confidence", "CONFIRMED"),
+                Map.of("factType", "PRONOMES", "value", "ela/dela", "confidence", "CONFIRMED"),
                 context("message-pronoun"));
         tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
-                Map.of("factType", "PROFISSÃO", "value", "DESIGNER", "confidence", "CONFIRMED"),
+                Map.of("factType", "PROFISSÃO", "value", "designer", "confidence", "CONFIRMED"),
                 context("message-occupation"));
 
         assertThat(facts.values).extracting(CustomerFact::type)
                 .containsExactly("PRONOUN_PREFERENCE", "OCCUPATION");
+        assertThat(facts.values).extracting(CustomerFact::value)
+                .containsExactly("ela/dela", "designer");
     }
 
     @Test
@@ -130,10 +170,112 @@ class StatefulDomainToolServiceTest {
                 context("message-service"));
 
         assertThat(facts.values).extracting(CustomerFact::value)
-                .containsExactly("ELA_DELA", "YES", "DESIGNER", "DECOR");
+                .containsExactly("ela/dela", "SIM", "designer", "DECOR_INTERIORES");
         assertThat(facts.values).extracting(CustomerFact::confidence)
                 .containsOnly(FactConfidence.CONFIRMED);
-        assertThat(conversations.value.selectedService()).isEqualTo("DECOR");
+        assertThat(conversations.value.selectedService()).isEqualTo("DECOR_INTERIORES");
+    }
+
+    @Test
+    void persistsTheApprovedFirstHiringValuesAsSimNaoAndNotInformed() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        conversations.value = ReceptionConversation.start("contact-1", NOW);
+        transcript.messages.put("message-first-yes", message("message-first-yes", "Sim, é a primeira vez."));
+        transcript.messages.put("message-first-no", message("message-first-no", "Não, já contratei antes."));
+        transcript.messages.put("message-first-unknown", message("message-first-unknown", "Prefiro não informar."));
+        StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, facts, transcript);
+
+        tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "FIRST_TIME_HIRING", "value", "YES", "confidence", "CONFIRMED"),
+                context("message-first-yes"));
+        assertThat(facts.findCurrentByContactId("contact-1", NOW)).singleElement()
+                .extracting(CustomerFact::value).isEqualTo("SIM");
+
+        tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "FIRST_TIME_HIRING", "value", "NO", "confidence", "CONFIRMED"),
+                context("message-first-no"));
+        assertThat(facts.findCurrentByContactId("contact-1", NOW)).singleElement()
+                .extracting(CustomerFact::value).isEqualTo("NÃO");
+
+        tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "FIRST_TIME_HIRING", "value", "NÃO INFORMADO", "confidence", "CONFIRMED"),
+                context("message-first-unknown"));
+        assertThat(facts.findCurrentByContactId("contact-1", NOW)).singleElement()
+                .extracting(CustomerFact::value).isEqualTo("NÃO INFORMADO");
+    }
+
+    @Test
+    void acceptsLegacyBooleanAndPortugueseFirstHiringInputs() {
+        for (String input : List.of("YES", "true", "sim")) {
+            MemoryConversation conversations = new MemoryConversation();
+            MemoryFacts facts = new MemoryFacts();
+            MemoryTranscript transcript = new MemoryTranscript();
+            conversations.value = ReceptionConversation.start("contact-1", NOW);
+            transcript.messages.put("message-yes-" + input,
+                    message("message-yes-" + input, "Sim, é a primeira vez."));
+            StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                    conversations, facts, transcript);
+
+            tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                    Map.of("factType", "FIRST_TIME_HIRING", "value", input, "confidence", "CONFIRMED"),
+                    context("message-yes-" + input));
+
+            assertThat(facts.values).singleElement().extracting(CustomerFact::value).isEqualTo("SIM");
+        }
+        for (String input : List.of("NO", "false", "não")) {
+            MemoryConversation conversations = new MemoryConversation();
+            MemoryFacts facts = new MemoryFacts();
+            MemoryTranscript transcript = new MemoryTranscript();
+            conversations.value = ReceptionConversation.start("contact-1", NOW);
+            transcript.messages.put("message-no-" + input,
+                    message("message-no-" + input, "Não, já contratei antes."));
+            StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                    conversations, facts, transcript);
+
+            tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                    Map.of("factType", "FIRST_TIME_HIRING", "value", input, "confidence", "CONFIRMED"),
+                    context("message-no-" + input));
+
+            assertThat(facts.values).singleElement().extracting(CustomerFact::value).isEqualTo("NÃO");
+        }
+    }
+
+    @Test
+    void reusesNotInformedSentinelsForAllProfileFieldsWithoutLeavingIcpMissing() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        conversations.value = ReceptionConversation.start("contact-1", NOW);
+        transcript.messages.put("message-pronoun-unknown", message("message-pronoun-unknown",
+                "Prefiro não responder."));
+        transcript.messages.put("message-first-unknown", message("message-first-unknown",
+                "Prefiro não informar."));
+        transcript.messages.put("message-occupation-unknown", message("message-occupation-unknown",
+                "Não quero informar."));
+        StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, facts, transcript);
+
+        tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "PRONOUN_PREFERENCE", "value", "PREFER_NOT_TO_ANSWER",
+                        "confidence", "TENTATIVE"), context("message-pronoun-unknown"));
+        tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "FIRST_TIME_HIRING", "value", "NÃO INFORMADO",
+                        "confidence", "CONFIRMED"), context("message-first-unknown"));
+        tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "OCCUPATION", "value", "prefiro não responder",
+                        "confidence", "CONFIRMED"), context("message-occupation-unknown"));
+
+        assertThat(facts.values).extracting(CustomerFact::value)
+                .containsExactly("NÃO INFORMADO", "NÃO INFORMADO", "NÃO INFORMADO");
+        assertThat(facts.values).extracting(CustomerFact::confidence)
+                .containsOnly(FactConfidence.CONFIRMED);
+        @SuppressWarnings("unchecked")
+        List<String> missing = (List<String>) tools.execute(DomainToolName.GET_CUSTOMER_PROFILE,
+                "contact-1", Map.of(), context("message-occupation-unknown")).get("missingIcpFields");
+        assertThat(missing).isEmpty();
     }
 
     @Test
@@ -156,6 +298,25 @@ class StatefulDomainToolServiceTest {
     }
 
     @Test
+    void listsOnlyCanonicalServicesWithTheSafeRichCatalogFields() {
+        MemoryConversation conversations = new MemoryConversation();
+        conversations.value = ReceptionConversation.start("contact-1", NOW);
+        StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, new MemoryFacts(), new MemoryTranscript());
+
+        Map<String, Object> result = tools.execute(DomainToolName.LIST_AVAILABLE_SERVICES, "contact-1",
+                Map.of(), context("message-services"));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> services = (List<Map<String, Object>>) result.get("services");
+        assertThat(services).hasSize(4).allSatisfy(service -> {
+            assertThat(service).containsKeys("scope", "areaRule", "deliverables", "process",
+                    "responsibilities", "exclusions", "support", "resources");
+            assertThat(service.get("serviceType")).isNotEqualTo("DECOR");
+        });
+    }
+
+    @Test
     void requiresExplicitAcceptanceFromTheSameInboundMessageBeforePreparingPayment() {
         CommercialPolicyService policy = new CommercialPolicyService();
         MemoryConversation conversations = new MemoryConversation();
@@ -169,16 +330,96 @@ class StatefulDomainToolServiceTest {
         facts.values.addAll(icp);
         conversation = policy.presentTerms(policy.selectService(conversation, "DECOR", NOW), icp, NOW);
         conversations.value = conversation;
-        transcript.messages.put("message-terms", message("message-terms", "Aceito"));
+        transcript.messages.put("message-terms", message("message-terms", "Aceito os termos"));
         StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts, transcript);
 
         Map<String, Object> result = tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
                 Map.of("serviceType", "DECOR", "method", "PIX"), context("message-terms"));
 
         assertThat(result).containsEntry("status", "PREPARED");
+        assertThat(result).containsEntry("instruction", policy.paymentUrl("DECOR_INTERIORES"))
+                .containsEntry("nextAction", "AWAIT_PAYMENT_PROOF")
+                .containsEntry("customerMessage",
+                        "Pagamento preparado. Realize o pagamento pelo link e envie o comprovante por aqui.");
         assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.ACCEPTED);
         assertThat(conversations.value.paymentStatus())
-                .isEqualTo(br.com.urbana.connect.domain.reception.model.PaymentStatus.PREPARED);
+                .isEqualTo(PaymentStatus.PREPARED);
+    }
+
+    @Test
+    void rejectsAnUnsupportedPaymentMethodWithACommercialCorrectionWithoutReaskingTerms() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        ReceptionConversation accepted = policy.acceptTerms(policy.presentTerms(
+                policy.selectService(ReceptionConversation.start("contact-1", NOW), "DECOR", NOW),
+                List.of(), NOW), NOW);
+        conversations.value = accepted;
+        StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts, transcript);
+
+        assertThatThrownBy(() -> tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
+                Map.of("serviceType", "DECOR", "method", "link"), context("message-method")))
+                .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
+                .satisfies(error -> {
+                    DomainToolInvocationUseCase.DomainRejectionException rejection =
+                            (DomainToolInvocationUseCase.DomainRejectionException) error;
+                    assertThat(rejection.code()).isEqualTo("PAYMENT_METHOD_INVALID");
+                    assertThat(rejection.nextAction()).isEqualTo("ASK_FOR_PAYMENT_METHOD");
+                    assertThat(rejection.customerMessage()).contains("PIX", "cartão de crédito")
+                            .doesNotContainIgnoringCase("termos", "aceite", "sistema", "ferramenta");
+                });
+        assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.ACCEPTED);
+        assertThat(conversations.value.paymentStatus()).isEqualTo(PaymentStatus.NOT_STARTED);
+    }
+
+    @Test
+    void reportsMissingPaymentMethodWithoutClassifyingItAsMissingTerms() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        MemoryConversation conversations = new MemoryConversation();
+        ReceptionConversation accepted = policy.acceptTerms(policy.presentTerms(
+                policy.selectService(ReceptionConversation.start("contact-1", NOW), "DECOR", NOW),
+                List.of(), NOW), NOW);
+        conversations.value = accepted;
+        StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations,
+                new MemoryFacts(), new MemoryTranscript());
+
+        assertThatThrownBy(() -> tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
+                Map.of("serviceType", "DECOR"), context("message-method-missing")))
+                .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
+                .satisfies(error -> {
+                    DomainToolInvocationUseCase.DomainRejectionException rejection =
+                            (DomainToolInvocationUseCase.DomainRejectionException) error;
+                    assertThat(rejection.code()).isEqualTo("PAYMENT_METHOD_INVALID");
+                    assertThat(rejection.missingFields()).containsExactly("method");
+                    assertThat(rejection.customerMessage()).contains("PIX", "cartão de crédito");
+                });
+    }
+
+    @Test
+    void reportsServiceMismatchWithoutClassifyingItAsMissingTerms() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        MemoryConversation conversations = new MemoryConversation();
+        ReceptionConversation accepted = policy.acceptTerms(policy.presentTerms(
+                policy.selectService(ReceptionConversation.start("contact-1", NOW), "DECOR_PINTURA", NOW),
+                List.of(), NOW), NOW);
+        conversations.value = accepted;
+        StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations,
+                new MemoryFacts(), new MemoryTranscript());
+
+        assertThatThrownBy(() -> tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
+                Map.of("serviceType", "DECOR_INTERIORES", "method", "PIX"), context("message-mismatch")))
+                .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
+                .satisfies(error -> {
+                    DomainToolInvocationUseCase.DomainRejectionException rejection =
+                            (DomainToolInvocationUseCase.DomainRejectionException) error;
+                    assertThat(rejection.code()).isEqualTo("SERVICE_NOT_CONFIRMED");
+                    assertThat(rejection.nextAction()).isEqualTo("CONFIRM_SERVICE");
+                    assertThat(rejection.missingFields()).containsExactly("serviceType");
+                    assertThat(rejection.customerMessage()).doesNotContainIgnoringCase("termos", "aceite");
+                });
+        assertThat(conversations.value.selectedService()).isEqualTo("DECOR_PINTURA");
+        assertThat(conversations.value.paymentStatus()).isEqualTo(PaymentStatus.NOT_STARTED);
     }
 
     @Test
@@ -205,6 +446,80 @@ class StatefulDomainToolServiceTest {
     }
 
     @Test
+    void doesNotReissuePaymentInstructionAfterPaymentWasConfirmed() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        MemoryConversation conversations = new MemoryConversation();
+        ReceptionConversation confirmed = policy.approvePaymentProof(
+                policy.receivePaymentProof(
+                        policy.preparePayment(
+                                policy.acceptTerms(policy.presentTerms(
+                                        policy.selectService(ReceptionConversation.start("contact-1", NOW), "DECOR", NOW),
+                                        List.of(), NOW), NOW), List.of(), "PIX", NOW), NOW), NOW);
+        conversations.value = confirmed;
+        StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations,
+                new MemoryFacts(), new MemoryTranscript());
+
+        Map<String, Object> result = tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
+                Map.of("serviceType", "DECOR", "method", "PIX"), context("message-payment-replay"));
+
+        assertThat(result).containsEntry("status", "CONFIRMED")
+                .containsEntry("serviceType", "DECOR_INTERIORES")
+                .containsEntry("nextAction", "NONE")
+                .containsEntry("customerMessage", "O pagamento já foi confirmado pela arquiteta.")
+                .doesNotContainKey("instruction");
+        assertThat(conversations.value.paymentStatus()).isEqualTo(PaymentStatus.CONFIRMED);
+    }
+
+    @Test
+    void rejectsOkAsInsufficientAcceptanceAndUsesTheStructuredSafeBusinessRejection() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        conversations.value = policy.presentTerms(
+                policy.selectService(ReceptionConversation.start("contact-1", NOW), "DECOR", NOW),
+                List.of(), NOW);
+        transcript.messages.put("message-ok", message("message-ok", "ok"));
+        StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts, transcript);
+
+        assertThatThrownBy(() -> tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
+                Map.of("serviceType", "DECOR", "method", "PIX"), context("message-ok")))
+                .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
+                .satisfies(error -> {
+                    DomainToolInvocationUseCase.DomainRejectionException rejection =
+                            (DomainToolInvocationUseCase.DomainRejectionException) error;
+                    assertThat(rejection.code()).isEqualTo("TERMS_NOT_ACCEPTED");
+                    assertThat(rejection.nextAction()).isEqualTo("ASK_FOR_CLEAR_ACCEPTANCE");
+                    assertThat(rejection.customerMessage()).contains("aceite claro");
+                    assertThat(rejection.customerMessage()).doesNotContainIgnoringCase("system", "api", "exception");
+                });
+        assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.PRESENTED);
+    }
+
+    @Test
+    void acceptsTheTwoApprovedExplicitTermsPhrasesWithTheDecorAlias() {
+        for (String acceptance : List.of("aceito os termos", "concordo com os termos")) {
+            CommercialPolicyService policy = new CommercialPolicyService();
+            MemoryConversation conversations = new MemoryConversation();
+            MemoryFacts facts = new MemoryFacts();
+            MemoryTranscript transcript = new MemoryTranscript();
+            conversations.value = policy.presentTerms(
+                    policy.selectService(ReceptionConversation.start("contact-1", NOW), "DECOR", NOW),
+                    List.of(), NOW);
+            transcript.messages.put("message-accepted", message("message-accepted", acceptance));
+            StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts, transcript);
+
+            Map<String, Object> result = tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
+                    Map.of("serviceType", "DECOR", "method", "PIX"), context("message-accepted"));
+
+            assertThat(result).containsEntry("status", "PREPARED")
+                    .containsEntry("serviceType", "DECOR_INTERIORES");
+            assertThat(conversations.value.selectedService()).isEqualTo("DECOR_INTERIORES");
+            assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.ACCEPTED);
+        }
+    }
+
+    @Test
     void rejectsAnExplicitTermsRefusalEvenWhenItContainsTheWordConcordo() {
         CommercialPolicyService policy = new CommercialPolicyService();
         MemoryConversation conversations = new MemoryConversation();
@@ -222,8 +537,9 @@ class StatefulDomainToolServiceTest {
 
         assertThatThrownBy(() -> tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
                 Map.of("serviceType", "DECOR", "method", "PIX"), context("message-refusal")))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("explicit terms acceptance");
+                .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
+                .satisfies(error -> assertThat(((DomainToolInvocationUseCase.DomainRejectionException) error).code())
+                        .isEqualTo("TERMS_NOT_ACCEPTED"));
 
         assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.PRESENTED);
         assertThat(conversations.value.paymentStatus())
@@ -262,10 +578,102 @@ class StatefulDomainToolServiceTest {
         assertThatThrownBy(() -> tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
                 Map.of("factType", "OCCUPATION", "value", "DESIGNER", "confidence", "CONFIRMED"),
                 context("message-late")))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("HUMAN");
+                .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
+                .satisfies(error -> {
+                    DomainToolInvocationUseCase.DomainRejectionException rejection =
+                            (DomainToolInvocationUseCase.DomainRejectionException) error;
+                    assertThat(rejection.code()).isEqualTo("HUMAN_OWNS_CONVERSATION");
+                    assertThat(rejection.customerMessage()).doesNotContainIgnoringCase(
+                            "system", "tool", "api", "database", "exception", "retry");
+                });
         assertThat(facts.values).isEmpty();
         assertThat(conversations.savedVersions).isEmpty();
+    }
+
+    @Test
+    void handoffPersistsOneCanonicalAckAndReplaysTheSameTransitionWithoutDuplicates() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        conversations.value = ReceptionConversation.start("conversation-1", "contact-1", NOW);
+        StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, facts, transcript);
+
+        Map<String, Object> first = tools.execute(DomainToolName.REQUEST_HUMAN_HANDOFF, "contact-1",
+                Map.of("reason", "cliente pediu uma pessoa"), context("message-1"));
+        Map<String, Object> replay = tools.execute(DomainToolName.REQUEST_HUMAN_HANDOFF, "contact-1",
+                Map.of("reason", "cliente pediu uma pessoa"), context("message-1"));
+
+        assertThat(first).containsEntry("status", "TRANSFERRED")
+                .containsEntry("ownership", "HUMAN")
+                .containsEntry("ackMessage", "Vou encaminhar sua conversa para a arquiteta, que continuará com você por aqui.");
+        assertThat(replay).isEqualTo(first);
+        assertThat(conversations.value.mode())
+                .isEqualTo(br.com.urbana.connect.domain.reception.model.ReceptionMode.HUMAN);
+        assertThat(transcript.messages.values())
+                .filteredOn(message -> message.senderType() == ReceptionMessageSender.URBA)
+                .singleElement()
+                .extracting(ReceptionMessage::text)
+                .isEqualTo("Vou encaminhar sua conversa para a arquiteta, que continuará com você por aqui.");
+    }
+
+    @Test
+    void prepareTermsKeepsTheCommercialResultAndRecordsOneOpaqueIcpSkipObservation() {
+        CommercialPolicyService policy = spy(new CommercialPolicyService());
+        doReturn(List.of("PRONOUN_PREFERENCE", "FIRST_TIME_HIRING", "OCCUPATION"))
+                .when(policy).missingIcpFields(anyCollection(), eq(NOW));
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        MemoryIcpObservations observations = new MemoryIcpObservations();
+        conversations.value = ReceptionConversation.start("conversation-1", "contact-1", NOW);
+        StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts,
+                transcript, observations);
+
+        Map<String, Object> first = tools.execute(DomainToolName.PREPARE_TERMS, "contact-1",
+                Map.of("serviceType", "DECOR_PINTURA"), context("message-terms"));
+        Map<String, Object> replay = tools.execute(DomainToolName.PREPARE_TERMS, "contact-1",
+                Map.of("serviceType", "DECOR_PINTURA"), context("message-terms"));
+
+        assertThat(replay).isEqualTo(first)
+                .containsEntry("status", "PRESENTED")
+                .containsEntry("serviceType", "DECOR_PINTURA");
+        assertThat(first).doesNotContainKeys("event", "eventType", "missingIcpFields", "turnId",
+                "conversationId", "idempotencyKey");
+        assertThat(observations.events).hasSize(1);
+        IcpObservationEvent event = observations.events.getFirst();
+        assertThat(event.eventType()).isEqualTo(IcpObservationEvent.TYPE);
+        assertThat(event.serviceType()).isEqualTo("DECOR_PINTURA");
+        assertThat(event.missingFields()).containsExactly("PRONOUN_PREFERENCE", "FIRST_TIME_HIRING",
+                "OCCUPATION");
+        assertThat(event.detectionPoint()).isEqualTo("PREPARE_TERMS");
+        assertThat(event.toString()).doesNotContain("message-terms", "contact-1", "ela", "designer");
+    }
+
+    @Test
+    void handoffEmitsOneInternalNotificationBeforeBlockingAndReplaysAsANoop() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        MemoryIcpObservations observations = new MemoryIcpObservations();
+        MemoryHandoffNotifications notifications = new MemoryHandoffNotifications();
+        conversations.value = ReceptionConversation.start("conversation-1", "contact-1", NOW);
+        StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, facts, transcript, observations, notifications);
+
+        Map<String, Object> first = tools.execute(DomainToolName.REQUEST_HUMAN_HANDOFF, "contact-1",
+                Map.of("reason", "cliente pediu uma pessoa"), context("message-handoff"));
+        Map<String, Object> replay = tools.execute(DomainToolName.REQUEST_HUMAN_HANDOFF, "contact-1",
+                Map.of("reason", "cliente pediu uma pessoa"), context("message-handoff"));
+
+        assertThat(replay).isEqualTo(first);
+        assertThat(notifications.events).hasSize(1);
+        HumanHandoffNotification notification = notifications.events.getFirst();
+        assertThat(notification.conversationId()).isEqualTo("conversation-1");
+        assertThat(notification.turnId()).isEqualTo("turn-1");
+        assertThat(notification.reason()).isEqualTo("cliente pediu uma pessoa");
+        assertThat(notification.idempotencyKey()).isEqualTo(first.get("handoffId"));
+        assertThat(notification.toString()).doesNotContain("contact-1", "message-handoff");
     }
 
     private static ToolExecutionContext context(String sourceMessageId) {
@@ -286,6 +694,32 @@ class StatefulDomainToolServiceTest {
         @Override public ReceptionConversation save(ReceptionConversation conversation) {
             savedVersions.add(conversation.version());
             return value = conversation;
+        }
+    }
+
+    private static final class MemoryIcpObservations implements IcpObservationEventGateway {
+        final List<IcpObservationEvent> events = new ArrayList<>();
+
+        @Override
+        public boolean appendIfAbsent(IcpObservationEvent event) {
+            if (events.stream().anyMatch(existing -> existing.idempotencyKey().equals(event.idempotencyKey()))) {
+                return false;
+            }
+            events.add(event);
+            return true;
+        }
+    }
+
+    private static final class MemoryHandoffNotifications implements HumanHandoffNotificationGateway {
+        final List<HumanHandoffNotification> events = new ArrayList<>();
+
+        @Override
+        public boolean notifyIfAbsent(HumanHandoffNotification notification) {
+            if (events.stream().anyMatch(existing -> existing.idempotencyKey().equals(notification.idempotencyKey()))) {
+                return false;
+            }
+            events.add(notification);
+            return true;
         }
     }
 

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/CustomerFactTypeTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/CustomerFactTypeTest.java
@@ -1,0 +1,27 @@
+package br.com.urbana.connect.domain.reception.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CustomerFactTypeTest {
+
+    @Test
+    void validatesAllowedTypesAndIdentifiesTheThreeIcpFields() {
+        assertThat(CustomerFactType.isAllowed(null)).isFalse();
+        assertThat(CustomerFactType.isAllowed("occupation")).isTrue();
+        assertThat(CustomerFactType.isAllowed("unknown")).isFalse();
+
+        assertThat(CustomerFactType.PRONOUN_PREFERENCE.isIcpField()).isTrue();
+        assertThat(CustomerFactType.FIRST_TIME_HIRING.isIcpField()).isTrue();
+        assertThat(CustomerFactType.OCCUPATION.isIcpField()).isTrue();
+        assertThat(CustomerFactType.NEED.isIcpField()).isFalse();
+        assertThat(CustomerFactType.SELECTED_SERVICE.isIcpField()).isFalse();
+
+        assertThat(CustomerFactType.icpFieldNames())
+                .containsExactly("PRONOUN_PREFERENCE", "FIRST_TIME_HIRING", "OCCUPATION");
+        assertThat(CustomerFactType.isIcpField(null)).isFalse();
+        assertThat(CustomerFactType.isIcpField("first_time_hiring")).isTrue();
+        assertThat(CustomerFactType.isIcpField("NEED")).isFalse();
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/ReceptionConversationTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/ReceptionConversationTest.java
@@ -41,6 +41,18 @@ class ReceptionConversationTest {
     }
 
     @Test
+    void incompleteIcpDoesNotBlockPaymentAfterTermsAreAccepted() {
+        ReceptionConversation conversation = ReceptionConversation.start("contact-1", now)
+                .selectService("DECOR_INTERIORES", now)
+                .presentTerms(now)
+                .acceptTerms(now);
+
+        ReceptionConversation prepared = conversation.preparePayment(false, "PIX", now);
+
+        assertThat(prepared.paymentStatus()).isEqualTo(PaymentStatus.PREPARED);
+    }
+
+    @Test
     void handoffStopsAiAndReturnRequiresExplicitOperatorAction() {
         ReceptionConversation conversation = ReceptionConversation.start("contact-1", now)
                 .requestHumanHandoff("cliente pediu uma pessoa", now.plusSeconds(1));
@@ -49,6 +61,41 @@ class ReceptionConversationTest {
         assertThat(conversation.handoffReason()).isEqualTo("cliente pediu uma pessoa");
         assertThatIllegalStateException().isThrownBy(() -> conversation.presentTerms(now.plusSeconds(2)));
 
+    }
+
+    @Test
+    void modelsTheVersionedFailClosedResumeStateAndOwnershipTransition() {
+        ReceptionConversation human = ReceptionConversation.start("contact-1", now)
+                .requestHumanHandoff("cliente pediu uma pessoa", now.plusSeconds(1));
+
+        ReceptionConversation syncing = human.beginResume("resume-1", "return-1", "sha256:abc", 3,
+                now.plusSeconds(2));
+        ReceptionConversation deciding = syncing.markResumeDeciding(now.plusSeconds(3));
+        ReceptionConversation completed = deciding.completeResume("WAIT", null, now.plusSeconds(4));
+
+        assertThat(syncing.mode()).isEqualTo(ReceptionMode.HUMAN);
+        assertThat(syncing.resumeStatus()).isEqualTo(ResumeStatus.SYNCHRONIZING);
+        assertThat(deciding.resumeStatus()).isEqualTo(ResumeStatus.DECIDING);
+        assertThat(completed.mode()).isEqualTo(ReceptionMode.AI);
+        assertThat(completed.resumeStatus()).isEqualTo(ResumeStatus.COMPLETED);
+        assertThat(completed.resumeId()).isEqualTo("resume-1");
+        assertThat(completed.version()).isEqualTo(human.version() + 3);
+    }
+
+    @Test
+    void preservesHumanOwnershipWhenResumeFailsAndReplaysSameActiveRequest() {
+        ReceptionConversation human = ReceptionConversation.start("contact-1", now)
+                .requestHumanHandoff("cliente pediu uma pessoa", now.plusSeconds(1));
+        ReceptionConversation syncing = human.beginResume("resume-1", "return-1", "sha256:abc", 1,
+                now.plusSeconds(2));
+
+        assertThat(syncing.beginResume("resume-1", "return-1", "sha256:abc", 1, now.plusSeconds(3)))
+                .isSameAs(syncing);
+        ReceptionConversation failed = syncing.failResume("RESUME_UNAVAILABLE", now.plusSeconds(4));
+
+        assertThat(failed.mode()).isEqualTo(ReceptionMode.HUMAN);
+        assertThat(failed.resumeStatus()).isEqualTo(ResumeStatus.FAILED_SAFE);
+        assertThat(failed.resumeFailureCode()).isEqualTo("RESUME_UNAVAILABLE");
     }
 
     @Test

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/AreaRuleTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/AreaRuleTest.java
@@ -1,0 +1,33 @@
+package br.com.urbana.connect.domain.servicecatalog.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AreaRuleTest {
+
+    @Test
+    void acceptsLimitedAndUnlimitedAreasAndRoutesOnlyOverflowToReview() {
+        AreaRule limited = AreaRule.UP_TO_20_SQM_PER_ENVIRONMENT;
+        AreaRule unlimited = AreaRule.UNLIMITED_BY_CATALOG;
+
+        assertThat(limited.maximumSquareMeters()).isEqualByComparingTo("20.00");
+        assertThat(limited.description()).isEqualTo("Até 20 m² por ambiente");
+        assertThat(limited.hasLimit()).isTrue();
+        assertThat(unlimited.maximumSquareMeters()).isNull();
+        assertThat(unlimited.hasLimit()).isFalse();
+
+        assertThat(limited.accepts(null)).isFalse();
+        assertThat(limited.accepts(new BigDecimal("-0.01"))).isFalse();
+        assertThat(limited.accepts(new BigDecimal("20.00"))).isTrue();
+        assertThat(limited.accepts(new BigDecimal("20.01"))).isFalse();
+        assertThat(unlimited.accepts(new BigDecimal("1000"))).isTrue();
+
+        assertThat(limited.requiresArchitectReview(null)).isFalse();
+        assertThat(limited.requiresArchitectReview(new BigDecimal("20"))).isFalse();
+        assertThat(limited.requiresArchitectReview(new BigDecimal("20.01"))).isTrue();
+        assertThat(unlimited.requiresArchitectReview(new BigDecimal("1000"))).isFalse();
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItemTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItemTest.java
@@ -1,0 +1,76 @@
+package br.com.urbana.connect.domain.servicecatalog.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServiceCatalogItemTest {
+
+    @Test
+    void canonicalCatalogContainsFourAvailableRichServicesAndNoLegacyAlias() {
+        var catalog = ServiceCatalogItem.canonicalCatalog();
+
+        assertThat(catalog)
+                .hasSize(4)
+                .extracting(ServiceCatalogItem::type)
+                .containsExactly(
+                        ServiceType.DECOR_INTERIORES,
+                        ServiceType.DECOR_PINTURA,
+                        ServiceType.DECOR_FACHADA,
+                        ServiceType.DECOR_REFORMA);
+        assertThat(catalog).allSatisfy(item -> {
+            assertThat(item.available()).isTrue();
+            assertThat(item.termsResource()).startsWith("https://fixtures.urbana.local/");
+            assertThat(item.paymentResource()).startsWith("https://fixtures.urbana.local/");
+            assertThat(item.briefingResource()).startsWith("https://fixtures.urbana.local/");
+            assertThat(item.deliverables()).containsExactly(
+                    "Manual PDF", "Tour Virtual", "3 opções de solução", "2 rodadas consolidadas");
+            assertThat(item.process()).anyMatch(value -> value.equals("briefing"));
+            assertThat(item.process()).anyMatch(value -> value.equals("medidas, fotos e vídeos"));
+            assertThat(item.process()).anyMatch(value -> value.contains("Google Meet"));
+            assertThat(item.process()).anyMatch(value -> value.equals("produção"));
+            assertThat(item.process()).anyMatch(value -> value.contains("7 dias úteis"));
+            assertThat(item.process()).anyMatch(value -> value.contains("e-mail"));
+            assertThat(item.process()).contains(
+                    "pagamento integral antecipado",
+                    "validação humana do comprovante",
+                    "validação dos dados pela arquiteta",
+                    "agendamento pelo link de disponibilidade da arquiteta",
+                    "pausa do prazo enquanto o cliente estiver pendente de feedback ou aprovação",
+                    "aprovação final explícita",
+                    "suporte de 3 meses pelo WhatsApp");
+            assertThat(item.responsibilities()).isNotEmpty();
+            assertThat(item.exclusions()).isNotEmpty();
+            assertThat(item.support()).contains("3 meses").containsIgnoringCase("sem visita");
+        });
+    }
+
+    @Test
+    void canonicalFactsMatchCommercialMatrixAndAreaRules() {
+        var byType = ServiceCatalogItem.canonicalCatalog().stream()
+                .collect(java.util.stream.Collectors.toMap(ServiceCatalogItem::type, item -> item));
+
+        assertThat(byType.get(ServiceType.DECOR_INTERIORES).price()).isEqualByComparingTo(new BigDecimal("400"));
+        assertThat(byType.get(ServiceType.DECOR_INTERIORES).areaRule())
+                .isEqualTo(AreaRule.UP_TO_20_SQM_PER_ENVIRONMENT);
+        assertThat(byType.get(ServiceType.DECOR_PINTURA).price()).isEqualByComparingTo(new BigDecimal("250"));
+        assertThat(byType.get(ServiceType.DECOR_PINTURA).areaRule())
+                .isEqualTo(AreaRule.UNLIMITED_BY_CATALOG);
+        assertThat(byType.get(ServiceType.DECOR_FACHADA).price()).isEqualByComparingTo(new BigDecimal("350"));
+        assertThat(byType.get(ServiceType.DECOR_FACHADA).areaRule())
+                .isEqualTo(AreaRule.UNLIMITED_BY_CATALOG);
+        assertThat(byType.get(ServiceType.DECOR_REFORMA).price()).isEqualByComparingTo(new BigDecimal("450"));
+        assertThat(byType.get(ServiceType.DECOR_REFORMA).areaRule())
+                .isEqualTo(AreaRule.UP_TO_20_SQM_PER_ENVIRONMENT);
+
+        assertThat(byType.get(ServiceType.DECOR_PINTURA).scope())
+                .contains("pintura", "desenhos", "tintas")
+                .doesNotContain("20 m²");
+        assertThat(byType.get(ServiceType.DECOR_FACHADA).scope())
+                .containsIgnoringCase("fachada")
+                .contains("externa")
+                .doesNotContain("20 m²");
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItemTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItemTest.java
@@ -33,8 +33,21 @@ class ServiceCatalogItemTest {
         assertThatThrownBy(() -> immutable.deliverables().add("outra"))
                 .isInstanceOf(UnsupportedOperationException.class);
 
+        ServiceCatalogItem nullableCollections = new ServiceCatalogItem(
+                ServiceType.DECOR, "Decor", "🏠", "escopo", "apresentação", BigDecimal.ONE,
+                null, null, null, AreaRule.UNLIMITED_BY_CATALOG, "escopo", null, null, null, null,
+                "suporte", true);
+        assertThat(nullableCollections.deliverables()).isEmpty();
+        assertThat(nullableCollections.process()).isEmpty();
+        assertThat(nullableCollections.responsibilities()).isEmpty();
+        assertThat(nullableCollections.exclusions()).isEmpty();
+
         assertThatThrownBy(() -> new ServiceCatalogItem(
                 ServiceType.DECOR, "", "🏠", "escopo", "apresentação", BigDecimal.ONE,
+                null, null, null, AreaRule.UNLIMITED_BY_CATALOG, "escopo", null, null, null, null,
+                "suporte", true)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ServiceCatalogItem(
+                ServiceType.DECOR, null, "🏠", "escopo", "apresentação", BigDecimal.ONE,
                 null, null, null, AreaRule.UNLIMITED_BY_CATALOG, "escopo", null, null, null, null,
                 "suporte", true)).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new ServiceCatalogItem(

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItemTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItemTest.java
@@ -3,10 +3,45 @@ package br.com.urbana.connect.domain.servicecatalog.model;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ServiceCatalogItemTest {
+
+    @Test
+    void protectsCatalogInvariantsAndDistinguishesFixtureResources() {
+        ServiceCatalogItem legacy = new ServiceCatalogItem(
+                ServiceType.DECOR, "Decor", "🏠", "escopo", "apresentação",
+                new BigDecimal("10"), "https://example.test/payment", "https://example.test/briefing", true);
+
+        assertThat(legacy.paymentLink()).isEqualTo("https://example.test/payment");
+        assertThat(legacy.briefingLink()).isEqualTo("https://example.test/briefing");
+        assertThat(legacy.termsLink()).isNull();
+        assertThat(legacy.description()).isEqualTo("escopo");
+        assertThat(legacy.areaLimitSqm()).isNull();
+        assertThat(legacy.isFixtureResource()).isFalse();
+
+        ServiceCatalogItem immutable = new ServiceCatalogItem(
+                ServiceType.DECOR_PINTURA, "Pintura", "🎨", "escopo", "apresentação",
+                new BigDecimal("10"), "https://fixtures.urbana.local/terms/pintura",
+                "https://fixtures.urbana.local/payment/pintura", "https://fixtures.urbana.local/briefing/pintura",
+                AreaRule.UNLIMITED_BY_CATALOG, "escopo", List.of("entrega"), List.of("processo"),
+                List.of("responsabilidade"), List.of("exclusão"), "suporte", true);
+        assertThat(immutable.isFixtureResource()).isTrue();
+        assertThatThrownBy(() -> immutable.deliverables().add("outra"))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThatThrownBy(() -> new ServiceCatalogItem(
+                ServiceType.DECOR, "", "🏠", "escopo", "apresentação", BigDecimal.ONE,
+                null, null, null, AreaRule.UNLIMITED_BY_CATALOG, "escopo", null, null, null, null,
+                "suporte", true)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ServiceCatalogItem(
+                ServiceType.DECOR, "Decor", "🏠", "escopo", "apresentação", new BigDecimal("-1"),
+                null, null, null, AreaRule.UNLIMITED_BY_CATALOG, "escopo", null, null, null, null,
+                "suporte", true)).isInstanceOf(IllegalArgumentException.class);
+    }
 
     @Test
     void canonicalCatalogContainsFourAvailableRichServicesAndNoLegacyAlias() {

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceTypeTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceTypeTest.java
@@ -1,0 +1,20 @@
+package br.com.urbana.connect.domain.servicecatalog.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServiceTypeTest {
+
+    @Test
+    void exposesCanonicalTypesAndMapsOnlyTheLegacyAlias() {
+        assertThat(ServiceType.canonicalValues())
+                .containsExactly(ServiceType.DECOR_INTERIORES, ServiceType.DECOR_PINTURA,
+                        ServiceType.DECOR_FACHADA, ServiceType.DECOR_REFORMA);
+        assertThat(ServiceType.DECOR.isCanonical()).isFalse();
+        assertThat(ServiceType.DECOR_INTERIORES.isCanonical()).isTrue();
+        assertThat(ServiceType.canonicalize(null)).isNull();
+        assertThat(ServiceType.canonicalize(ServiceType.DECOR)).isEqualTo(ServiceType.DECOR_INTERIORES);
+        assertThat(ServiceType.canonicalize(ServiceType.DECOR_REFORMA)).isEqualTo(ServiceType.DECOR_REFORMA);
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/hermes/HttpHermesResumeGatewayTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/hermes/HttpHermesResumeGatewayTest.java
@@ -1,0 +1,152 @@
+package br.com.urbana.connect.infrastructure.hermes;
+
+import br.com.urbana.connect.domain.reception.port.out.HermesResumeGateway;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class HttpHermesResumeGatewayTest {
+
+    @Test
+    void synchronizesFullTranscriptAndFactsAndNormalizesBaseUrl() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        HttpHermesResumeGateway gateway = new HttpHermesResumeGateway(
+                builder, "http://hermes.test/", "resume-secret");
+
+        server.expect(requestTo("http://hermes.test/api/internal/v1/sessions/session-1/context-sync"))
+                .andExpect(method(POST))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer resume-secret"))
+                .andExpect(jsonPath("$.contractVersion").value(1))
+                .andExpect(jsonPath("$.resumeId").value("resume-1"))
+                .andExpect(jsonPath("$.messages[0].content").value("Oi"))
+                .andExpect(jsonPath("$.facts[0].type").value("OCCUPATION"))
+                .andRespond(withSuccess(
+                        "{\"resumeId\":\"resume-1\",\"lineageId\":\"lineage-1\","
+                                + "\"effectiveSessionId\":\"session-2\",\"checksum\":\"sha256:abc\","
+                                + "\"cursor\":17,\"coveredThroughSequence\":4}",
+                        MediaType.APPLICATION_JSON));
+
+        HermesResumeGateway.ContextSyncReceipt receipt = gateway.synchronize("session-1",
+                new HermesResumeGateway.ResumeContext(1, "resume-1", "lineage-1", "idem-1",
+                        "HUMAN_TO_URBA", 12, 4, "sha256:abc",
+                        List.of(new HermesResumeGateway.ContextMessage(1, "m-1", "CUSTOMER", "user", "Oi")),
+                        List.of(new HermesResumeGateway.ContextFact("OCCUPATION", "designer", "CONFIRMED"))));
+
+        assertThat(receipt).isEqualTo(new HermesResumeGateway.ContextSyncReceipt(
+                "resume-1", "lineage-1", "session-2", "sha256:abc", 17, 4));
+        server.verify();
+    }
+
+    @Test
+    void decidesResumeAndSupportsNullableAndTextualMessages() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        HttpHermesResumeGateway gateway = new HttpHermesResumeGateway(
+                builder, "http://hermes.test", "secret");
+        HermesResumeGateway.ContextSyncReceipt receipt = new HermesResumeGateway.ContextSyncReceipt(
+                "resume-1", "lineage-1", "session-1", "sha256:abc", 17, 4);
+
+        server.expect(requestTo("http://hermes.test/api/internal/v1/sessions/session-1/resume-decide"))
+                .andExpect(method(POST))
+                .andExpect(jsonPath("$.contractVersion").value(1))
+                .andExpect(jsonPath("$.resumeId").value("resume-1"))
+                .andExpect(jsonPath("$.contextReceipt.effectiveSessionId").value("session-1"))
+                .andExpect(jsonPath("$.contextReceipt.coveredThroughSequence").value(4))
+                .andExpect(jsonPath("$.directive.nextStep").value("briefing"))
+                .andRespond(withSuccess(
+                        "{\"resumeId\":\"resume-1\",\"effectiveSessionId\":\"session-1\","
+                                + "\"action\":\"SEND_MESSAGE\",\"nextStep\":\"BRIEFING\","
+                                + "\"message\":null,\"evidenceMessageIds\":[\"m-4\"],"
+                                + "\"reasonCode\":\"HUMAN_RETURNED\",\"confidence\":0.91}",
+                        MediaType.APPLICATION_JSON));
+        server.expect(requestTo("http://hermes.test/api/internal/v1/sessions/session-1/resume-decide"))
+                .andExpect(method(POST))
+                .andRespond(withSuccess(
+                        "{\"resumeId\":\"resume-1\",\"effectiveSessionId\":\"session-1\","
+                                + "\"action\":\"WAIT\",\"nextStep\":\"PAYMENT\","
+                                + "\"message\":\"Aguardo seu retorno.\",\"evidenceMessageIds\":[],"
+                                + "\"reasonCode\":\"WAITING_CUSTOMER\",\"confidence\":0.5}",
+                        MediaType.APPLICATION_JSON));
+
+        HermesResumeGateway.ResumeDecision send = gateway.decide("session-1",
+                new HermesResumeGateway.ResumeCommand(1, "resume-1", "lineage-1", "idem-1", receipt,
+                        Map.of("nextStep", "briefing")));
+        HermesResumeGateway.ResumeDecision wait = gateway.decide("session-1",
+                new HermesResumeGateway.ResumeCommand(1, "resume-1", "lineage-1", "idem-1", receipt,
+                        Map.of()));
+
+        assertThat(send.action()).isEqualTo(HermesResumeGateway.Action.SEND_MESSAGE);
+        assertThat(send.message()).isNull();
+        assertThat(send.evidenceMessageIds()).containsExactly("m-4");
+        assertThat(send.confidence()).isEqualTo(0.91);
+        assertThat(wait.action()).isEqualTo(HermesResumeGateway.Action.WAIT);
+        assertThat(wait.message()).isEqualTo("Aguardo seu retorno.");
+        server.verify();
+    }
+
+    @Test
+    void classifiesHttpFailuresWithTheirStatus() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        HttpHermesResumeGateway gateway = new HttpHermesResumeGateway(
+                builder, "http://hermes.test", null);
+
+        server.expect(requestTo("http://hermes.test/api/internal/v1/sessions/s%2F1/context-sync"))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer "))
+                .andRespond(withServerError());
+
+        assertThatThrownBy(() -> gateway.synchronize("s/1",
+                new HermesResumeGateway.ResumeContext(1, "r", "l", "i", "mode", 0, 0, "checksum",
+                        List.of())))
+                .isInstanceOf(HttpHermesResumeGateway.ResumeGatewayException.class)
+                .satisfies(error -> assertThat(((HttpHermesResumeGateway.ResumeGatewayException) error).status())
+                        .isEqualTo(500));
+        server.verify();
+    }
+
+    @Test
+    void classifiesMalformedResponsesAsTransportFailuresAndRejectsInvalidRequiredFields() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        HttpHermesResumeGateway gateway = new HttpHermesResumeGateway(builder, "   ", "secret");
+
+        server.expect(requestTo("http://127.0.0.1:8642/api/internal/v1/sessions/s/context-sync"))
+                .andRespond(withSuccess("not-json", MediaType.APPLICATION_JSON));
+        assertThatThrownBy(() -> gateway.synchronize("s",
+                new HermesResumeGateway.ResumeContext(1, "r", "l", "i", "mode", 0, 0, "checksum",
+                        List.of())))
+                .isInstanceOf(HttpHermesResumeGateway.ResumeGatewayException.class)
+                .satisfies(error -> assertThat(((HttpHermesResumeGateway.ResumeGatewayException) error).status())
+                        .isZero());
+
+        RestClient.Builder secondBuilder = RestClient.builder();
+        MockRestServiceServer secondServer = MockRestServiceServer.bindTo(secondBuilder).build();
+        HttpHermesResumeGateway secondGateway = new HttpHermesResumeGateway(secondBuilder, null, "secret");
+        secondServer.expect(requestTo("http://127.0.0.1:8642/api/internal/v1/sessions/s/context-sync"))
+                .andRespond(withSuccess("{\"resumeId\":\" \"}", MediaType.APPLICATION_JSON));
+
+        assertThatThrownBy(() -> secondGateway.synchronize("s",
+                new HermesResumeGateway.ResumeContext(1, "r", "l", "i", "mode", 0, 0, "checksum",
+                        List.of())))
+                .isInstanceOf(HttpHermesResumeGateway.ResumeGatewayException.class)
+                .satisfies(error -> assertThat(((HttpHermesResumeGateway.ResumeGatewayException) error).status())
+                        .isZero());
+        secondServer.verify();
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/hermes/HttpHermesResumeGatewayTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/hermes/HttpHermesResumeGatewayTest.java
@@ -107,11 +107,11 @@ class HttpHermesResumeGatewayTest {
         HttpHermesResumeGateway gateway = new HttpHermesResumeGateway(
                 builder, "http://hermes.test", null);
 
-        server.expect(requestTo("http://hermes.test/api/internal/v1/sessions/s%2F1/context-sync"))
+        server.expect(requestTo("http://hermes.test/api/internal/v1/sessions/session-1/context-sync"))
                 .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer "))
                 .andRespond(withServerError());
 
-        assertThatThrownBy(() -> gateway.synchronize("s/1",
+        assertThatThrownBy(() -> gateway.synchronize("session-1",
                 new HermesResumeGateway.ResumeContext(1, "r", "l", "i", "mode", 0, 0, "checksum",
                         List.of())))
                 .isInstanceOf(HttpHermesResumeGateway.ResumeGatewayException.class)

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/hermes/HttpHermesResumeGatewayTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/hermes/HttpHermesResumeGatewayTest.java
@@ -148,5 +148,20 @@ class HttpHermesResumeGatewayTest {
                 .satisfies(error -> assertThat(((HttpHermesResumeGateway.ResumeGatewayException) error).status())
                         .isZero());
         secondServer.verify();
+
+        RestClient.Builder thirdBuilder = RestClient.builder();
+        MockRestServiceServer thirdServer = MockRestServiceServer.bindTo(thirdBuilder).build();
+        HttpHermesResumeGateway thirdGateway = new HttpHermesResumeGateway(thirdBuilder,
+                "http://hermes.test", "secret");
+        thirdServer.expect(requestTo("http://hermes.test/api/internal/v1/sessions/s/context-sync"))
+                .andRespond(withSuccess());
+
+        assertThatThrownBy(() -> thirdGateway.synchronize("s",
+                new HermesResumeGateway.ResumeContext(1, "r", "l", "i", "mode", 0, 0, "checksum",
+                        List.of())))
+                .isInstanceOf(HttpHermesResumeGateway.ResumeGatewayException.class)
+                .satisfies(error -> assertThat(((HttpHermesResumeGateway.ResumeGatewayException) error).status())
+                        .isZero());
+        thirdServer.verify();
     }
 }

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/MongoTransactionBoundaryIntegrationTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/MongoTransactionBoundaryIntegrationTest.java
@@ -1,0 +1,164 @@
+package br.com.urbana.connect.infrastructure.persistence.mongodb;
+
+import br.com.urbana.connect.domain.reception.model.CommercialStage;
+import br.com.urbana.connect.domain.reception.model.PaymentStatus;
+import br.com.urbana.connect.domain.reception.model.ReceptionMessageDirection;
+import br.com.urbana.connect.domain.reception.model.ReceptionMessageSender;
+import br.com.urbana.connect.domain.reception.model.ReceptionMessageType;
+import br.com.urbana.connect.domain.reception.model.ReceptionMode;
+import br.com.urbana.connect.domain.reception.model.TermsStatus;
+import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.ReceptionConversationDocument;
+import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.ReceptionMessageDocument;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Testcontainers
+class MongoTransactionBoundaryIntegrationTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-16T12:00:00Z");
+
+    @Container
+    static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:6.0.5");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", () -> mongoDBContainer.getReplicaSetUrl("pee104"));
+    }
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoTransactionManager mongoTransactionManager;
+
+    private final List<String> conversationIds = new ArrayList<>();
+    private final List<String> messageIds = new ArrayList<>();
+
+    @AfterEach
+    void cleanUpProbeDocuments() {
+        if (!conversationIds.isEmpty()) {
+            mongoTemplate.remove(Query.query(Criteria.where("_id").in(conversationIds)),
+                    ReceptionConversationDocument.class);
+        }
+        if (!messageIds.isEmpty()) {
+            mongoTemplate.remove(Query.query(Criteria.where("_id").in(messageIds)),
+                    ReceptionMessageDocument.class);
+        }
+    }
+
+    @Test
+    void commitsConversationVersionAndTranscriptMessageAtomically() {
+        String conversationId = probeId("conversation");
+        String messageId = probeId("message");
+        conversationIds.add(conversationId);
+        messageIds.add(messageId);
+        mongoTemplate.insert(conversation(conversationId));
+
+        new org.springframework.transaction.support.TransactionTemplate(mongoTransactionManager)
+                .executeWithoutResult(status -> {
+                    mongoTemplate.updateFirst(
+                            Query.query(Criteria.where("_id").is(conversationId)),
+                            new Update().set("version", 1L).set("updatedAt", NOW.plusSeconds(1)),
+                            ReceptionConversationDocument.class);
+                    mongoTemplate.insert(message(messageId, conversationId));
+                });
+
+        ReceptionConversationDocument persistedConversation = mongoTemplate.findById(
+                conversationId, ReceptionConversationDocument.class);
+        ReceptionMessageDocument persistedMessage = mongoTemplate.findById(
+                messageId, ReceptionMessageDocument.class);
+
+        assertThat(persistedConversation).isNotNull();
+        assertThat(persistedConversation.getVersion()).isEqualTo(1L);
+        assertThat(persistedMessage).isNotNull();
+        assertThat(persistedMessage.getConversationId()).isEqualTo(conversationId);
+    }
+
+    @Test
+    void rollsBackConversationVersionAndTranscriptMessageWithoutResidue() {
+        String conversationId = probeId("conversation");
+        String messageId = probeId("message");
+        conversationIds.add(conversationId);
+        messageIds.add(messageId);
+        mongoTemplate.insert(conversation(conversationId));
+
+        assertThatThrownBy(() ->
+                new org.springframework.transaction.support.TransactionTemplate(mongoTransactionManager)
+                        .executeWithoutResult(status -> {
+                            mongoTemplate.updateFirst(
+                                    Query.query(Criteria.where("_id").is(conversationId)),
+                                    new Update().set("version", 1L).set("updatedAt", NOW.plusSeconds(1)),
+                                    ReceptionConversationDocument.class);
+                            mongoTemplate.insert(message(messageId, conversationId));
+                            throw new IllegalStateException("force PEE-104 rollback");
+                        }))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("force PEE-104 rollback");
+
+        ReceptionConversationDocument persistedConversation = mongoTemplate.findById(
+                conversationId, ReceptionConversationDocument.class);
+        ReceptionMessageDocument persistedMessage = mongoTemplate.findById(
+                messageId, ReceptionMessageDocument.class);
+
+        assertThat(persistedConversation).isNotNull();
+        assertThat(persistedConversation.getVersion()).isZero();
+        assertThat(persistedMessage).isNull();
+        assertThat(mongoTemplate.exists(
+                Query.query(Criteria.where("eventId").is("pee104-event-" + messageId)),
+                ReceptionMessageDocument.class)).isFalse();
+    }
+
+    private static String probeId(String kind) {
+        return "pee104-" + kind + "-" + UUID.randomUUID();
+    }
+
+    private static ReceptionConversationDocument conversation(String id) {
+        ReceptionConversationDocument document = new ReceptionConversationDocument();
+        document.setId(id);
+        document.setContactId(id + "-contact");
+        document.setMode(ReceptionMode.AI);
+        document.setCommercialStage(CommercialStage.DISCOVERY);
+        document.setTermsStatus(TermsStatus.NOT_PRESENTED);
+        document.setPaymentStatus(PaymentStatus.NOT_STARTED);
+        document.setCreatedAt(NOW);
+        document.setUpdatedAt(NOW);
+        document.setVersion(0);
+        return document;
+    }
+
+    private static ReceptionMessageDocument message(String id, String conversationId) {
+        ReceptionMessageDocument document = new ReceptionMessageDocument();
+        document.setId(id);
+        document.setEventId("pee104-event-" + id);
+        document.setCorrelationId("pee104-correlation-" + id);
+        document.setConversationId(conversationId);
+        document.setContactId(conversationId + "-contact");
+        document.setDirection(ReceptionMessageDirection.INBOUND);
+        document.setSenderType(ReceptionMessageSender.CONTACT);
+        document.setType(ReceptionMessageType.TEXT);
+        document.setText("synthetic PEE-104 transaction probe");
+        document.setCreatedAt(NOW);
+        return document;
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoReceptionBoundaryGatewayTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoReceptionBoundaryGatewayTest.java
@@ -1,0 +1,58 @@
+package br.com.urbana.connect.infrastructure.persistence.mongodb.reception;
+
+import br.com.urbana.connect.domain.reception.model.HumanHandoffNotification;
+import br.com.urbana.connect.domain.reception.model.IcpObservationEvent;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MongoReceptionBoundaryGatewayTest {
+    private static final Instant NOW = Instant.parse("2026-08-05T12:00:00Z");
+
+    @Test
+    void storesIcpObservationOutsideTheTranscriptAndReplaysTheSameEventAsNoop() {
+        SpringDataIcpObservationEventRepository repository = mock(SpringDataIcpObservationEventRepository.class);
+        IcpObservationEvent event = IcpObservationEvent.beforeTerms("conversation-1", "turn-1",
+                "DECOR_PINTURA", List.of("OCCUPATION"), "icp-key-1", NOW);
+        when(repository.findById(event.eventId())).thenReturn(Optional.empty(), Optional.of(document(event)));
+        when(repository.save(any(IcpObservationEventDocument.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        MongoIcpObservationEventGateway gateway = new MongoIcpObservationEventGateway(repository);
+
+        assertThat(gateway.appendIfAbsent(event)).isTrue();
+        assertThat(gateway.appendIfAbsent(event)).isFalse();
+        verify(repository, times(1)).save(any(IcpObservationEventDocument.class));
+    }
+
+    @Test
+    void handoffNotificationTreatsAConcurrentDuplicateAsAnIdempotentNoop() {
+        SpringDataHumanHandoffNotificationRepository repository =
+                mock(SpringDataHumanHandoffNotificationRepository.class);
+        HumanHandoffNotification notification = HumanHandoffNotification.create("handoff-key-1",
+                "conversation-1", "turn-1", "cliente pediu uma pessoa", "DECOR_PINTURA",
+                "ICP", "NOT_STARTED", List.of("OCCUPATION"), List.of("PRONOUN_PREFERENCE"), NOW);
+        when(repository.findById(notification.notificationId())).thenReturn(Optional.empty());
+        when(repository.save(any(HumanHandoffNotificationDocument.class)))
+                .thenThrow(new DuplicateKeyException("duplicate"));
+        MongoHumanHandoffNotificationGateway gateway = new MongoHumanHandoffNotificationGateway(repository);
+
+        assertThat(gateway.notifyIfAbsent(notification)).isFalse();
+        verify(repository).save(any(HumanHandoffNotificationDocument.class));
+    }
+
+    private static IcpObservationEventDocument document(IcpObservationEvent event) {
+        IcpObservationEventDocument document = new IcpObservationEventDocument();
+        document.setEventId(event.eventId());
+        return document;
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/MongoServiceCatalogGatewayIntegrationTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/MongoServiceCatalogGatewayIntegrationTest.java
@@ -37,69 +37,112 @@ class MongoServiceCatalogGatewayIntegrationTest {
     private ServiceCatalogSeeder serviceCatalogSeeder;
 
     @Test
-    void shouldSeedInitialCatalogOnStartup() {
+    void shouldSeedInitialCanonicalCatalogOnStartup() {
         var catalog = serviceCatalogGateway.findAll();
 
         assertThat(catalog)
             .hasSize(4)
             .extracting(ServiceCatalogItem::type)
             .containsExactlyInAnyOrder(
-                ServiceType.DECOR,
+                ServiceType.DECOR_INTERIORES,
                 ServiceType.DECOR_PINTURA,
                 ServiceType.DECOR_FACHADA,
                 ServiceType.DECOR_REFORMA
             );
 
+        assertThat(catalog).allSatisfy(item -> {
+            assertThat(item.available()).isTrue();
+            assertThat(item.termsResource()).startsWith("https://fixtures.urbana.local/");
+            assertThat(item.paymentResource()).startsWith("https://fixtures.urbana.local/");
+            assertThat(item.briefingResource()).startsWith("https://fixtures.urbana.local/");
+            assertThat(item.areaRule()).isNotNull();
+            assertThat(item.scope()).isNotBlank();
+            assertThat(item.deliverables()).contains(
+                "Manual PDF", "Tour Virtual", "3 opções de solução", "2 rodadas consolidadas");
+            assertThat(item.process()).anyMatch(value -> value.contains("briefing"));
+            assertThat(item.process()).anyMatch(value -> value.contains("Google Meet"));
+            assertThat(item.process()).anyMatch(value -> value.contains("7 dias úteis"));
+            assertThat(item.process()).anyMatch(value -> value.contains("e-mail"));
+            assertThat(item.responsibilities()).isNotEmpty();
+            assertThat(item.exclusions()).isNotEmpty();
+            assertThat(item.support()).contains("3 meses");
+        });
+
         assertThat(serviceCatalogGateway.findByType(ServiceType.DECOR_REFORMA))
             .isPresent()
             .get()
-            .extracting(ServiceCatalogItem::available, ServiceCatalogItem::paymentLink)
-            .containsExactly(false, null);
+            .extracting(ServiceCatalogItem::available, ServiceCatalogItem::price)
+            .containsExactly(true, new java.math.BigDecimal("450.00"));
     }
 
     @Test
-    void shouldReturnOnlyAvailableServices() {
+    void shouldReturnOnlyAvailableCanonicalServices() {
         var availableServices = serviceCatalogGateway.findAvailable();
 
         assertThat(availableServices)
+            .hasSize(4)
             .extracting(ServiceCatalogItem::type)
             .containsExactlyInAnyOrder(
-                ServiceType.DECOR,
+                ServiceType.DECOR_INTERIORES,
                 ServiceType.DECOR_PINTURA,
-                ServiceType.DECOR_FACHADA
+                ServiceType.DECOR_FACHADA,
+                ServiceType.DECOR_REFORMA
             );
     }
 
     @Test
-    void shouldRefreshCatalogCopyWithoutOverwritingOperationalFields() throws Exception {
-        ServiceCatalogDocument original = repository.findByType(ServiceType.DECOR)
+    void shouldCanonicalizeLegacyAliasAtTheGatewayBoundary() {
+        ServiceCatalogItem resolved = serviceCatalogGateway.findByType(ServiceType.DECOR)
+            .orElseThrow();
+
+        assertThat(resolved.type()).isEqualTo(ServiceType.DECOR_INTERIORES);
+        assertThat(resolved.name()).isEqualTo("Decor Interiores");
+        assertThat(serviceCatalogGateway.findAll())
+            .noneMatch(item -> item.type() == ServiceType.DECOR);
+    }
+
+    @Test
+    void shouldRefreshCatalogCopyWithAllCanonicalRichFields() {
+        ServiceCatalogDocument original = repository.findByType(ServiceType.DECOR_INTERIORES)
             .orElseThrow();
         ServiceCatalogDocument mutated = new ServiceCatalogDocument();
         mutated.setId(original.getId());
         mutated.setType(original.getType());
-        mutated.setName(original.getName());
-        mutated.setEmoji(original.getEmoji());
-        mutated.setPrice(original.getPrice());
+        mutated.setName("cópia antiga");
+        mutated.setEmoji("❌");
+        mutated.setPrice(new java.math.BigDecimal("1.00"));
         mutated.setScenarioText("copy antiga");
         mutated.setPresentationText("apresentação antiga");
-        mutated.setPaymentLink("https://custom.example/pagamento");
-        mutated.setBriefingLink("https://custom.example/briefing");
+        mutated.setTermsResource("https://mpago.la/legacy-terms");
+        mutated.setPaymentResource("https://mpago.la/legacy-payment");
+        mutated.setBriefingResource("https://forms.gle/legacy-briefing");
+        mutated.setAreaRule(null);
+        mutated.setScope(null);
+        mutated.setDeliverables(null);
+        mutated.setProcess(null);
+        mutated.setResponsibilities(null);
+        mutated.setExclusions(null);
+        mutated.setSupport(null);
         mutated.setAvailable(false);
         repository.save(mutated);
 
         try {
             serviceCatalogSeeder.run(new DefaultApplicationArguments(new String[0]));
 
-            ServiceCatalogItem updated = serviceCatalogGateway.findByType(ServiceType.DECOR)
+            ServiceCatalogItem updated = serviceCatalogGateway.findByType(ServiceType.DECOR_INTERIORES)
                 .orElseThrow();
 
-            assertThat(updated.scenarioText()).isEqualTo("Quero renovar meu espaço interno sem gastar muito, nada de quebra-quebra.");
-            assertThat(updated.presentationText())
-                .contains("Para espaços de até 20m², temos a Decor 🛋️")
-                .contains("solução faça você mesmo");
-            assertThat(updated.paymentLink()).isEqualTo("https://custom.example/pagamento");
-            assertThat(updated.briefingLink()).isEqualTo("https://custom.example/briefing");
-            assertThat(updated.available()).isFalse();
+            ServiceCatalogItem expected = ServiceCatalogItem.canonicalCatalog().stream()
+                .filter(item -> item.type() == ServiceType.DECOR_INTERIORES)
+                .findFirst()
+                .orElseThrow();
+
+            assertThat(updated).isEqualTo(expected);
+            assertThat(updated.termsResource()).startsWith("https://fixtures.urbana.local/");
+            assertThat(updated.paymentResource()).startsWith("https://fixtures.urbana.local/");
+            assertThat(updated.briefingResource()).startsWith("https://fixtures.urbana.local/");
+            assertThat(updated.paymentResource()).doesNotContain("mpago.la");
+            assertThat(updated.briefingResource()).doesNotContain("forms.gle");
         } finally {
             repository.save(original);
         }

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/ServiceCatalogSeederTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/ServiceCatalogSeederTest.java
@@ -1,0 +1,70 @@
+package br.com.urbana.connect.infrastructure.persistence.mongodb.servicecatalog;
+
+import br.com.urbana.connect.domain.servicecatalog.model.ServiceType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ServiceCatalogSeederTest {
+
+    @Test
+    void seedsTheSameFourRichCanonicalServicesAsThePolicy() {
+        var repository = mock(SpringDataServiceCatalogRepository.class);
+        when(repository.findByType(any(ServiceType.class))).thenReturn(Optional.empty());
+        var seeder = new ServiceCatalogSeeder(repository);
+
+        seeder.run(null);
+
+        var captor = org.mockito.ArgumentCaptor.forClass(ServiceCatalogDocument.class);
+        verify(repository, org.mockito.Mockito.times(4)).save(captor.capture());
+        var saved = captor.getAllValues();
+        assertThat(saved).extracting(ServiceCatalogDocument::getType)
+                .containsExactly(
+                        ServiceType.DECOR_INTERIORES,
+                        ServiceType.DECOR_PINTURA,
+                        ServiceType.DECOR_FACHADA,
+                        ServiceType.DECOR_REFORMA);
+        assertThat(saved).allSatisfy(item -> {
+            assertThat(item.isAvailable()).isTrue();
+            assertThat(item.getAreaRule()).isNotNull();
+            assertThat(item.getDeliverables()).contains("Manual PDF", "Tour Virtual");
+            assertThat(item.getProcess()).anyMatch(value -> value.contains("Google Meet"));
+            assertThat(item.getProcess()).anyMatch(value -> value.contains("7 dias úteis"));
+            assertThat(item.getTermsResource()).startsWith("https://fixtures.urbana.local/");
+            assertThat(item.getPaymentResource()).startsWith("https://fixtures.urbana.local/");
+            assertThat(item.getBriefingResource()).startsWith("https://fixtures.urbana.local/");
+        });
+    }
+
+    @Test
+    void refreshesLegacyCopyFieldsAndApprovedFixtureResourcesFromCanonicalCatalog() {
+        var repository = mock(SpringDataServiceCatalogRepository.class);
+        var existing = new ServiceCatalogDocument();
+        existing.setType(ServiceType.DECOR_PINTURA);
+        existing.setName("cópia antiga");
+        existing.setPaymentLink("https://mpago.la/legacy");
+        existing.setBriefingLink("https://forms.gle/legacy");
+        existing.setAvailable(false);
+        when(repository.findByType(ServiceType.DECOR_PINTURA)).thenReturn(Optional.of(existing));
+        when(repository.findByType(ServiceType.DECOR_INTERIORES)).thenReturn(Optional.empty());
+        when(repository.findByType(ServiceType.DECOR_FACHADA)).thenReturn(Optional.empty());
+        when(repository.findByType(ServiceType.DECOR_REFORMA)).thenReturn(Optional.empty());
+        var seeder = new ServiceCatalogSeeder(repository);
+
+        seeder.run(null);
+
+        verify(repository, org.mockito.Mockito.times(4)).save(any(ServiceCatalogDocument.class));
+        assertThat(existing.getName()).isEqualTo("Decor Pintura");
+        assertThat(existing.isAvailable()).isTrue();
+        assertThat(existing.getPaymentResource()).startsWith("https://fixtures.urbana.local/");
+        assertThat(existing.getBriefingResource()).startsWith("https://fixtures.urbana.local/");
+        assertThat(existing.getPaymentResource()).doesNotContain("mpago.la");
+        assertThat(existing.getBriefingResource()).doesNotContain("forms.gle");
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/interfaces/rest/poc/ConversationSimulatorControllerTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/interfaces/rest/poc/ConversationSimulatorControllerTest.java
@@ -9,6 +9,8 @@ import br.com.urbana.connect.application.reception.ReceptionOrchestrator;
 import br.com.urbana.connect.domain.reception.model.AgentNextAction;
 import br.com.urbana.connect.domain.reception.model.AgentOutput;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessageType;
+import br.com.urbana.connect.domain.reception.model.ResumeStatus;
+import br.com.urbana.connect.domain.reception.port.out.HermesResumeGateway;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -78,6 +81,65 @@ class ConversationSimulatorControllerTest {
                 .andExpect(jsonPath("$.output.message").value("Briefing DECOR liberado."));
 
         verify(orchestrator).approvePaymentProof("poc:ana");
+    }
+
+    @Test
+    void exposesBackendControlledHumanMessageAndIdempotentReturnRoutesBehindThePocToken() throws Exception {
+        ReceptionOrchestrator orchestrator = mock(ReceptionOrchestrator.class);
+        PocReceptionIngress ingress = mock(PocReceptionIngress.class);
+        HermesResumeGateway resumeGateway = mock(HermesResumeGateway.class);
+        when(orchestrator.recordHumanMessage(eq("poc:ana"), eq("human-1"), eq("Decisão humana"),
+                eq(Instant.parse("2026-08-05T12:00:00Z"))))
+                .thenReturn(new ReceptionOrchestrator.HumanMessageReceipt(
+                        "human-event-1", "RECORDED", false, "Mensagem humana registrada."));
+        when(orchestrator.returnToUrba(eq("poc:ana"), eq("return-1"), eq(7L), same(resumeGateway)))
+                .thenReturn(new ReceptionOrchestrator.ResumeReceipt(
+                        "resume-1", ResumeStatus.COMPLETED, "URBA", null, false,
+                        "A Urba retomou o atendimento."));
+        MockMvc mvc = MockMvcBuilders.standaloneSetup(
+                new ConversationSimulatorController(orchestrator, ingress, "poc-token", resumeGateway)).build();
+
+        mvc.perform(post("/api/poc/conversations/ana/human/messages")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer poc-token")
+                        .header("Idempotency-Key", "human-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"text\":\"Decisão humana\",\"occurredAt\":\"2026-08-05T12:00:00Z\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("RECORDED"))
+                .andExpect(jsonPath("$.message").value("Mensagem humana registrada."));
+
+        mvc.perform(post("/api/poc/conversations/ana/ownership/urba")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer poc-token")
+                        .header("Idempotency-Key", "return-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"expectedVersion\":7}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ownership").value("URBA"))
+                .andExpect(jsonPath("$.status").value("COMPLETED"));
+
+        verify(orchestrator).recordHumanMessage("poc:ana", "human-1", "Decisão humana",
+                Instant.parse("2026-08-05T12:00:00Z"));
+        verify(orchestrator).returnToUrba("poc:ana", "return-1", 7L, resumeGateway);
+    }
+
+    @Test
+    void protectsOperatorRoutesWithTheSamePocToken() throws Exception {
+        ReceptionOrchestrator orchestrator = mock(ReceptionOrchestrator.class);
+        PocReceptionIngress ingress = mock(PocReceptionIngress.class);
+        MockMvc mvc = MockMvcBuilders.standaloneSetup(
+                new ConversationSimulatorController(orchestrator, ingress, "poc-token", mock(HermesResumeGateway.class)))
+                .build();
+
+        mvc.perform(post("/api/poc/conversations/ana/human/messages")
+                        .header("Idempotency-Key", "human-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"text\":\"Decisão\"}"))
+                .andExpect(status().isUnauthorized());
+        mvc.perform(post("/api/poc/conversations/ana/ownership/urba")
+                        .header("Idempotency-Key", "return-1"))
+                .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(orchestrator);
     }
 
     @Test

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/interfaces/rest/poc/DomainToolControllerTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/interfaces/rest/poc/DomainToolControllerTest.java
@@ -65,7 +65,7 @@ class DomainToolControllerTest {
     }
 
     @Test
-    void delegatesOnlyAllowlistedToolWithSessionIdentityAndReturnsDerivedIdempotencyKey() {
+    void delegatesOnlyAllowlistedToolWithoutExposingTheInternalIdempotencyKey() {
         DomainToolInvocationUseCase useCase = mock(DomainToolInvocationUseCase.class);
         DomainToolController controller = new DomainToolController(useCase, TOKEN, PRINCIPAL);
         when(useCase.invoke(eq("session-1"), eq(PRINCIPAL), eq(DomainToolName.PREPARE_TERMS), any()))
@@ -76,13 +76,13 @@ class DomainToolControllerTest {
 
         assertThat(response.getStatusCode().value()).isEqualTo(200);
         assertThat(response.getBody().ok()).isTrue();
-        assertThat(response.getBody().idempotencyKey()).isEqualTo("turn-1:prepare_terms:hash");
+        assertThat(response.getBody().idempotencyKey()).isNull();
         verify(useCase).invoke(eq("session-1"), eq(PRINCIPAL), eq(DomainToolName.PREPARE_TERMS),
                 eq(Map.of("serviceType", "DECOR")));
     }
 
     @Test
-    void redactsCredentialLikeDetailsFromDomainErrors() {
+    void replacesTechnicalFailureDetailsWithAStructuredSafeEnvelope() {
         DomainToolInvocationUseCase useCase = mock(DomainToolInvocationUseCase.class);
         DomainToolController controller = new DomainToolController(useCase, TOKEN, PRINCIPAL);
         when(useCase.invoke(any(), any(), eq(DomainToolName.GET_CUSTOMER_PROFILE), any()))
@@ -92,8 +92,30 @@ class DomainToolControllerTest {
                 new DomainToolController.ToolRequest("session-1", PRINCIPAL, Map.of()));
 
         assertThat(response.getStatusCode().value()).isEqualTo(409);
-        assertThat(response.getBody().error()).doesNotContain("super-secret-token", "OPENROUTER_API_KEY");
-        assertThat(response.getBody().error()).contains("REDACTED");
+        assertThat(response.getBody().error().code()).isEqualTo("BUSINESS_RULE_REJECTED");
+        assertThat(response.getBody().error().customerMessage())
+                .doesNotContain("super-secret-token", "OPENROUTER_API_KEY", "sistema", "ferramenta", "API",
+                        "banco", "HTTP", "exceção", "retry", "idempotência", "stack");
+    }
+
+    @Test
+    void returnsStableBusinessCodeNextActionAndCustomerSafeMessage() {
+        DomainToolInvocationUseCase useCase = mock(DomainToolInvocationUseCase.class);
+        DomainToolController controller = new DomainToolController(useCase, TOKEN, PRINCIPAL);
+        when(useCase.invoke(any(), any(), eq(DomainToolName.PREPARE_PAYMENT), any()))
+                .thenThrow(new DomainToolInvocationUseCase.DomainRejectionException(
+                        "TERMS_NOT_ACCEPTED", "ASK_FOR_CLEAR_ACCEPTANCE", java.util.List.of(),
+                        "Antes do pagamento, preciso do seu aceite claro dos termos."));
+
+        var response = controller.invoke("prepare_payment", "Bearer " + TOKEN,
+                new DomainToolController.ToolRequest("session-1", PRINCIPAL,
+                        Map.of("serviceType", "DECOR", "method", "PIX")));
+
+        assertThat(response.getStatusCode().value()).isEqualTo(409);
+        assertThat(response.getBody().error().code()).isEqualTo("TERMS_NOT_ACCEPTED");
+        assertThat(response.getBody().error().nextAction()).isEqualTo("ASK_FOR_CLEAR_ACCEPTANCE");
+        assertThat(response.getBody().error().customerMessage())
+                .isEqualTo("Antes do pagamento, preciso do seu aceite claro dos termos.");
     }
 
     @Test

--- a/docs/specs/pee-102-catalogo-e-contexto-operacional-urba.md
+++ b/docs/specs/pee-102-catalogo-e-contexto-operacional-urba.md
@@ -1,0 +1,503 @@
+# PEE-102 — Catálogo de serviços e contexto operacional da Urba
+
+## Metadados
+
+- **Ticket:** [PEE-102](https://urbanadobrasil.atlassian.net/browse/PEE-102)
+- **Épico relacionado:** PEE-23 — Urba: Fluxo de Triagem e Vendas
+- **Status:** contrato de negócio e discovery técnica consolidados; implementação não iniciada
+- **Data da consolidação:** 2026-08-16
+- **Fonte de negócio:** entrevista com a Urbana do Brasil, registrada na PEE-102
+
+## 1. Objetivo
+
+Dar à Urba contexto suficiente para explicar, qualificar e encaminhar os quatro
+serviços da Urbana do Brasil com precisão, mantendo a conversa simples e
+natural. O catálogo também define o que pertence à Urba, o que pertence à
+arquiteta e o que fica sob responsabilidade do cliente.
+
+Esta spec é a referência de negócio para complementar e, quando necessário,
+substituir informações antigas dos scripts e da especificação inicial da
+PEE-23. Links de pagamento presentes em materiais antigos não são fonte de
+verdade.
+
+## 2. Identidade e proposta da Urbana
+
+A Urba deve se identificar como **“Urba, a assistente virtual da Urbana do
+Brasil”**. Ela não deve se apresentar como arquiteta, responsável técnica ou
+executora do serviço.
+
+A Urbana oferece consultoria online para criar uma solução específica para o
+ambiente do cliente, materializada em um Manual prático. A proposta é
+democratizar arquitetura e interiores e empoderar mulheres e
+microempreendedores do Nordeste a transformarem seus lares e pequenos
+negócios de forma acessível e amigável.
+
+Os serviços podem ser contratados por pessoas e pequenos negócios de qualquer
+região do Brasil.
+
+Termos preferenciais:
+
+- consultoria online;
+- Manual;
+- Tour Virtual;
+- solução para o ambiente.
+
+Evitar, salvo explicação contextual da arquiteta:
+
+- projeto executivo;
+- obra completa;
+- execução;
+- gestão de obra;
+- garantia do resultado da obra.
+
+## 3. Catálogo comercial vigente
+
+Todos os quatro serviços estão disponíveis para contratação. Os preços abaixo
+são por ambiente e por contratação independente.
+
+| Serviço | Preço padrão | Limite de área | Escopo resumido |
+|---|---:|---|---|
+| **Decor Interiores** | R$ 400 | Até 20 m² por ambiente | Solução para ambiente interno, com layout, mobiliário, cores e composição; sem intervenção estrutural. |
+| **Decor Pintura** | R$ 250 | Sem limite de m² | Pintura, desenhos e especificação de tintas; não inclui layout, mobiliário ou ensino prático de pintura. |
+| **Decor Fachada** | R$ 350 | Sem limite de m² | Fachada ou parede externa, podendo considerar pintura e elementos complementares como revestimentos, portão, iluminação e paisagismo. |
+| **Decor Reforma** | R$ 450 | Até 20 m² por ambiente | Solução para reforma interna; qualquer demanda técnica específica precisa ser avaliada pela arquiteta. |
+
+Regras comerciais:
+
+- não há pacote ou desconto automático;
+- a Urba nunca oferece desconto, condição especial ou negociação por iniciativa própria;
+- múltiplos ambientes são múltiplas contratações, mesmo que a arquiteta os conduza na mesma agenda;
+- serviços diferentes no mesmo ambiente também são contratações separadas;
+- os valores individuais podem ser apresentados separadamente;
+- a Urba não envia link de pagamento se não souber qual serviço/ambiente está sendo contratado;
+- os links antigos dos scripts estão desatualizados e não devem ser usados como fonte de pagamento;
+- se o link correto não estiver disponível ou houver dúvida, a Urba encaminha para o atendimento humano.
+
+### 3.1 Decor Interiores
+
+Atende um ambiente interno de até 20 m². A solução pode abordar layout,
+mobiliário, cores, materiais e composição visual. Não envolve intervenção
+estrutural ou execução prática.
+
+O Manual pode trazer sugestões de mobiliário e materiais. Estoque,
+disponibilidade, preço e existência de links de compra não são garantidos.
+
+### 3.2 Decor Pintura
+
+É focado em pintura, desenhos e escolha/especificação de tintas. O Manual pode
+especificar o desenho e a tinta, mas não ensina como pintar e não inclui
+tutorial técnico de execução.
+
+Não prometer layout, mobiliário, reforma geral ou acompanhamento da pintura
+como parte deste serviço.
+
+### 3.3 Decor Fachada
+
+É focado em fachada, muro ou parede externa. A solução pode agregar elementos
+que melhorem o resultado, como revestimentos, portão, iluminação, paisagismo e
+outros componentes externos. A inclusão e o nível de detalhamento ficam a
+critério da arquiteta na confecção do Manual.
+
+A Urba pode orientar o cliente até esse serviço quando a necessidade fizer
+sentido. Não deve encaminhar automaticamente apenas porque o cliente citou um
+elemento complementar.
+
+### 3.4 Decor Reforma
+
+É voltado a uma solução de reforma interna. Pedidos que mencionem paredes,
+estrutura, elétrica, hidráulica, gás, viabilidade técnica, ART/RRT, projeto
+legal ou aprovação em condomínio/prefeitura devem ser encaminhados
+imediatamente à arquiteta.
+
+A Urba não confirma previamente que esses itens estão incluídos, são viáveis,
+serão aprovados ou serão executados.
+
+## 4. Entregas comuns aos quatro serviços
+
+Como padrão comercial, os quatro serviços incluem:
+
+- Manual em PDF;
+- Tour Virtual, normalmente um vídeo renderizado disponibilizado por link não listado do YouTube;
+- três opções de solução;
+- duas rodadas de ajustes;
+- suporte de três meses após a entrega.
+
+As opções, o nível de detalhamento do Tour e os ajustes são conduzidos pela
+arquiteta. Uma rodada representa um conjunto consolidado de feedbacks. Uma
+terceira rodada pode ser autorizada como exceção pela arquiteta, normalmente
+como cortesia, mas não deve ser prometida pela Urba.
+
+O suporte de três meses deve ser chamado de **suporte**, não de garantia. Ele
+cobre dúvidas sobre o Manual e as cores pelo WhatsApp. Não inclui visita ao
+local, gestão direta da obra ou responsabilidade pelo resultado da execução.
+
+## 5. Responsabilidades
+
+### 5.1 Urba
+
+Antes da transferência formal para o humano, a Urba:
+
+- conduz a triagem comercial;
+- ajuda o cliente a identificar o serviço adequado;
+- apresenta o preço vigente e o resumo do serviço;
+- envia os termos pelo WhatsApp;
+- valida que houve aceite textual antes de pagamento;
+- envia o link de pagamento correto;
+- recebe o comprovante;
+- encaminha dúvidas que não consegue resolver;
+- envia o briefing e o link de agendamento nos momentos corretos.
+
+Após a arquiteta devolver a conversa para a Urba, ela retoma o funil e trata
+perguntas gerais. Dúvidas específicas sobre Manual, Tour, cores ou execução
+voltam para a arquiteta.
+
+### 5.2 Arquiteta
+
+A arquiteta é responsável por:
+
+- validar o comprovante de pagamento na primeira versão;
+- validar briefing, medidas, fotos e vídeos;
+- conduzir a reunião no Google Meet;
+- definir e produzir as soluções, opções, ajustes, Manual e Tour;
+- avaliar exceções, limites de área e demandas técnicas;
+- decidir sobre orientações pontuais, suporte e correções;
+- conduzir atrasos, faltas e reprogramações da reunião;
+- enviar a entrega final por e-mail;
+- decidir quando a conversa pode voltar ao funil da Urba.
+
+Enquanto a conversa está sob responsabilidade da arquiteta, as decisões dela
+são a fonte de verdade daquele caso, mesmo que sejam específicas e diferentes
+da regra genérica do catálogo.
+
+### 5.3 Cliente
+
+O cliente é responsável por:
+
+- aceitar os termos;
+- pagar integralmente antes do briefing/início;
+- enviar briefing, medidas corretas, fotos e vídeos;
+- comprar materiais;
+- escolher e contratar profissionais;
+- executar ou acompanhar a execução;
+- verificar preço, estoque, disponibilidade e links dos produtos;
+- assumir custos, prazos, qualidade e resultado da execução.
+
+A Urbana especifica materiais, mas não compra, não fornece, não contrata mão
+de obra e atualmente não mantém uma rede de profissionais para indicação.
+
+## 6. Fluxo comercial e operacional
+
+### 6.1 Descoberta e escolha do serviço
+
+A abertura deve ser curta e natural. Exemplo de direção:
+
+> Olá! Eu sou a Urba, assistente virtual da Urbana do Brasil. Posso te ajudar a entender qual dos nossos serviços combina melhor com o que você precisa. O que você gostaria de transformar?
+
+A Urba deve:
+
+1. fazer perguntas abertas e simples;
+2. entender o objetivo do cliente;
+3. sugerir um serviço como hipótese;
+4. explicar essa hipótese em um mini resumo;
+5. aguardar a confirmação explícita do cliente;
+6. confirmar o enquadramento do ambiente, incluindo a área quando aplicável;
+7. seguir para os termos somente depois da confirmação.
+
+O mini resumo usado para sugerir o serviço já explica o suficiente e pede a
+confirmação. Depois que o cliente confirmar, a Urba não precisa reapresentar o
+mesmo texto.
+
+Não conduzir uma venda apenas para fechar. Se o serviço não parece capaz de
+gerar valor para a necessidade apresentada, continuar investigando ou
+encaminhar ao humano.
+
+### 6.2 Limite de área
+
+Decor Interiores e Decor Reforma têm limite padrão de 20 m² por ambiente.
+Decor Pintura e Decor Fachada não têm esse limite.
+
+Se o cliente estiver acima do limite de Interiores/Reforma:
+
+- não prometer exceção, atendimento, preço ou adaptação;
+- informar que o caso excede o limite padrão;
+- encaminhar para avaliação da arquiteta.
+
+Se o cliente não souber a área, a Urba pode fazer perguntas simples e indicar o
+material oficial de medição. Se ele continuar sem conseguir informar o espaço,
+encaminhar à arquiteta. Isso não substitui a validação posterior da arquiteta.
+
+### 6.3 Termos e aceite
+
+Antes do pagamento:
+
+- a Urba envia os termos de uso pelo WhatsApp;
+- o cliente deve responder com confirmação textual clara;
+- exemplos válidos: “aceito os termos”, “estou de acordo”;
+- silêncio, pagamento, reação, “ok” ou resposta ambígua não valem como aceite;
+- cada ambiente/serviço independente exige seu próprio aceite;
+- o aceite comercial do serviço não substitui o aceite formal dos termos.
+
+Para auditoria, associar à contratação:
+
+- serviço;
+- ambiente;
+- termos enviados;
+- versão ou link dos termos;
+- data/hora do envio;
+- data/hora do aceite;
+- mensagem textual de aceite.
+
+Sem aceite, a contratação não avança e o link de pagamento não é enviado. Se
+o cliente mudar de serviço antes do pagamento, pode fazê-lo sem problema, mas
+o fluxo deve reiniciar com os termos, aceite e link do novo serviço.
+
+### 6.4 Pagamento
+
+- o pagamento é integral antes do briefing e da produção, inclusive quando houver parcelamento no link;
+- o cliente envia o comprovante;
+- na primeira versão, uma pessoa valida o pagamento;
+- somente após a validação a Urba libera o briefing;
+- pagamento não é aceite de termos e não deve ocorrer antes dele.
+
+### 6.5 Briefing e dados do ambiente
+
+Após o pagamento confirmado, a Urba envia o link fixo do formulário Google de
+briefing. O cliente informa gostos, preferências e necessidades.
+
+O cliente também deve:
+
+- medir o ambiente;
+- enviar as medidas;
+- enviar fotos e/ou vídeos.
+
+Medidas, fotos e vídeos são obrigatórios para o trabalho remoto. O material
+oficial da arquiteta orienta como medir e registrar o espaço. A Urba pode ajudar
+com perguntas simples; dificuldade persistente vai para a arquiteta.
+
+Durante o briefing, a Urba continua recebendo as mensagens. Uma dificuldade
+pontual que ela não consiga resolver pode ser escalada e, depois de resolvida,
+a arquiteta devolve a conversa para a Urba.
+
+### 6.6 Reunião e produção
+
+Depois de briefing, medidas, fotos e vídeos adequados, a Urba envia o link da
+disponibilidade da agenda da arquiteta. O cliente escolhe e confirma o horário.
+
+O envio do link de agendamento é o gatilho da transferência formal para o
+humano. A arquiteta passa a conduzir diretamente:
+
+- a reunião no Google Meet;
+- produção;
+- opções;
+- feedbacks e ajustes;
+- atualizações;
+- entrega.
+
+O prazo padrão de produção é de **7 dias úteis** para os quatro serviços,
+contados a partir do início de produção acordado após os dados necessários e o
+kickoff/reunião estarem prontos. O prazo cobre o ciclo até a entrega final
+aprovada, incluindo ajustes.
+
+Se o cliente estiver pendente de resposta, feedback ou aprovação, o prazo fica
+pausado e retoma com os dias úteis restantes. A arquiteta comunica qualquer
+nova previsão.
+
+### 6.7 Aprovação e entrega
+
+O cliente precisa aprovar explicitamente a solução final, normalmente pelo
+WhatsApp. Silêncio não é aprovação.
+
+A arquiteta envia a entrega formal por e-mail, contendo:
+
+- Manual em PDF;
+- link não listado do Tour Virtual.
+
+Depois de entregar, a arquiteta marca a conversa como **“de responsabilidade da
+Urba agora”**. Essa ação libera a retomada do funil.
+
+## 7. Handoff entre Urba e arquiteta
+
+### 7.1 Quando a Urba encaminha
+
+Transferir imediatamente quando:
+
+- o cliente pedir para falar com uma pessoa ou com a arquiteta;
+- a Urba não conseguir esclarecer as dúvidas;
+- a Urba não conseguir conduzir o cliente a um serviço que faça sentido;
+- o assunto envolver decisão técnica, viabilidade, ART/RRT, aprovação ou responsabilidade profissional;
+- houver pedido de cancelamento, reembolso, troca pós-pagamento ou condição que dependa de decisão humana;
+- a Urba enviar o link de agendamento, iniciando a etapa formal do serviço.
+
+Não encaminhar automaticamente apenas porque o cliente mencionou um elemento
+complementar que a Urba consegue relacionar ao serviço. A Urba tem autonomia
+para orientar e sugerir.
+
+### 7.2 Notificação interna
+
+O acionamento deve gerar uma notificação interna, sem poluir a conversa visível
+ao cliente. O resumo mínimo deve conter:
+
+- motivo do acionamento;
+- necessidade principal do cliente;
+- serviço considerado;
+- dúvida ou ponto pendente;
+- etapa atual do fluxo;
+- estado conhecido de termos, pagamento e briefing quando relevante.
+
+O histórico integral permanece disponível para a arquiteta. Ela não precisa
+redigir manualmente um template.
+
+### 7.3 Durante a responsabilidade humana
+
+Depois do aviso de transferência, a Urba para de responder. Mensagens novas do
+cliente ficam disponíveis para o atendimento humano. A Urba não promete prazo
+nem reassume automaticamente.
+
+### 7.4 Retomada automática de contexto
+
+Quando a arquiteta marca a conversa como “de responsabilidade da Urba agora”,
+a plataforma deve detectar a transição real `HUMANO -> URBA` e disparar um evento
+interno para o Hermes.
+
+O evento deve incluir ou disponibilizar:
+
+- histórico completo da conversa;
+- serviço e ambiente;
+- etapa atual conhecida;
+- motivo da retomada;
+- decisões registradas pela arquiteta;
+- estado conhecido de pagamento, briefing, medidas, fotos/vídeos e entrega;
+- instrução de que decisões da arquiteta são a fonte de verdade do caso.
+
+A arquiteta apenas altera a responsabilidade na plataforma. Ela não precisa
+escrever a mensagem de contexto.
+
+O cliente não precisa repetir ou relatar o que a arquiteta decidiu. O Hermes
+deve incorporar a decisão ao estado da conversa e continuar o fluxo a partir
+dela.
+
+O evento não deve ser emitido novamente se a conversa já estiver sob
+responsabilidade da Urba e a mesma flag for marcada sem mudança de estado.
+
+### 7.5 Retomada proativa
+
+A retomada não é sempre silenciosa. Depois de receber o evento, o Hermes deve
+avaliar se existe uma próxima ação clara:
+
+- se existir, pode enviar uma mensagem proativa reconduzindo o cliente;
+- se não existir, deve aguardar ou seguir a regra do estágio sem inventar uma ação.
+
+Exemplo: depois de uma dúvida ser resolvida, se o próximo passo conhecido for
+preencher o briefing, a Urba pode dizer:
+
+> Agora que essa dúvida foi esclarecida, o próximo passo é preencher o briefing do ambiente. Ele vai nos ajudar a entender melhor seus gostos e necessidades. Você pode acessá-lo por este link: [...]
+
+Essa mensagem é gerada pelo sistema/Hermes com base no contexto; não depende de
+um template escrito manualmente pela arquiteta.
+
+## 8. Estado de verdade e precedência
+
+Para uma conversa retomada:
+
+1. decisões explícitas da arquiteta no histórico do caso;
+2. evento de retomada e estado operacional associado;
+3. regras gerais deste catálogo;
+4. linguagem genérica do modelo.
+
+Se a decisão da arquiteta for específica e diferente do catálogo, seguir a
+decisão específica. Só encaminhar novamente se surgir uma dificuldade real
+para compreender ou executar o que foi decidido.
+
+## 9. Respostas e limites importantes
+
+### 9.1 Materiais e mobiliário
+
+A Urba pode explicar que o Manual especifica materiais e pode sugerir
+mobiliário. Não deve prometer:
+
+- estoque;
+- preço atual;
+- rendimento ou orçamento, salvo se constarem do Manual;
+- lista completa de links;
+- busca de substitutos;
+- compra pela Urbana.
+
+O cliente verifica essas informações e realiza a compra.
+
+### 9.2 Execução
+
+O Manual não ensina a pintar, instalar ou executar uma reforma. A Urba deve
+encaminhar pedidos de orientação prática à arquiteta, sem prometer que ela
+fornecerá um passo a passo.
+
+### 9.3 Casos fora do catálogo
+
+Se o pedido não puder ser relacionado a nenhum dos quatro serviços, a Urba não
+deve adaptar ou inventar um serviço. Deve informar que é necessária avaliação e
+encaminhar ao humano.
+
+### 9.4 Cancelamento, reembolso e pós-pagamento
+
+A Urba não decide nem promete cancelamento, reembolso, troca de escopo,
+desconto ou prazo de solução. Encaminha para a arquiteta.
+
+## 10. Tom e estratégia de conversa
+
+- acolhedor, simples, didático e próximo;
+- linguagem humana, sem jargão desnecessário;
+- sem pressão comercial;
+- resumo curto primeiro;
+- detalhes progressivos quando o cliente demonstrar interesse;
+- honestidade sobre limites;
+- nunca se apresentar como arquiteta;
+- respeitar imediatamente pedido de atendimento humano.
+
+O primeiro contato deve identificar a Urba e perguntar o que o cliente deseja
+transformar. A explicação detalhada de entregas e responsabilidades vem depois
+que o serviço parecer adequado, em uma mensagem curta.
+
+## 11. Critérios de aceite para a próxima implementação
+
+1. A Urba identifica-se como assistente virtual da Urbana do Brasil e inicia a
+   descoberta com uma pergunta curta.
+2. A Urba consegue fazer perguntas abertas, sugerir um serviço como hipótese e
+   esperar confirmação explícita.
+3. A Urba não aprova automaticamente Interiores/Reforma acima de 20 m².
+4. A Urba não usa links de pagamento antigos ou sem vínculo confirmado com o
+   serviço/ambiente.
+5. A Urba exige termos enviados pelo WhatsApp e aceite textual claro antes do
+   pagamento.
+6. Cada contratação independente mantém seu próprio aceite e registro de
+   auditoria.
+7. O comprovante é validado por humano antes do briefing.
+8. Briefing, medidas, fotos e vídeos são tratados como pré-requisitos da
+   produção.
+9. O envio do link de agendamento transfere a responsabilidade para a
+   arquiteta.
+10. A solicitação explícita de humano transfere imediatamente, sem retenção.
+11. A notificação interna inclui o resumo mínimo e não polui a conversa do
+    cliente.
+12. A mudança `HUMANO -> URBA` dispara o evento de reidratação de contexto uma
+    única vez por transição.
+13. O evento entrega ao Hermes o histórico completo e as decisões da arquiteta;
+    o cliente não precisa repeti-las.
+14. O Hermes pode enviar mensagem proativa quando o próximo passo estiver claro
+    e não envia uma ação inventada quando não houver próximo passo definido.
+15. A Urba respeita decisões específicas da arquiteta quando retoma o fluxo.
+16. A entrega final é enviada por e-mail com Manual PDF e Tour Virtual.
+17. O suporte é comunicado como suporte de três meses, sem promessa de visita ou
+    gestão de obra.
+
+## 12. Itens para a implementação
+
+Esta spec define o contrato de negócio. O detalhamento e as decisões da
+responsabilidade da conversa, do evento, da sincronização do Hermes e da
+retomada proativa estão em
+[`pee-102-retomada-tecnica-humano-urba-hermes.md`](pee-102-retomada-tecnica-humano-urba-hermes.md).
+
+Os itens restantes, separados do contrato de retomada, são:
+
+- origem dos links atuais de pagamento;
+- versionamento e armazenamento dos termos;
+- modelagem do catálogo e de suas fontes canônicas;
+- evolução do estado operacional além da etapa de briefing.

--- a/docs/specs/pee-102-retomada-tecnica-humano-urba-hermes.md
+++ b/docs/specs/pee-102-retomada-tecnica-humano-urba-hermes.md
@@ -1,0 +1,701 @@
+# PEE-102 — Retomada técnica HUMANO → URBA no Hermes
+
+## Metadados
+
+- **Ticket:** [PEE-102](https://urbanadobrasil.atlassian.net/browse/PEE-102)
+- **Spec de negócio:** [Catálogo de serviços e contexto operacional da Urba](pee-102-catalogo-e-contexto-operacional-urba.md)
+- **Status:** discovery técnica concluída; implementação não iniciada
+- **Data:** 2026-08-16
+- **Escopo:** contrato técnico da responsabilidade da conversa, sincronização de contexto e retomada proativa
+
+## 1. Objetivo
+
+Definir como uma conversa que estava sob responsabilidade da arquiteta volta
+para a Urba sem pedir que o cliente repita decisões, sem perder mensagens e sem
+permitir que o Hermes responda antes de receber o contexto humano completo.
+
+Esta spec detalha o item 12 da spec de negócio. Ela não autoriza nem inicia a
+implementação.
+
+## 2. Evidências do estado atual
+
+| Capacidade atual | Evidência | Lacuna para a retomada |
+|---|---|---|
+| Responsabilidade exclusiva | `ReceptionConversation.mode` possui `AI` e `HUMAN` | Não existe estado de sincronização nem transição de volta |
+| Handoff para humano | `HumanHandoffService.enterHumanMode(...)` | O próprio serviço declara que não implementa `HUMAN -> AI` |
+| Concorrência otimista | `ReceptionConversation.version` e save Mongo por compare-and-set | Falta aplicar a mesma proteção ao comando de retorno |
+| Transcript canônico | `ReceptionMessage` distingue `CONTACT`, `URBA`, `HUMAN` e `SYSTEM` | A POC ainda não possui ingresso explícito para mensagem da arquiteta |
+| Sessão persistente | `HermesSessionService` mantém uma sessão Hermes ativa por contato | Mensagens ocorridas em `HUMAN` não entram na memória do Hermes |
+| Turnos resilientes | PEE-101 impede execução remota concorrente e trata timeout ambíguo | O evento de retomada precisa reutilizar essas garantias |
+| Pass-through transparente | O turno normal envia ao Hermes apenas a mensagem atual do cliente | Um evento interno não pode ser disfarçado de mensagem do cliente |
+| Interface de teste | A projeção e o frontend entendem `AI` e `HUMAN` | Faltam ação de devolução, progresso da sincronização e falha segura |
+| Roteamento | O webhook pode escolher `reception/Hermes` ou o `ConversationFlowService` legado | Os dois caminhos possuem semânticas diferentes de handoff |
+
+Conclusão: o transcript Mongo continua sendo a fonte canônica. A sessão Hermes
+é uma projeção conversacional que precisa ser sincronizada antes de voltar a
+responder.
+
+## 3. Escopo
+
+### 3.1 Incluído
+
+- registro canônico das mensagens enviadas pela arquiteta;
+- ação da plataforma “de responsabilidade da Urba agora”;
+- transição concorrente e idempotente de responsabilidade;
+- evento durável de retomada;
+- sincronização do histórico humano com a sessão Hermes;
+- decisão entre mensagem proativa, espera e novo handoff;
+- proteção contra duplicidade, reordenação e timeout ambíguo;
+- projeção do progresso para a plataforma;
+- auditoria, métricas e testes do fluxo.
+
+O contrato aplica-se ao bounded context `reception` e ao caminho Hermes. O
+fluxo legado não se torna uma segunda fonte de responsabilidade.
+
+### 3.2 Fora de escopo
+
+- implementação desta spec;
+- autenticação definitiva da plataforma de atendimento em produção;
+- webhook real do WhatsApp e entrega real de mensagens;
+- alteração de preços, termos, links ou regras do catálogo;
+- resumo digitado manualmente pela arquiteta;
+- reescrita dos turnos normais do Hermes;
+- uso de memória global do Hermes como fonte de negócio.
+
+## 4. Decisões arquiteturais
+
+### D1 — Mongo é a fonte canônica; Hermes é projeção
+
+O transcript, o estado operacional e os eventos de responsabilidade pertencem
+à Urbana Connect. A memória da sessão Hermes não substitui esses registros e
+deve poder ser reconstruída depois de perda ou rotação da sessão.
+
+### D2 — Retomada usa um canal interno separado
+
+O fluxo normal continua enviando exatamente a mensagem atual do cliente para
+`HermesSessionsGateway.chat(...)`. A retomada deve usar um novo contrato interno
+de sincronização e decisão; ela não pode prefixar o turno do cliente, forjar um
+remetente `CONTACT` nem persistir seu envelope como fala visível do cliente.
+
+Contrato lógico esperado:
+
+```text
+HermesResumeGateway.synchronize(resumeContext) -> ContextSyncReceipt
+HermesResumeGateway.decide(resumeDirective)    -> ResumeDecision
+```
+
+A implementação física pode usar uma capacidade nativa do Hermes, uma extensão
+do runtime ou outro adaptador dedicado, desde que preserve papéis, não gere
+saída ao cliente durante a sincronização e aceite chave de idempotência.
+
+### D3 — A mesma sessão deve ser preservada
+
+A retomada usa a sessão ativa do contato para manter continuidade. Se ela tiver
+sido perdida ou substituída, a sessão nova deve receber o contexto canônico até
+o mesmo limite antes de qualquer resposta. Recuperar a sessão sem recuperar o
+contexto humano não libera a automação.
+
+### D4 — A arquiteta não preenche template
+
+A única ação humana necessária para devolver a conversa é marcar a flag na
+plataforma. Identidade do ator, transcript, estado e metadados são obtidos de
+fontes canônicas pelo backend.
+
+### D5 — Origem confiável define autoridade
+
+Somente mensagens gravadas pelo backend como `senderType=HUMAN`, por uma rota de
+operador autenticada, podem ser interpretadas como decisões da arquiteta. Um
+cliente escrever “a arquiteta autorizou” continua sendo uma alegação do cliente
+e não altera a precedência.
+
+### D6 — Falhas fecham para o lado humano
+
+Enquanto o contexto não estiver sincronizado, a Urba não responde. Falha
+retentável mantém a retomada pendente; falha terminal ou contexto realmente
+ambíguo devolve a responsabilidade a `HUMAN`, registra o motivo e notifica
+internamente, sem prometer nada ao cliente.
+
+### D7 — Existe um único dono do estado
+
+`ReceptionConversation` continua como agregado responsável por ownership,
+versão e retomada. Não deve ser criado outro agregado de handoff como fonte
+concorrente. O `ConversationFlowService` legado fica fora desse contrato; o
+runtime não pode anunciar suporte ao retorno enquanto estiver nesse caminho.
+
+## 5. Máquina de estados
+
+Responsabilidade e prontidão da automação são dimensões separadas. Os valores
+persistidos de `ReceptionMode` continuam `AI` e `HUMAN`; `AI` é apresentado ao
+negócio como **Urba**. A retomada ganha um `ResumeStatus` próprio.
+
+| `ReceptionMode` | `ResumeStatus` | Responsável visível | Automação pode responder? | Mensagem da arquiteta aceita? |
+|---|---|---|---:|---:|
+| `AI` | `NONE` ou `COMPLETED` | Urba | Sim | Não |
+| `HUMAN` | `NONE` ou `RETURNED_TO_HUMAN` | Arquiteta | Não | Sim |
+| `AI` | `PENDING`, `SYNCHRONIZING`, `DECIDING` ou `RETRYABLE_FAILURE` | Retornando para Urba | Não | Não |
+
+Transições válidas:
+
+```text
+AI/NONE --handoff--> HUMAN/NONE
+                         |
+                         +-- flag de retorno --> AI/PENDING
+                                                    |
+                                                    +--> AI/SYNCHRONIZING
+                                                    |          |
+                                                    |          +--> AI/DECIDING
+                                                    |                    |
+                                                    |                    +--> AI/COMPLETED
+                                                    |
+                                                    +-- falha terminal --> HUMAN/RETURNED_TO_HUMAN
+```
+
+Regras:
+
+1. `AI -> HUMAN/NONE` preserva o comportamento existente e encerra qualquer
+   status concluído da retomada anterior.
+2. `HUMAN/NONE -> AI/PENDING` ocorre uma vez por retorno confirmado: a Urba já
+   é a responsável, mas ainda não está liberada para responder.
+3. Repetir a flag com a mesma chave retorna o mesmo resultado.
+4. Marcar a flag em `AI` sem retomada ativa é no-op e não cria evento.
+5. Duas tentativas concorrentes usam `expectedVersion`; somente uma vence.
+6. Mensagens do cliente recebidas com retomada ativa são persistidas e aguardam.
+7. Nenhum turno Hermes normal começa em `HUMAN` ou com `ResumeStatus` ativo;
+   são ativos `PENDING`, `SYNCHRONIZING`, `DECIDING` e `RETRYABLE_FAILURE`.
+8. `COMPLETED` só é gravado depois do recibo de sincronização e da persistência
+   da decisão de retomada.
+
+## 6. Comando da plataforma e auditoria
+
+### 6.1 Retornar para a Urba
+
+Contrato HTTP lógico:
+
+```http
+POST /api/operator/conversations/{conversationId}/return-to-urba
+Idempotency-Key: <uuid>
+
+{
+  "expectedVersion": 17
+}
+```
+
+O ator é obtido da sessão autenticada, nunca do corpo. A resposta é assíncrona e
+informa `resumeId`, estado da retomada e nova versão da conversa.
+
+- `202`: retorno criado ou ainda em processamento;
+- `200`: repetição idempotente ou no-op porque a Urba já era responsável;
+- `409`: versão desatualizada ou estado incompatível;
+- `401/403`: operador não autenticado ou sem permissão.
+
+### 6.2 Registrar mensagem humana
+
+A plataforma precisa de um caso de uso próprio para acrescentar mensagens
+`HUMAN` ao transcript. O backend define remetente, direção, conversa e ator; a
+requisição fornece somente conteúdo e identidade idempotente. A escrita só é
+aceita em `HUMAN` e participa da mesma serialização usada pelo retorno.
+
+### 6.3 Registro atômico
+
+O compare-and-set que grava `AI/PENDING` deve participar de uma transação
+multi-documento que também grava a intenção/process manager e o outbox. A
+transação é a fronteira que impede a conversa de mudar de responsável sem que o
+evento recuperável exista.
+
+Coleções previstas:
+
+- `reception_conversations`: raiz de ownership, versão, epoch, status e limite;
+- `reception_messages`: transcript imutável com sequência;
+- `reception_resumes`: estado operacional da retomada;
+- `reception_outbox`: evento imutável `ConversationOwnershipReturnedToUrba`;
+- `reception_inbox`: idempotência de comandos e consumidores.
+
+O Mongo de homologação precisa ser promovido a replica set, ainda que de um
+único membro, antes de liberar esse fluxo. A implementação não deve trocar essa
+garantia por uma sequência de escritas independentes ou por outbox embutida.
+
+O evento imutável da transição preserva no mínimo:
+
+- `eventId` determinístico, `schemaVersion`, `resumeId` e
+  `idempotencyKeyHash`;
+- `conversationId`, `contactId` e `conversationVersion`;
+- `ownershipEpoch`, incrementado a cada mudança de responsável;
+- `fromMode`, `toMode`, `reason` e `occurredAt`;
+- `actorId` e `actorRole` provenientes do contexto autenticado;
+- `causationId`, `correlationId` e `traceId`;
+- limite canônico do transcript.
+
+O registro operacional da retomada, separado do payload imutável do evento,
+preserva estado, tentativas, classificação da última falha, recibo/checksum da
+sincronização, decisão final e identificador da mensagem proativa.
+
+O evento lógico emitido por essa intenção chama-se
+`ConversationOwnershipReturnedToUrba`, versão 1. Consumidores mantêm inbox única
+por `consumer + eventId` e ordenam trabalho por
+`conversationId + ownershipEpoch`. Tentativas e falhas do consumidor pertencem
+ao registro de dispatch/inbox, não alteram o payload imutável do evento.
+
+## 7. Ordenação e limite do transcript
+
+O transcript deve ganhar uma sequência monotônica por conversa. `createdAt`
+sozinho não é suficiente para ordenar mensagens concorrentes nem para definir
+com segurança até onde o Hermes foi sincronizado.
+
+O comando de retorno captura `resumeBoundarySequence`. O pacote contém ou
+disponibiliza todas as mensagens com `sequence <= resumeBoundarySequence`, em
+ordem, incluindo `CONTACT`, `URBA`, `HUMAN` e `SYSTEM`.
+
+Mensagens posteriores ao limite:
+
+- mensagens humanas são rejeitadas porque a responsabilidade já voltou para
+  `AI` e a retomada está ativa;
+- mensagens do cliente são persistidas, mantidas em fila e não alteram o pacote
+  já fechado;
+- antes de enviar uma fala proativa, o processador verifica se apareceu entrada
+  nova do cliente; se apareceu, suprime a fala proativa e libera essa entrada
+  como o próximo turno após a sincronização.
+
+Alocação da sequência, escrita da mensagem e mudança de responsabilidade devem
+usar serialização por conversa ou transação equivalente. Lacunas numéricas são
+aceitáveis; reordenação e reutilização não são.
+
+## 8. Pacote de contexto da retomada
+
+O evento durável não precisa carregar conteúdo conversacional sensível. Ele
+carrega referências e integridade; o consumidor lê a fonte canônica.
+
+```json
+{
+  "schemaVersion": 1,
+  "resumeId": "uuid",
+  "conversationId": "uuid",
+  "contactId": "opaque-id",
+  "hermesSessionId": "opaque-id",
+  "ownershipEpoch": 4,
+  "resumeBoundarySequence": 42,
+  "transcriptChecksum": "sha256:...",
+  "businessState": {
+    "commercialStage": "BRIEFING",
+    "selectedService": "DECOR_INTERIORES",
+    "termsStatus": "ACCEPTED",
+    "paymentStatus": "CONFIRMED"
+  },
+  "handoff": {
+    "reason": "CUSTOMER_QUESTION",
+    "returnedBy": "operator-id",
+    "returnedAt": "2026-08-16T18:00:00Z"
+  },
+  "authorityPolicy": "HUMAN_CASE_DECISIONS_OVERRIDE_CATALOG"
+}
+```
+
+O identificador do contato é opaco. Logs e métricas não recebem texto do
+transcript.
+
+### 8.1 Conteúdo integral e limites do runtime
+
+O transcript canônico integral até o limite deve permanecer acessível ao
+Hermes. Para conversas que caibam no limite aceito pelo runtime, ele é
+sincronizado integralmente. Para conversas maiores, a integração deve usar
+sincronização paginada/chunked ou uma ferramenta de leitura do transcript com
+ordem e papéis preservados; não pode truncar silenciosamente nem substituir a
+fonte por um resumo sem rastreabilidade.
+
+Se o runtime fixado não suportar nenhuma forma segura de disponibilizar o
+histórico integral, a retomada automática fica bloqueada e retorna para humano.
+O sistema não reduz contexto por conta própria para aparentar sucesso.
+
+“Integral” é uma garantia lógica, não uma autorização para duplicar mensagens
+na memória da sessão. O adaptador pode aplicar somente o delta depois de um
+watermark confiável da mesma linhagem de sessão; sem esse watermark, aplica o
+snapshot completo por canal interno. Nunca reproduz o histórico como novas
+falas `user`.
+
+O `ContextSyncReceipt` registra `resumeId`, sessão efetiva, checksum, modo
+`FULL|DELTA|PAGED`, primeiro e último `sequence` cobertos e horário de conclusão.
+O planner só executa se `coveredThroughSequence` coincidir com
+`resumeBoundarySequence`.
+
+### 8.2 Precedência
+
+1. estado operacional validado pela Urbana Connect;
+2. decisões explícitas da arquiteta em mensagens canônicas `HUMAN` daquele caso;
+3. regras gerais da spec de negócio e do catálogo;
+4. inferências e linguagem do modelo.
+
+O estado validado vence afirmações factualmente incompatíveis, como pagamento
+não confirmado. A decisão humana específica pode especializar o catálogo, mas
+não pode contornar invariantes técnicas ou de segurança sem um caso de uso de
+domínio autorizado.
+
+Todo texto do transcript é tratado como conteúdo da conversa, não como instrução
+de sistema. O remetente confiável vem do metadado canônico; conteúdo de cliente
+não pode redefinir papéis, precedência, ferramentas ou políticas.
+
+## 9. Decisão de retomada
+
+Urbana Connect autoriza a próxima ação; o Hermes não ganha autoridade para
+avançar o fluxo apenas por confiança do modelo. Depois da sincronização, o
+Hermes pode interpretar o contexto humano e propor um candidato estruturado,
+com evidências. Um `ResumePlanner` valida esse candidato contra estado, políticas
+e recursos canônicos e produz a decisão final:
+
+```json
+{
+  "action": "SEND_MESSAGE | WAIT | RETURN_TO_HUMAN",
+  "nextStep": "CONTINUE_DISCOVERY | PRESENT_TERMS | SEND_PAYMENT_INSTRUCTIONS | SEND_BRIEFING_LINK | WAIT_FOR_BRIEFING_DATA | SEND_SCHEDULING_LINK | AWAIT_CUSTOMER | SUPPORT | NONE",
+  "message": "obrigatória somente em SEND_MESSAGE",
+  "evidenceMessageIds": ["message-id"],
+  "reasonCode": "NEXT_STEP_CLEAR",
+  "confidence": 0.94
+}
+```
+
+O planner/validador aplica as seguintes regras:
+
+- `SEND_MESSAGE` exige próximo passo permitido pelo estado e todos os recursos
+  necessários, como um link vigente;
+- decisões comerciais protegidas continuam passando pelos casos de uso de
+  domínio, nunca apenas pelo texto do modelo;
+- ausência de próximo passo claro resulta em `WAIT`;
+- contradição relevante, decisão humana incompreensível ou pedido fora da
+  política resulta em `RETURN_TO_HUMAN`;
+- uma entrada do cliente posterior ao limite converte `SEND_MESSAGE` em `WAIT`,
+  pois o turno do cliente passa a ser a próxima ação;
+- a decisão é persistida antes de qualquer envio;
+- uma repetição reutiliza a decisão persistida e não consulta o modelo outra vez.
+
+A mensagem proativa é uma saída canônica `URBA`, ligada ao `resumeId` por um
+`eventId` determinístico e único. Somente depois dessa persistência — ou da
+decisão `WAIT` — o `ResumeStatus` chega a `COMPLETED`.
+
+### 9.1 Dependência do estado operacional
+
+O `CommercialStage` atual termina em `BRIEFING`. Antes de habilitar proatividade
+em agendamento, produção, entrega ou suporte, a implementação do catálogo deve
+representar esses marcos e uma `nextOperationalAction` explícita. Enquanto um
+passo não tiver representação canônica e pré-condições verificáveis, o planner
+retorna `WAIT` ou `RETURN_TO_HUMAN`; não infere autorização apenas do texto.
+Essa ação é mantida ou derivada pelo workflow da Urbana Connect; a arquiteta não
+precisa selecioná-la nem preencher um template ao devolver a conversa.
+
+## 10. Concorrência, retries e recuperação
+
+1. O worker de retomada adquire exclusão por conversa e não concorre com turno
+   normal do Hermes.
+2. A chave `resumeId` acompanha sincronização, decisão e saída proativa.
+3. Timeout ambíguo do Hermes entra em conciliação; não dispara segunda chamada.
+4. Retry seguro reutiliza a mesma identidade e o mesmo limite do transcript.
+5. Queda depois da transição é recuperada pela intenção durável pendente.
+6. Queda depois da decisão, mas antes da saída, reutiliza a decisão persistida.
+7. Saída proativa tem unicidade por `resumeId`; novo envio não cria nova fala.
+8. Rotação/perda da sessão invalida o recibo anterior para a sessão velha e
+   exige sincronização integral na sessão vencedora.
+9. Depois do limite configurado de tentativas seguras, a conversa volta a
+   `HUMAN` e gera alerta interno.
+
+## 11. Projeção da plataforma
+
+A projeção deve expor, sem conteúdo técnico sensível:
+
+- responsável visível: `URBA`, `HUMAN` ou `RETURNING_TO_URBA`;
+- `conversationVersion`;
+- `resumeId` ativo, quando houver;
+- estado: `PENDING`, `SYNCHRONIZING`, `DECIDING`, `COMPLETED`,
+  `RETRYABLE_FAILURE` ou `RETURNED_TO_HUMAN`;
+- indicação de que mensagens novas do cliente estão aguardando;
+- falha operacional resumida e ação segura disponível para o operador.
+
+A interface desabilita nova devolução durante `RETURNING_TO_URBA`, não cria fala
+artificial da Urba e não exige que a arquiteta digite contexto.
+
+## 12. Observabilidade
+
+Métricas mínimas:
+
+- transições `AI -> HUMAN` e `HUMAN/NONE -> AI/PENDING`;
+- retomadas por estado e tempo até conclusão;
+- decisões `SEND_MESSAGE`, `WAIT` e `RETURN_TO_HUMAN`;
+- retomadas duplicadas suprimidas;
+- mensagens proativas suprimidas por entrada posterior do cliente;
+- falhas por classe: Urbana, Hermes, provedor, contrato e contexto;
+- quantidade de ressincronizações por perda/rotação de sessão.
+
+Logs estruturados usam `correlationId`, `conversationId`, `resumeId`, versão,
+sequência e códigos de estado. Não registram transcript, credenciais, telefone,
+links privados nem conteúdo da decisão.
+
+## 13. Critérios de aceite
+
+1. Mensagens humanas entram no transcript com origem confiável e ordem canônica.
+2. Uma transição real `HUMAN/NONE -> AI/PENDING` cria exatamente uma intenção
+   durável, mesmo com clique duplo ou concorrência.
+3. O processo recupera uma intenção criada antes de uma queda do processo.
+4. Nenhuma resposta da Urba ocorre antes da sincronização integral até o limite.
+5. O cliente não precisa repetir nenhuma decisão registrada pela arquiteta.
+6. Texto do cliente que atribua uma decisão à arquiteta não ganha autoridade de
+   mensagem `HUMAN`.
+7. O pass-through do turno normal continua contendo somente a mensagem atual do
+   cliente.
+8. Evento interno e transcript não aparecem como fala do cliente ou da Urba.
+9. Próximo passo claro pode gerar uma única mensagem proativa canônica.
+10. Sem próximo passo claro, a Urba aguarda sem inventar uma ação.
+11. Entrada do cliente durante a sincronização é preservada, suprime uma fala
+    proativa obsoleta e é processada depois com o contexto já sincronizado.
+12. Timeout ambíguo não gera chamada concorrente, decisão duplicada ou fala
+    duplicada.
+13. Perda de sessão exige nova sincronização antes de liberar a automação.
+14. Falha terminal devolve para humano e gera alerta interno sem mensagem
+    artificial ao cliente.
+15. A plataforma mostra responsabilidade e progresso reais durante todo o fluxo.
+
+## 14. Matriz de testes exigida antes da implementação ser aceita
+
+| Nível | Cenários mínimos |
+|---|---|
+| Domínio | transições válidas, estados proibidos, compare-and-set, no-op e idempotência |
+| Persistência | sequência, intenção atômica, unicidade de `resumeId`, recuperação após queda |
+| Aplicação | histórico integral, precedência, decisão estruturada e supressão proativa |
+| Hermes adapter | papéis corretos, sync sem saída, timeout ambíguo, rotação e sessão perdida |
+| REST | autenticação, `Idempotency-Key`, `expectedVersion`, `202`, `200`, `409` e autorização |
+| Frontend | flag, estado intermediário, clique duplo, erro seguro e mensagens aguardando |
+| Regressão | handoff existente, turn lease, transcript canônico e pass-through byte a byte |
+| Segurança | tentativa de forjar `HUMAN`, prompt injection no transcript e ausência de conteúdo em logs |
+
+## 15. Decisões fechadas pela discovery técnica
+
+### 15.1 Hermes: capability interna obrigatória
+
+Na versão pinada `v2026.8.3`, o endpoint nativo
+`POST /api/sessions/{session_id}/chat` valida primeiro uma mensagem de usuário;
+`system_message`/`instructions` são complementares e não iniciam uma execução
+sozinhos. O endpoint `POST /v1/runs` também exige `input`, mesmo aceitando
+`session_id`, `instructions` e `conversation_history`.
+
+Evidências primárias:
+
+- [session chat no Hermes v2026.8.3](https://github.com/NousResearch/hermes-agent/blob/v2026.8.3/gateway/platforms/api_server.py#L3211-L3325);
+- [runs no Hermes v2026.8.3](https://github.com/NousResearch/hermes-agent/blob/v2026.8.3/gateway/platforms/api_server.py#L5833-L5913);
+- [documentação da Runs API](https://github.com/NousResearch/hermes-agent/blob/v2026.8.3/website/docs/user-guide/features/api-server.md#runs-api-streaming-friendly-alternative).
+
+Decisão:
+
+- o `HermesSessionsGateway.chat(...)` continua responsável apenas pelo turno
+  normal, com a mensagem real do cliente;
+- a retomada exige uma capability interna separada, conceitualmente:
+
+  ```text
+  sync_context(resumeContext) -> ContextSyncReceipt
+  resume_decide(resumeDirective) -> ResumeDecision
+  ```
+
+- essa capability pode ser uma extensão do runtime pinado ou um endpoint interno
+  do adaptador, mas deve aceitar papéis, checksum, watermark e idempotência;
+- o contrato mínimo exige append/import atômico com `sourceMessageId`,
+  `senderType` e `role`, revisão/cursor monotônico e idempotência durável que
+  sobreviva a restart;
+- em perda/rotação de sessão, a nova sessão deve ser hidratada antes de liberar
+  ferramentas ou decisão, e o lease deve ser transferido para a sessão efetiva;
+- a sincronização não pode gerar uma fala, e a decisão proativa não pode ser
+  persistida como `user`/`CONTACT`;
+- usar `chat`/`runs` com texto artificial como “evento de retomada” está
+  explicitamente proibido;
+- enquanto a capability não estiver disponível e coberta por contract test, o
+  retorno fica seguro, sem mensagem proativa automática. Isso é um blocker
+  técnico do caminho proativo, não uma decisão pendente da Urbana.
+
+### 15.2 Mongo: transação multi-documento como pré-requisito
+
+O runtime de homologação atual usa Mongo 6.0.5 com StatefulSet de uma réplica e
+sem configuração de replica set. Transações multi-documento, portanto, não são
+uma premissa válida para a primeira implementação.
+
+Decisão:
+
+- `ReceptionConversation` continua sendo o agregado dono do ownership;
+- o Mongo suportado deve ser promovido a replica set e a aplicação deve usar
+  transação multi-documento para o fluxo;
+- a escrita de uma mensagem canônica atualiza atomicamente o alocador
+  `lastTranscriptSequence` e insere a mensagem em `reception_messages`;
+- o retorno atualiza atomicamente `mode`, `resumeStatus`, `version`,
+  `ownershipEpoch` e `resumeBoundarySequence`, além de inserir
+  `reception_resumes` e `reception_outbox`;
+- `reception_inbox` registra `Idempotency-Key` e consumo por
+  `consumer + eventId`, com índices únicos explícitos;
+- o dispatcher permanece at-least-once, mas todas as operações são idempotentes;
+  entrega externa não é declarada exactly-once;
+- o alocador de sequência aceita lacunas após rollback/retentativa, mas nunca
+  reutiliza ou reordena uma sequência confirmada;
+- a persistência canônica do inbound deve ocorrer no aceite do ingress, antes de
+  o lote ser encaminhado ao orquestrador. Caso contrário, um retorno concorrente
+  pode não enxergar uma mensagem já aceita pelo sistema.
+
+Não será usado fallback silencioso para Mongo standalone. Um replica set de um
+único membro habilita a garantia transacional, mas não fornece alta
+disponibilidade; a topologia de produção deverá ser definida separadamente.
+
+Esta é uma dependência de infraestrutura antes da implementação, não uma
+decisão de negócio.
+
+### 15.3 Operador: principal confiável, não identidade inventada
+
+Hoje a POC possui apenas o token compartilhado `HERMES_POC_API_TOKEN`; a rota
+fica permitida pelo Spring Security e o controller faz uma validação opcional.
+Isso autentica a integração, mas não identifica individualmente a arquiteta.
+
+Decisão:
+
+- o caso de uso recebe um `TrustedOperatorPrincipal` fornecido pela plataforma
+  ou por um adaptador interno autenticado;
+- o corpo nunca informa `actorId`, `role` ou `senderType`;
+- uma rota de retorno não será liberada se seu segredo estiver vazio;
+- no ambiente POC, o principal pode ser explicitamente
+  `poc-human-operator`, deixando claro que a auditoria é da integração, não da
+  pessoa física;
+- a auditoria individual da arquiteta fica condicionada à futura plataforma
+  com sessão/identidade própria. Não será simulada com um nome enviado pelo
+  navegador.
+
+### 15.4 Próximo passo: escopo incremental e autorização determinística
+
+O estado atual termina em `CommercialStage.BRIEFING`. O catálogo possui links de
+pagamento e briefing, mas os valores semeados são fixtures/legados e os estados
+de agendamento, produção, entrega e suporte ainda não existem no agregado.
+
+Decisão para a primeira implementação:
+
+- permitir proatividade somente quando houver `nextOperationalAction` canônica,
+  pré-condições satisfeitas e recurso validado;
+- o primeiro caso autorizado é `SEND_BRIEFING_LINK`, condicionado a pagamento
+  confirmado e link vigente;
+- `nextOperationalAction` deve ser um valor estruturado, no mínimo `{code,
+  resourceKey}`. O `resourceKey` é resolvido pelo backend em uma fonte
+  canônica; o modelo e a arquiteta não fornecem URL diretamente;
+- ausência de estado/recurso confiável resulta em `WAIT` ou `RETURN_TO_HUMAN`,
+  nunca em inferência livre do modelo;
+- a arquiteta não precisa selecionar a ação nem preencher template: o workflow
+  e o planner derivam um candidato do estado e do transcript, e o backend
+  autoriza apenas ações permitidas;
+- ações posteriores exigem uma evolução separada do estado operacional com, no
+  mínimo, `ServiceLifecycleStage` (`BRIEFING`, `SCHEDULING`, `PRODUCTION`,
+  `DELIVERY`, `SUPPORT`, `CLOSED`) e `nextOperationalAction` (`SEND_BRIEFING_LINK`,
+  `WAIT_FOR_BRIEFING_DATA`, `SEND_SCHEDULING_LINK`, `WAIT_CUSTOMER`,
+  `WAIT_HUMAN`, `SEND_DELIVERY`, `SUPPORT`, `NONE`).
+
+Essa decisão permite entregar o caminho de contexto sem fingir que a aplicação
+já conhece o fluxo pós-briefing completo.
+
+## 16. Evidências verificadas dos spikes técnicos
+
+Os spikes foram reexecutados em 2026-08-16 depois da disponibilização do
+ambiente Docker local. O resultado abaixo separa capacidade comprovada de
+capacidade ainda ausente; nenhum código de produção do fluxo foi alterado.
+
+### 16.1 Hermes
+
+- A POC local respondeu com sucesso em `/health` e `/api/v1/readiness`, usando a
+  imagem integrada `urbana-hermes-agent:0.20.0`.
+- A chamada autenticada de capabilities confirmou suporte a sessões, chat de
+  sessão e submissão de runs, mas não expôs uma operação de sincronização ou
+  importação de transcript.
+- Criar e excluir uma sessão funcionou. O chat de sessão rejeitou tanto um
+  corpo vazio quanto uma requisição contendo apenas `system_message`, com
+  `400/missing_message`. Isso confirma no ambiente executável que os endpoints
+  públicos não podem ser usados para injetar contexto silenciosamente.
+- Os testes direcionados do runtime passaram: 19 testes em
+  `test_session_api.py`, `test_internal_event_never_interrupts_busy_session.py`
+  e `test_pre_gateway_dispatch.py`.
+- O código local do Hermes possui eventos sintéticos `internal=True` para
+  recuperação de sessões após restart. Eles são transformados em uma nota de
+  sistema dentro do processamento interno e não constituem um canal tipado
+  para importar mensagens `HUMAN`, preservar `sourceMessageId` ou confirmar
+  checksum/watermark.
+
+Conclusão do spike: o adaptador atual continua **não aprovado** para a
+retomada. A extensão/fork do runtime é tecnicamente viável e deve aproveitar o
+ponto interno de eventos somente como mecanismo de acionamento, adicionando a
+capability explícita definida em D2. A implementação não pode simular a
+sincronização com uma mensagem artificial do cliente, `chat` ou `runs`.
+
+### 16.2 MongoDB
+
+- A instância Mongo da POC executa como standalone (`mongo:8.0`): o comando
+  `hello` não informa `setName`, e o driver Java registra modo `SINGLE` sem
+  `requiredReplicaSetName`.
+- Uma tentativa de transação na instância atual foi rejeitada pela topologia
+  standalone. Portanto, o Mongo atualmente utilizado pela POC não sustenta a
+  fronteira transacional exigida por 6.3.
+- Um container temporário, isolado e sem volume, foi iniciado com um replica set
+  de um membro (`rs0`). O smoke test confirmou commit e rollback de uma
+  transação via URI com `replicaSet=rs0`. O container temporário foi removido
+  após o teste; nenhum volume ou manifesto do projeto foi alterado.
+- Com JDK 21, os testes focados do gateway Hermes, do domínio de recepção e o
+  `MongoConnectivityVerifierIntegrationTest` passaram depois que o Docker foi
+  disponibilizado. O Testcontainers já fornece a topologia de replica set
+  necessária para testes de integração, mas o teste existente ainda não prova
+  a transação do caso de uso.
+- A inspeção dos manifestos de homologação continua indicando StatefulSet de
+  uma réplica sem `replSet` configurado. A homologação ainda precisa da
+  alteração de infraestrutura e da URI correspondente.
+
+Conclusão do spike: a garantia transacional é **viável**, mas a topologia atual
+é insuficiente. O próximo trabalho deve promover a infraestrutura para replica
+set, validar a conexão com `replicaSet`/retry writes e adicionar teste da
+fronteira transacional real entre conversa, sequência, mensagem, retomada e
+outbox. Não há fallback aceitável para standalone.
+
+### 16.3 Estado após a execução das PEE-103 e PEE-104
+
+Os dois spikes foram executados com escopo delimitado e verificação local:
+
+- **PEE-103:** capability interna versionada do Hermes implementada no runtime
+  pinado (`v2026.8.3` / `0.20.0`), com `sync_context`, `resume_decide`,
+  hidratação tipada fora do transcript visível, idempotência durável e
+  contract tests. O contrato está pronto para a integração funcional da
+  Urbana; essa integração continua fora destes spikes.
+- **PEE-104:** replica set `rs0`, URI/retries, readiness, inicialização da POC,
+  manifests de HML, `MongoTransactionManager` e teste de commit/rollback foram
+  implementados e validados localmente. A aplicação em HML e o smoke test
+  contra o cluster ainda são pendências operacionais; nenhum deploy foi feito.
+  O replica set de um membro comprova transações, mas não alta disponibilidade.
+
+Evidências locais adicionais: 27 testes direcionados do Hermes passaram, com
+Ruff e Ty limpos; os testes focados e de regressão do backend Java passaram;
+`docker compose config` e `kubectl kustomize` também passaram.
+
+### 16.4 Gates derivados
+
+Antes de iniciar a implementação funcional HUMANO → URBA, os dois trabalhos
+devem entregar, no mínimo:
+
+1. **HERMES-EXT:** contrato interno versionado para `sync_context` e
+   `resume_decide`, com papéis confiáveis, `sourceMessageId`, sequência,
+   checksum, watermark, idempotência durável, hidratação antes de tools e
+   contract tests contra a versão pinada do runtime.
+2. **MONGO-RS:** replica set reproduzível no ambiente-alvo, URI e healthcheck
+   compatíveis, transação multi-documento exercitada no caso de uso e índices
+   únicos para idempotência/inbox/outbox.
+
+Até os dois gates estarem verdes, a única conduta suportada é manter a
+conversa com a arquiteta ou falhar fechando para `HUMAN`, sem mensagem
+proativa automática.
+
+## 17. Pendências antes da implementação
+
+Não restou pergunta de negócio bloqueante para esta etapa. Permanecem gates
+objetivos de execução:
+
+1. ~~especificar e testar a capability interna do Hermes~~ (**PEE-103 —
+   concluído localmente; aguardando revisão**);
+2. promover o Mongo de homologação para replica set e habilitar transações
+   (**PEE-104 — implementação local concluída; aplicação e smoke test em HML
+   pendentes**);
+3. mover a persistência canônica do inbound para o aceite do ingress e criar o
+   backfill/índice de sequência;
+4. implementar o principal confiável do operador no adaptador da POC;
+5. separar links fixtures/legados de recursos comercialmente válidos;
+6. detalhar a evolução de `ServiceLifecycleStage` quando o fluxo pós-briefing
+   entrar no escopo.
+
+Até os cinco primeiros itens estarem cobertos por contrato/teste, a
+implementação não deve declarar a retomada proativa como suportada.

--- a/docs/specs/pee-104-mongo-replica-set.md
+++ b/docs/specs/pee-104-mongo-replica-set.md
@@ -1,0 +1,79 @@
+# PEE-104 — Mongo replica set e fronteira transacional
+
+## Objetivo e limite
+
+Esta entrega promove o Mongo suportado pela POC e pelos manifestos de
+homologação para um replica set reproduzível e deixa disponível o
+`MongoTransactionManager` necessário à próxima implementação do fluxo de
+retomada.
+
+Ela não implementa HUMANO → URBA, worker de retomada, `reception_resumes`,
+`reception_outbox` ou `reception_inbox`. A fronteira exercitada pelo teste usa
+as coleções que já existem: atualização de `reception_conversations` e
+inserção em `reception_messages` na mesma transação.
+
+## Topologia suportada
+
+- O nome do conjunto é `rs0`.
+- A POC local usa `mongo:8.0`, hostname estável `mongodb` e um serviço
+  `mongodb-rs-init` idempotente que inicia o membro `mongodb:27017` quando
+  necessário.
+- Homologação usa um `StatefulSet` de um membro. O pod é endereçado pelo DNS
+  estável `urbana-connect-mongodb-0.urbana-connect-mongodb.<namespace>.svc.cluster.local`;
+  um sidecar inicia o membro com esse endereço.
+- O readiness do Mongo e o readiness da aplicação só liberam tráfego quando
+  `hello` informa `setName=rs0` e `isWritablePrimary=true`. Um ping em um
+  standalone não é suficiente.
+
+## URI e retries
+
+As URIs suportadas incluem:
+
+```text
+?replicaSet=rs0&retryWrites=true&retryReads=true&w=majority
+```
+
+`w=majority` mantém a confirmação compatível com o commit da topologia de um
+membro. O customizer Java também força `retryWrites` e `retryReads` no cliente,
+mas não remove a exigência de replica set feita pela URI e pelo readiness.
+`retryWrites=false` não é fallback suportado.
+
+Retries de uma operação de retomada futura devem repetir a transação inteira
+com a mesma chave de idempotência e os mesmos predicados de versão. Não se
+deve repetir apenas uma escrita isolada depois de um erro ambíguo.
+
+## Índices e idempotência
+
+As identidades atualmente materializadas são:
+
+| Coleção | Identidade única | Finalidade |
+|---|---|---|
+| `reception_messages` | `eventId`; `providerMessageId` quando presente | impedir duplicação do evento recebido |
+| `reception_turns` | `correlationId` | uma execução durável por turno |
+| `reception_domain_tool_invocations` | `idempotencyKey` | não repetir ferramenta com a mesma intenção |
+| `reception_active_turn_leases` | `hermesSessionId + status=RUNNING` | uma lease ativa por sessão |
+
+Os índices futuros da retomada permanecem contrato para o próximo ticket:
+`reception_resumes.resumeId`, `reception_outbox.eventId` e
+`reception_inbox.(consumer,eventId)`, além da chave de idempotência do comando.
+Eles não são criados nesta entrega porque os agregados correspondentes ainda
+não existem.
+
+## Um membro não é alta disponibilidade
+
+Um replica set de um membro fornece a topologia Mongo necessária para
+transações multi-documento e permite validar commit/rollback de forma
+reproduzível. Ele não fornece redundância, failover, continuidade durante a
+perda do nó, backup ou restore. A topologia de produção com múltiplos membros
+e sua operação permanecem uma decisão separada.
+
+## Evidência técnica
+
+`MongoTransactionBoundaryIntegrationTest` usa Testcontainers e verifica que:
+
+1. atualização da conversa e inserção da mensagem são persistidas juntas após
+   commit;
+2. uma falha após as duas operações reverte a atualização e a inserção, sem
+   mensagem ou evento residual.
+
+Nenhum manifesto foi aplicado em homologação ou produção por esta entrega.

--- a/docs/specs/pee-104-mongo-replica-set.md
+++ b/docs/specs/pee-104-mongo-replica-set.md
@@ -61,6 +61,13 @@ Os índices futuros da retomada permanecem contrato para o próximo ticket:
 Eles não são criados nesta entrega porque os agregados correspondentes ainda
 não existem.
 
+Em runtime, a aplicação resolve as anotações de índice dos documentos
+`@Document` e chama `ensureIndex` durante o startup. Assim, a unicidade
+`providerMessageId` e `eventId` não depende de
+`spring.data.mongodb.auto-index-creation`, que pode permanecer desabilitado
+nos ambientes controlados. O teste de integração de provisionamento desabilita
+explicitamente essa propriedade e inspeciona os índices reais da coleção.
+
 ## Um membro não é alta disponibilidade
 
 Um replica set de um membro fornece a topologia Mongo necessária para

--- a/docs/specs/pee-104-mongo-replica-set.md
+++ b/docs/specs/pee-104-mongo-replica-set.md
@@ -18,6 +18,8 @@ inserção em `reception_messages` na mesma transação.
 - A POC local usa `mongo:8.0`, hostname estável `mongodb` e um serviço
   `mongodb-rs-init` idempotente que inicia o membro `mongodb:27017` quando
   necessário.
+- O Compose e o `dev-env.sh` mantidos em `apps/urbana-connect-api` usam a
+  mesma inicialização e não oferecem mais um caminho standalone divergente.
 - Homologação usa um `StatefulSet` de um membro. O pod é endereçado pelo DNS
   estável `urbana-connect-mongodb-0.urbana-connect-mongodb.<namespace>.svc.cluster.local`;
   um sidecar inicia o membro com esse endereço.

--- a/docs/specs/pee-23-triagem-e-vendas.md
+++ b/docs/specs/pee-23-triagem-e-vendas.md
@@ -9,6 +9,15 @@
 - `Branch`: `feature/PEE-2-urba`
 - `Data`: 2026-04-04
 
+> **Atualização de negócio — PEE-102 (2026-08-16):** esta spec registra a
+> baseline histórica da primeira versão do fluxo. Para catálogo, nomes e
+> escopo dos serviços, disponibilidade, preços, termos, pagamento, briefing,
+> prazo, responsabilidades e handoff humano, a fonte canônica passa a ser
+> [`pee-102-catalogo-e-contexto-operacional-urba.md`](pee-102-catalogo-e-contexto-operacional-urba.md).
+> Em caso de conflito, a PEE-102 prevalece. Em particular, não usar o antigo
+> serviço `Decor`, os links de pagamento históricos ou a regra que mantinha
+> Decor Reforma indisponível.
+
 ---
 
 ## 1. Contexto

--- a/docs/specs/pee-99-arch-ia-context-assembler.md
+++ b/docs/specs/pee-99-arch-ia-context-assembler.md
@@ -11,6 +11,15 @@
 - `Data`: 2026-05-01
 - `Fonte principal`: [Refinamento Participação da IA v7](https://urbanadobrasil.atlassian.net/wiki/spaces/pro/pages/374865922)
 
+> **Contrato de negócio relacionado — PEE-102 (2026-08-16):** o Context
+> Assembler também deve suportar a retomada da conversa após responsabilidade
+> humana. A semântica de negócio do evento `HUMANO -> URBA`, da precedência das
+> decisões da arquiteta, do histórico completo e da retomada proativa está
+> definida em [`pee-102-catalogo-e-contexto-operacional-urba.md`](pee-102-catalogo-e-contexto-operacional-urba.md).
+> O contrato técnico que preserva o pass-through dos turnos normais e cria um
+> canal interno separado está em
+> [`pee-102-retomada-tecnica-humano-urba-hermes.md`](pee-102-retomada-tecnica-humano-urba-hermes.md).
+
 ---
 
 ## 1. Contexto

--- a/infra/kubernetes/mongodb/base/configmap.yaml
+++ b/infra/kubernetes/mongodb/base/configmap.yaml
@@ -9,6 +9,8 @@ data:
     net:
       bindIp: 0.0.0.0
       port: 27017
+    replication:
+      replSetName: rs0
     security:
       authorization: enabled
     setParameter:

--- a/infra/kubernetes/mongodb/base/service.yaml
+++ b/infra/kubernetes/mongodb/base/service.yaml
@@ -6,6 +6,9 @@ metadata:
     app.kubernetes.io/name: urbana-connect-mongodb
 spec:
   clusterIP: None
+  # Publish the stable StatefulSet DNS record before readiness. The Mongo
+  # readiness probe still gates application traffic until rs0 has a primary.
+  publishNotReadyAddresses: true
   ports:
     - name: mongodb
       port: 27017

--- a/infra/kubernetes/mongodb/base/statefulset.yaml
+++ b/infra/kubernetes/mongodb/base/statefulset.yaml
@@ -30,6 +30,55 @@ spec:
             limits:
               cpu: 250m
               memory: 512Mi
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - >-
+                  mongosh --quiet --host 127.0.0.1:27017/admin
+                  --username "$MONGO_INITDB_ROOT_USERNAME"
+                  --password "$MONGO_INITDB_ROOT_PASSWORD"
+                  --authenticationDatabase admin --eval
+                  'try { quit(db.adminCommand({ping: 1}).ok === 1 ? 0 : 1); }
+                  catch (error) { quit(1); }'
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - >-
+                  mongosh --quiet --host 127.0.0.1:27017/admin
+                  --username "$MONGO_INITDB_ROOT_USERNAME"
+                  --password "$MONGO_INITDB_ROOT_PASSWORD"
+                  --authenticationDatabase admin --eval
+                  'try {
+                  const hello = db.adminCommand({hello: 1});
+                  quit(hello.ok === 1 && hello.setName === "rs0" &&
+                  hello.isWritablePrimary === true ? 0 : 1);
+                  } catch (error) { quit(1); }'
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - >-
+                  mongosh --quiet --host 127.0.0.1:27017/admin
+                  --username "$MONGO_INITDB_ROOT_USERNAME"
+                  --password "$MONGO_INITDB_ROOT_PASSWORD"
+                  --authenticationDatabase admin --eval
+                  'try { quit(db.adminCommand({ping: 1}).ok === 1 ? 0 : 1); }
+                  catch (error) { quit(1); }'
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
           env:
             - name: MONGO_INITDB_ROOT_USERNAME
               valueFrom:
@@ -52,6 +101,67 @@ spec:
             - name: mongodb-config
               mountPath: /etc/mongod.conf
               subPath: mongod.conf
+        - name: mongodb-replica-set-init
+          image: mongo:6.0.5
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              until mongosh --quiet --host 127.0.0.1:27017/admin \
+                --username "$MONGO_INITDB_ROOT_USERNAME" \
+                --password "$MONGO_INITDB_ROOT_PASSWORD" \
+                --authenticationDatabase admin --eval '
+                try { quit(db.adminCommand({ping: 1}).ok === 1 ? 0 : 1); }
+                catch (error) { quit(1); }
+              '; do sleep 2; done
+
+              until mongosh --quiet --host 127.0.0.1:27017/admin \
+                --username "$MONGO_INITDB_ROOT_USERNAME" \
+                --password "$MONGO_INITDB_ROOT_PASSWORD" \
+                --authenticationDatabase admin --eval '
+                const hello = db.adminCommand({hello: 1});
+                if (hello.setName === "rs0" && hello.isWritablePrimary === true) {
+                  quit(0);
+                }
+                try {
+                  rs.initiate({
+                    _id: "rs0",
+                    members: [{_id: 0, host: process.env.MONGO_RS_MEMBER_HOST}]
+                  });
+                } catch (error) {}
+                quit(1);
+              '; do sleep 2; done
+
+              exec tail -f /dev/null
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: urbana-connect-mongodb
+                  key: username
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: urbana-connect-mongodb
+                  key: password
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MONGO_RS_MEMBER_HOST
+              value: "$(POD_NAME).urbana-connect-mongodb.$(POD_NAMESPACE).svc.cluster.local:27017"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 50m
+              memory: 128Mi
       volumes:
         - name: mongodb-config
           configMap:

--- a/infra/kubernetes/mongodb/overlays/hml/README.md
+++ b/infra/kubernetes/mongodb/overlays/hml/README.md
@@ -7,10 +7,12 @@ Inclui:
 - `Service` interno `urbana-connect-mongodb`
 - `ConfigMap` com `mongod.conf`
 - `PersistentVolumeClaim` via `volumeClaimTemplates`
+- replica set `rs0` inicializado de forma idempotente por sidecar
+- probes que só consideram o Mongo pronto quando `hello` informa `rs0` e um primary gravável
 
 Não inclui:
 - backup/restore
-- replicaset
+- alta disponibilidade: um único membro não fornece failover
 - tuning avançado
 - secret real versionado
 
@@ -31,8 +33,20 @@ kubectl apply -k infra/kubernetes/mongodb/overlays/hml
 A URI da aplicação deve apontar para o service interno:
 
 ```text
-mongodb://<username>:<password>@urbana-connect-mongodb.urbana-connect-hml.svc.cluster.local:27017/<database>?authSource=admin
+mongodb://<username>:<password>@urbana-connect-mongodb.urbana-connect-hml.svc.cluster.local:27017/<database>?authSource=admin&replicaSet=rs0&retryWrites=true&retryReads=true&w=majority
 ```
+
+A URI efetiva deve incluir `replicaSet=rs0`, `retryWrites=true`,
+`retryReads=true` e `w=majority`. O template versionado em
+`infra/kubernetes/secrets/templates/mongodb-uri-secret-template.yaml` já
+contém essas opções.
+
+O pod usa o DNS estável do StatefulSet
+`urbana-connect-mongodb-0.urbana-connect-mongodb.<namespace>.svc.cluster.local`
+como membro do replica set. A promoção para um replica set de um único membro
+habilita transações multi-documento, mas não é uma topologia de alta
+disponibilidade; o desenho de produção com múltiplos membros, failover,
+backup e restore permanece fora da PEE-104.
 
 O namespace `urbana-connect-hml` também é declarado na overlay da app. Isso é intencional para permitir `apply` isolado de cada componente sem depender da ordem de execução.
 

--- a/infra/kubernetes/secrets/templates/mongodb-uri-secret-template.yaml
+++ b/infra/kubernetes/secrets/templates/mongodb-uri-secret-template.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: urbana-connect-hml
 type: Opaque
 stringData:
-  MONGODB_URI: "mongodb://PLACEHOLDER_MONGODB_USERNAME:PLACEHOLDER_MONGODB_PASSWORD@urbana-connect-mongodb.urbana-connect-hml.svc.cluster.local:27017/urbana-connect?authSource=admin"
+  MONGODB_URI: "mongodb://PLACEHOLDER_MONGODB_USERNAME:PLACEHOLDER_MONGODB_PASSWORD@urbana-connect-mongodb.urbana-connect-hml.svc.cluster.local:27017/urbana-connect?authSource=admin&replicaSet=rs0&retryWrites=true&retryReads=true&w=majority"
 
 # Template para a URI consumida pela aplicação.

--- a/infra/local-poc/README.md
+++ b/infra/local-poc/README.md
@@ -5,6 +5,12 @@ Hermes, Urbana Connect, `poc-chat` e os dois proxies. O runtime Hermes continua
 externo; seus artefatos mantidos pela Urbana ficam em
 `integrations/hermes-agent/`.
 
+O Mongo local executa como replica set `rs0` de um membro. O serviço
+`mongodb-rs-init` inicializa o membro `mongodb:27017` de forma idempotente, e o
+healthcheck só fica verde quando `hello` confirma um primary gravável. A URI
+consumida pela aplicação inclui `replicaSet=rs0`, retries de leitura/escrita e
+`w=majority`.
+
 Na raiz do repositório, com `.env.poc` local configurado:
 
 ```bash
@@ -31,6 +37,10 @@ Após a subida, valide a dependência obrigatória com
 `curl -fsS http://127.0.0.1:8081/api/v1/readiness` e o chat com
 `curl -fsS http://127.0.0.1:3000/health`. O chat depende de
 `urbana-connect: service_healthy` no Compose.
+
+Esse replica set de um membro habilita a transação multi-documento usada na
+prova técnica, mas não representa alta disponibilidade nem failover de
+produção.
 
 `.env.poc` não é movido, copiado ou exibido. Para validações Hermes, use os
 scripts em `integrations/hermes-agent/scripts/` e registre apenas resultados

--- a/infra/local-poc/README.md
+++ b/infra/local-poc/README.md
@@ -22,10 +22,21 @@ docker compose --env-file .env.poc \
   -f infra/local-poc/docker-compose.poc.yml ps
 ```
 
+O backend é compilado no próprio build Docker com Gradle e JDK 21: a imagem
+nunca copia `build/libs/*.jar` da máquina host. Assim, `up -d --build` usa
+necessariamente o código-fonte presente em `apps/urbana-connect-api/` no
+momento do build. O `poc-chat` também é reconstruído pelo Compose a partir do
+seu contexto de fonte.
+
 O mesmo fluxo pode ser iniciado por
 `./integrations/hermes-agent/scripts/run-local.sh -d`. O script resolve a
 imagem do serviço pelo Compose, constrói e valida a imagem PEE-103 padrão, ou
-usa uma imagem explicitamente configurada sem reconstruí-la.
+usa uma imagem explicitamente configurada sem reconstruí-la. Em ambos os
+casos, ele constrói antes as imagens atuais de `urbana-connect` e `poc-chat`,
+depois sobe o Compose com `--no-build` e aguarda os healthchecks dos dois
+serviços. O argumento `--build` é aceito, mas é dispensado pelo script porque
+os builds selecionados já ocorreram; isso impede que um `HERMES_IMAGE` externo
+seja reconstruído acidentalmente.
 
 O Compose usa por padrão a imagem local
 `urbana-hermes-agent:pee-103-2f5472a15`. Ela é construída a partir do Hermes
@@ -47,6 +58,20 @@ docker image inspect urbana-hermes-agent:pee-103-2f5472a15 \
   --format 'revision={{index .Config.Labels "org.opencontainers.image.revision"}}'
 ```
 
+Após a execução de `run-local.sh -d`, a saída também mostra o ID da imagem do
+backend, a revisão Git usada pelo script (com o sufixo `-dirty` quando há
+alterações locais em `apps/urbana-connect-api`) e a marca
+`containerized-gradle-jdk21`. Para inspecionar manualmente a imagem em uma
+subida direta do Compose:
+
+```bash
+docker compose --env-file .env.poc \
+  -f infra/local-poc/docker-compose.poc.yml images urbana-connect
+docker image inspect $(docker compose --env-file .env.poc \
+  -f infra/local-poc/docker-compose.poc.yml images -q urbana-connect) \
+  --format 'revision={{index .Config.Labels "org.opencontainers.image.revision"}} build={{index .Config.Labels "br.com.urbana.connect.build"}}'
+```
+
 Os contexts apontam para `apps/urbana-connect-api/` e `apps/poc-chat/`; os
 mounts do profile/plugin apontam para `integrations/hermes-agent/`. Nomes de
 serviços, portas, redes, volumes, healthchecks e isolamento permanecem os da
@@ -63,6 +88,19 @@ Após a subida, valide a dependência obrigatória com
 `curl -fsS http://127.0.0.1:3000/health`. O chat depende de
 `urbana-connect: service_healthy` no Compose.
 
+Para confirmar também o estado dos containers e o JAR que está sendo executado:
+
+```bash
+docker compose --env-file .env.poc \
+  -f infra/local-poc/docker-compose.poc.yml ps
+docker compose --env-file .env.poc \
+  -f infra/local-poc/docker-compose.poc.yml exec urbana-connect \
+  sh -c 'sha256sum /app/app.jar && java -version'
+```
+
+O hash do JAR acima é produzido dentro do estágio de build da imagem atual;
+ele não deve ser comparado a artefatos antigos do `build/libs` local.
+
 Esse replica set de um membro habilita a transação multi-documento usada na
 prova técnica, mas não representa alta disponibilidade nem failover de
 produção.
@@ -70,3 +108,27 @@ produção.
 `.env.poc` não é movido, copiado ou exibido. Para validações Hermes, use os
 scripts em `integrations/hermes-agent/scripts/` e registre apenas resultados
 sanitizados.
+
+## Controles locais de validação humana
+
+O `poc-chat` só mostra os controles da arquiteta quando a projeção canônica
+declara a capability correspondente. Eles aparecem com a marca
+`ação da arquiteta/teste`, fora do histórico do cliente, e não usam o ingresso
+de mensagens do cliente.
+
+As rotas expostas pelo proxy local são exclusivamente estas, sempre para um
+alias opaco `manual-<uuid>` e com o token injetado no servidor:
+
+```text
+POST /api/poc/conversations/{contactAlias}/payment-proof/approve
+POST /api/poc/conversations/{contactAlias}/human/messages
+POST /api/poc/conversations/{contactAlias}/ownership/urba
+```
+
+A mensagem humana exige `Idempotency-Key` e `{text, occurredAt}`. A devolução
+exige `Idempotency-Key` e `{expectedVersion}`; o backend sincroniza o histórico
+canônico completo com o Hermes antes de decidir se a Urba pode retomar. Falha
+de sincronização mantém a conversa com a arquiteta.
+
+Não habilite esses controles com links, tokens ou dados de produção. Eles são
+somente fixtures locais e não representam pagamento, contratação ou envio real.

--- a/infra/local-poc/README.md
+++ b/infra/local-poc/README.md
@@ -22,6 +22,31 @@ docker compose --env-file .env.poc \
   -f infra/local-poc/docker-compose.poc.yml ps
 ```
 
+O mesmo fluxo pode ser iniciado por
+`./integrations/hermes-agent/scripts/run-local.sh -d`. O script resolve a
+imagem do serviço pelo Compose, constrói e valida a imagem PEE-103 padrão, ou
+usa uma imagem explicitamente configurada sem reconstruí-la.
+
+O Compose usa por padrão a imagem local
+`urbana-hermes-agent:pee-103-2f5472a15`. Ela é construída a partir do Hermes
+pinado no commit `2f5472a15a026b6bd5847ad65058f1565d2b40ba`, sobre a imagem
+`urbana-hermes-agent:0.20.0`, sem montar o código-fonte no container. O valor
+pode ser substituído por `HERMES_IMAGE` para validar uma tag explicitamente
+publicada em homologação; nesse caso, suba o stack sem `--build`.
+
+```bash
+HERMES_IMAGE=urbana-hermes-agent:<tag-de-homologacao> \
+  docker compose --env-file .env.poc \
+  -f infra/local-poc/docker-compose.poc.yml up -d --no-build
+```
+
+Para verificar a identidade da imagem antes de subir o stack:
+
+```bash
+docker image inspect urbana-hermes-agent:pee-103-2f5472a15 \
+  --format 'revision={{index .Config.Labels "org.opencontainers.image.revision"}}'
+```
+
 Os contexts apontam para `apps/urbana-connect-api/` e `apps/poc-chat/`; os
 mounts do profile/plugin apontam para `integrations/hermes-agent/`. Nomes de
 serviços, portas, redes, volumes, healthchecks e isolamento permanecem os da

--- a/infra/local-poc/docker-compose.poc.yml
+++ b/infra/local-poc/docker-compose.poc.yml
@@ -17,7 +17,8 @@ services:
       test:
         - CMD-SHELL
         - >-
-          mongosh --quiet --host 127.0.0.1:27017/admin --eval
+          mongosh --quiet
+          'mongodb://127.0.0.1:27017/admin?directConnection=true&serverSelectionTimeoutMS=3000' --eval
           'const hello = db.adminCommand({hello: 1}); quit(
           hello.ok === 1 && hello.setName === "rs0" &&
           hello.isWritablePrimary === true ? 0 : 1);'
@@ -39,12 +40,14 @@ services:
       - /bin/sh
       - -ec
       - |
-        until mongosh --quiet --host mongodb:27017/admin --eval '
+        until mongosh --quiet \
+          'mongodb://mongodb:27017/admin?directConnection=true&serverSelectionTimeoutMS=3000' --eval '
           try { quit(db.adminCommand({ping: 1}).ok === 1 ? 0 : 1); }
           catch (error) { quit(1); }
         '; do sleep 1; done
 
-        until mongosh --quiet --host mongodb:27017/admin --eval '
+        until mongosh --quiet \
+          'mongodb://mongodb:27017/admin?directConnection=true&serverSelectionTimeoutMS=3000' --eval '
           const hello = db.adminCommand({hello: 1});
           if (hello.setName === "rs0" && hello.isWritablePrimary === true) {
             quit(0);
@@ -59,7 +62,7 @@ services:
         '; do sleep 1; done
 
   hermes-profile-init:
-    image: urbana-hermes-agent:0.20.0
+    image: ${HERMES_IMAGE:-urbana-hermes-agent:pee-103-2f5472a15}
     restart: "no"
     user: "0:0"
     volumes:
@@ -159,7 +162,12 @@ services:
       start_period: 5s
 
   hermes:
-    image: urbana-hermes-agent:0.20.0
+    image: ${HERMES_IMAGE:-urbana-hermes-agent:pee-103-2f5472a15}
+    build:
+      context: ../../..
+      dockerfile: urbana-connect/infra/local-poc/hermes-pee-103.Dockerfile
+      args:
+        HERMES_GIT_SHA: 2f5472a15a026b6bd5847ad65058f1565d2b40ba
     restart: unless-stopped
     depends_on:
       urbana-connect:

--- a/infra/local-poc/docker-compose.poc.yml
+++ b/infra/local-poc/docker-compose.poc.yml
@@ -4,17 +4,59 @@ services:
   mongodb:
     image: mongo:8.0
     restart: unless-stopped
+    hostname: mongodb
+    command:
+      - mongod
+      - --replSet=rs0
+      - --bind_ip_all
     networks:
       - data
     volumes:
       - mongodb_data:/data/db
     healthcheck:
-      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      test:
+        - CMD-SHELL
+        - >-
+          mongosh --quiet --host 127.0.0.1:27017/admin --eval
+          'const hello = db.adminCommand({hello: 1}); quit(
+          hello.ok === 1 && hello.setName === "rs0" &&
+          hello.isWritablePrimary === true ? 0 : 1);'
       interval: 5s
       timeout: 5s
-      retries: 12
+      retries: 30
     security_opt:
       - no-new-privileges:true
+
+  mongodb-rs-init:
+    image: mongo:8.0
+    restart: "no"
+    depends_on:
+      mongodb:
+        condition: service_started
+    networks:
+      - data
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        until mongosh --quiet --host mongodb:27017/admin --eval '
+          try { quit(db.adminCommand({ping: 1}).ok === 1 ? 0 : 1); }
+          catch (error) { quit(1); }
+        '; do sleep 1; done
+
+        until mongosh --quiet --host mongodb:27017/admin --eval '
+          const hello = db.adminCommand({hello: 1});
+          if (hello.setName === "rs0" && hello.isWritablePrimary === true) {
+            quit(0);
+          }
+          try {
+            rs.initiate({
+              _id: "rs0",
+              members: [{_id: 0, host: "mongodb:27017"}]
+            });
+          } catch (error) {}
+          quit(1);
+        '; do sleep 1; done
 
   hermes-profile-init:
     image: urbana-hermes-agent:0.20.0
@@ -45,6 +87,8 @@ services:
     depends_on:
       mongodb:
         condition: service_healthy
+      mongodb-rs-init:
+        condition: service_completed_successfully
     networks:
       - data
       - hermes_app
@@ -54,7 +98,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: poc
       SERVER_PORT: 8081
-      MONGODB_URI: mongodb://mongodb:27017/urbana-connect-poc
+      MONGODB_URI: "mongodb://mongodb:27017/urbana-connect-poc?replicaSet=rs0&retryWrites=true&retryReads=true&w=majority"
       HERMES_BASE_URL: http://hermes:8642
       HERMES_API_SERVER_KEY: ${HERMES_API_SERVER_KEY:?set HERMES_API_SERVER_KEY in .env.poc}
       HERMES_INTERNAL_TOOL_TOKEN: ${HERMES_INTERNAL_TOOL_TOKEN:?set HERMES_INTERNAL_TOOL_TOKEN in .env.poc}

--- a/infra/local-poc/docker-compose.poc.yml
+++ b/infra/local-poc/docker-compose.poc.yml
@@ -68,6 +68,8 @@ services:
     volumes:
       - hermes_data:/opt/data
       - ../../integrations/hermes-agent/profile/config.yaml.example:/profile/config.yaml:ro
+      - ../../integrations/hermes-agent/profile/SOUL.md:/profile/SOUL.md:ro
+      - ../../integrations/hermes-agent/plugins/urbana-domain:/profile/urbana-domain:ro
     read_only: true
     tmpfs:
       - /run:rw,exec,nosuid,nodev,size=16m
@@ -80,7 +82,14 @@ services:
     security_opt:
       - no-new-privileges:true
     entrypoint: ["/bin/sh", "-c"]
-    command: ["cp /profile/config.yaml /opt/data/config.yaml"]
+    command:
+      - |
+        set -eu
+        cp /profile/config.yaml /opt/data/config.yaml
+        cp /profile/SOUL.md /opt/data/SOUL.md
+        mkdir -p /opt/data/plugins
+        rm -rf /opt/data/plugins/urbana-domain
+        cp -R /profile/urbana-domain /opt/data/plugins/urbana-domain
 
   urbana-connect:
     build:
@@ -125,7 +134,10 @@ services:
       interval: 10s
       timeout: 5s
       retries: 12
-      start_period: 20s
+      # Spring Boot + Mongo bootstrap can exceed two minutes on a cold Docker
+      # Desktop VM. Keep failures during that window from being classified as
+      # an unhealthy application; readiness still requires the exact READY body.
+      start_period: 180s
 
   poc-chat:
     build:
@@ -196,8 +208,6 @@ services:
       PYTHONDONTWRITEBYTECODE: "1"
     volumes:
       - hermes_data:/opt/data
-      - ../../integrations/hermes-agent/profile/SOUL.md:/opt/data/SOUL.md:ro
-      - ../../integrations/hermes-agent/plugins/urbana-domain:/opt/data/plugins/urbana-domain:ro
     read_only: true
     tmpfs:
       - /run:rw,exec,nosuid,nodev,size=32m

--- a/infra/local-poc/hermes-pee-103.Dockerfile
+++ b/infra/local-poc/hermes-pee-103.Dockerfile
@@ -1,0 +1,18 @@
+# Local PEE-103 image used by the POC Compose stack.
+#
+# The published v0.20.0 image is the exact parent runtime pinned by the
+# integration. Only the files changed by PEE-103 are overlaid from the sibling
+# Hermes checkout, preserving an image-based runtime without source bind mounts.
+FROM urbana-hermes-agent:0.20.0
+
+ARG HERMES_GIT_SHA=2f5472a15a026b6bd5847ad65058f1565d2b40ba
+
+LABEL org.opencontainers.image.version="v2026.8.3-pee-103" \
+      org.opencontainers.image.revision="${HERMES_GIT_SHA}" \
+      org.opencontainers.image.source="https://github.com/NousResearch/hermes-agent"
+
+COPY hermes-agent/gateway/platforms/api_server.py /opt/hermes/gateway/platforms/api_server.py
+COPY hermes-agent/gateway/resume_capability.py /opt/hermes/gateway/resume_capability.py
+COPY hermes-agent/hermes_state_common.py /opt/hermes/hermes_state_common.py
+
+RUN printf '%s\n' "${HERMES_GIT_SHA}" > /opt/hermes/.hermes_build_sha

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -4,20 +4,29 @@ Este diretório contém somente artefatos mantidos pela Urbana para configurar e
 validar o runtime externo Hermes: profile, plugin `urbana-domain` e scripts
 locais. O código upstream Hermes não é versionado aqui.
 
-O runtime é fixado pelos scripts em `scripts/`: versão `v2026.8.3`, commit
-`3c27eb6234bf91b8ceee9e9071591b31e9b148cb` e imagem local
-`urbana-hermes-agent:0.20.0`. O Compose e os proxies ficam em
-`infra/local-poc/docker-compose.poc.yml`.
+O runtime upstream de referência continua fixado pelos scripts em `scripts/`:
+versão `v2026.8.3`, commit `3c27eb6234bf91b8ceee9e9071591b31e9b148cb` e
+imagem base `urbana-hermes-agent:0.20.0`. Para validar a capability PEE-103 no
+POC atual, o Compose constrói a imagem local
+`urbana-hermes-agent:pee-103-2f5472a15` a partir do checkout irmão do Hermes,
+usando o commit `2f5472a15a026b6bd5847ad65058f1565d2b40ba` e sem bind mount do
+código-fonte. O valor pode ser substituído pela variável `HERMES_IMAGE`.
 
 Os scripts resolvem a raiz do repositório a partir de sua própria localização,
 portanto podem ser chamados da raiz ou de outro diretório:
 
 ```bash
 ./integrations/hermes-agent/scripts/install-local.sh
+./integrations/hermes-agent/scripts/run-local.sh -d
 ./integrations/hermes-agent/scripts/smoke-contract.sh
 ./integrations/hermes-agent/scripts/smoke-isolation.sh
 ./integrations/hermes-agent/scripts/verify-tool-surface.sh
 ```
+
+`install-local.sh` mantém a imagem upstream base pinada. O `run-local.sh`
+constrói e valida a sobreposição PEE-103 usada pelo Compose; uma variável
+`HERMES_IMAGE` explícita é tratada como imagem já publicada e não é
+reconstruída.
 
 O arquivo `.env.poc` real permanece na raiz, fora do Git, e nunca deve ser
 copiado para este diretório nem impresso em logs.

--- a/integrations/hermes-agent/plugins/urbana-domain/__init__.py
+++ b/integrations/hermes-agent/plugins/urbana-domain/__init__.py
@@ -12,6 +12,40 @@ except ImportError:  # direct local unittest import
 
 TOOLSET = "urbana-domain"
 
+TOOL_DESCRIPTIONS = {
+    "get_customer_profile": (
+        "Consulta o perfil e os fatos já confirmados do cliente para manter contexto. "
+        "Não use para inventar ou inferir dados ausentes."
+    ),
+    "update_customer_fact": (
+        "Registra um fato que o cliente acabou de informar, usando somente os tipos permitidos."
+    ),
+    "list_available_services": (
+        "Consulta o catálogo aprovado de serviços. Use quando o cliente perguntar como funciona, "
+        "o que recebe, etapas, escopo, limites, disponibilidade ou preço. O resultado contém o "
+        "catálogo rico; responda à dúvida sem iniciar termos, pagamento ou handoff por esse motivo. "
+        "Ao detalhar um serviço identificado, explicite que é uma consultoria online e mencione "
+        "processo, Manual em PDF, Tour Virtual, 3 opções e até 2 rodadas de ajustes."
+    ),
+    "prepare_terms": (
+        "Prepara os termos de um serviço já escolhido para uma intenção clara de contratação. "
+        "Use somente nesse momento; não use para dúvidas, explicações ou comparação de serviços."
+    ),
+    "prepare_payment": (
+        "Prepara o pagamento de um serviço somente depois de os termos terem sido apresentados "
+        "e aceitos de forma textual clara e de a pessoa escolher uma forma válida. "
+        "As formas aceitas são PIX ou CARD (cartão de crédito). Se a forma não tiver sido "
+        "informada, não use a ferramenta: pergunte se a pessoa prefere PIX ou cartão de crédito. "
+        "Nunca use `link` como método; o link é a instrução retornada após o preparo. "
+        "Não repita a chamada com os mesmos argumentos depois de uma rejeição: corrija a informação "
+        "ou faça a pergunta necessária ao cliente."
+    ),
+    "request_human_handoff": (
+        "Transfere para atendimento humano quando o cliente pedir uma pessoa explicitamente ou "
+        "quando houver incapacidade real de avançar com as informações disponíveis."
+    ),
+}
+
 
 def _schema(tool_name: str) -> dict:
     parameters = {"type": "object", "additionalProperties": False, "properties": {}}
@@ -31,7 +65,14 @@ def _schema(tool_name: str) -> dict:
         parameters["properties"] = {"serviceType": {"type": "string"}}
         parameters["required"] = ["serviceType"]
     elif tool_name == "prepare_payment":
-        parameters["properties"] = {"serviceType": {"type": "string"}, "method": {"type": "string"}}
+        parameters["properties"] = {
+            "serviceType": {"type": "string"},
+            "method": {
+                "type": "string",
+                "enum": ["PIX", "CARD"],
+                "description": "Forma válida: PIX ou cartão de crédito.",
+            },
+        }
         parameters["required"] = ["serviceType", "method"]
     elif tool_name == "request_human_handoff":
         parameters["properties"] = {"reason": {"type": "string"}}
@@ -42,7 +83,7 @@ def _schema(tool_name: str) -> dict:
 def _function_schema(tool_name: str, parameters: dict) -> dict:
     return {
         "name": tool_name,
-        "description": f"Urbana domain operation: {tool_name}",
+        "description": TOOL_DESCRIPTIONS[tool_name],
         "parameters": parameters,
     }
 
@@ -58,7 +99,7 @@ def register(ctx) -> None:
             toolset=TOOLSET,
             schema=_schema(name),
             handler=handler,
-            description=f"Urbana domain operation: {name}",
+            description=TOOL_DESCRIPTIONS[name],
         )
 
 

--- a/integrations/hermes-agent/plugins/urbana-domain/test_tools.py
+++ b/integrations/hermes-agent/plugins/urbana-domain/test_tools.py
@@ -1,8 +1,11 @@
 import json
 import unittest
+from io import BytesIO
+from pathlib import Path
+from urllib import error
 
 import __init__ as plugin
-from tools import PluginClient, TOOL_NAMES, dispatch_tool
+from tools import SAFE_FAILURE, PluginClient, TOOL_NAMES, dispatch_tool
 
 
 class FakeResponse:
@@ -45,6 +48,50 @@ class PluginToolsTest(unittest.TestCase):
             "prepare_terms", "prepare_payment", "request_human_handoff",
         })
 
+    def test_tool_descriptions_make_informative_service_lookup_distinct_from_commercial_actions(self):
+        registered = []
+
+        class Context:
+            def register_tool(self, **kwargs):
+                registered.append(kwargs)
+
+        plugin.register(Context())
+        descriptions = {item["name"]: item["description"] for item in registered}
+
+        self.assertIn("como funciona", descriptions["list_available_services"].lower())
+        self.assertIn("catálogo", descriptions["list_available_services"].lower())
+        self.assertIn("intenção clara", descriptions["prepare_terms"].lower())
+        self.assertIn("não use para dúvidas", descriptions["prepare_terms"].lower())
+        self.assertIn("aceitos", descriptions["prepare_payment"].lower())
+
+    def test_prepare_payment_schema_enumerates_canonical_methods_with_natural_labels(self):
+        registered = []
+
+        class Context:
+            def register_tool(self, **kwargs):
+                registered.append(kwargs)
+
+        plugin.register(Context())
+        prepare_payment = next(item["schema"] for item in registered
+                               if item["name"] == "prepare_payment")
+        method = prepare_payment["parameters"]["properties"]["method"]
+
+        self.assertEqual(method["enum"], ["PIX", "CARD"])
+        self.assertIn("PIX", method["description"])
+        self.assertIn("cartão de crédito", method["description"].lower())
+
+    def test_soul_requires_progressive_replies_and_safe_payment_method_question(self):
+        soul = (Path(__file__).resolve().parents[2] / "profile" / "SOUL.md").read_text()
+        normalized = soul.lower()
+
+        self.assertIn("responda somente à nova dúvida ou decisão", normalized)
+        self.assertIn("não repita a lista completa", normalized)
+        self.assertIn("pix ou cartão de crédito", normalized)
+        self.assertIn("não chame `prepare_payment`", normalized)
+        self.assertIn("não exponha ao cliente", normalized)
+        self.assertNotIn("await_payment_approval", normalized)
+        self.assertNotIn("terms_not_accepted", normalized)
+
     def test_handler_forwards_runtime_session_only(self):
         requests = []
 
@@ -66,12 +113,137 @@ class PluginToolsTest(unittest.TestCase):
         }, {"task_id": "session-1"}, None)
         payload = json.loads(result)
         self.assertFalse(payload["ok"])
-        self.assertIsInstance(payload["error"], str)
+        self.assertIsInstance(payload["error"], dict)
+        self.assertEqual(payload["error"]["code"], "TEMPORARILY_UNAVAILABLE")
 
     def test_handler_catches_missing_runtime_session(self):
         payload = json.loads(dispatch_tool("list_available_services", {}, {}, None))
         self.assertFalse(payload["ok"])
-        self.assertIn("session", payload["error"])
+        self.assertEqual(payload["error"]["nextAction"], "CORRECT_INPUT")
+
+    def test_transports_structured_business_rejection_without_exception_text(self):
+        def opener(_req, timeout):
+            return FakeResponse({
+                "ok": False,
+                "error": {
+                    "code": "TERMS_NOT_ACCEPTED",
+                    "nextAction": "ASK_FOR_CLEAR_ACCEPTANCE",
+                    "missingFields": [],
+                    "customerMessage": "Antes do pagamento, preciso do seu aceite claro dos termos.",
+                },
+            })
+
+        payload = json.loads(dispatch_tool(
+            "prepare_payment", {"serviceType": "DECOR", "method": "PIX"},
+            {"task_id": "session-1"}, PluginClient("http://internal", "token", opener)))
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"]["code"], "TERMS_NOT_ACCEPTED")
+        self.assertNotIn("exception", json.dumps(payload).lower())
+
+    def test_transport_failure_never_exposes_forbidden_technical_vocabulary(self):
+        def opener(_req, timeout):
+            raise RuntimeError("HTTP 500 database API exception; retry with idempotency key")
+
+        payload = json.loads(dispatch_tool(
+            "get_customer_profile", {}, {"task_id": "session-1"},
+            PluginClient("http://internal", "token", opener)))
+        rendered = json.dumps(payload, ensure_ascii=False).lower()
+
+        self.assertFalse(payload["ok"])
+        for forbidden in ("http", "database", "api", "exception", "retry", "idempotency", "stack"):
+            self.assertNotIn(forbidden, rendered)
+
+    def test_http_business_rejection_keeps_the_structured_customer_safe_error(self):
+        body = json.dumps({
+            "ok": False,
+            "error": {
+                "code": "PAYMENT_METHOD_INVALID",
+                "nextAction": "ASK_FOR_PAYMENT_METHOD",
+                "missingFields": [],
+                "customerMessage": "Para continuar, você prefere realizar o pagamento via PIX ou cartão de crédito?",
+            },
+        }).encode("utf-8")
+
+        def opener(_req, timeout):
+            raise error.HTTPError("http://internal", 409, "business rejection", {}, BytesIO(body))
+
+        payload = json.loads(dispatch_tool(
+            "prepare_payment", {"serviceType": "DECOR", "method": "link"},
+            {"task_id": "session-1"}, PluginClient("http://internal", "token", opener)))
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"], {
+            "code": "PAYMENT_METHOD_INVALID",
+            "nextAction": "ASK_FOR_PAYMENT_METHOD",
+            "missingFields": [],
+            "customerMessage": "Para continuar, você prefere realizar o pagamento via PIX ou cartão de crédito?",
+        })
+
+    def test_http_409_malformed_business_rejection_returns_generic_safe_failure(self):
+        body = json.dumps({
+            "ok": False,
+            "error": {
+                "code": "PAYMENT_METHOD_INVALID",
+                "nextAction": "ASK_FOR_PAYMENT_METHOD",
+                "missingFields": [],
+            },
+        }).encode("utf-8")
+
+        def opener(_req, timeout):
+            raise error.HTTPError("http://internal", 409, "malformed rejection", {}, BytesIO(body))
+
+        payload = json.loads(dispatch_tool(
+            "prepare_payment", {"serviceType": "DECOR", "method": "PIX"},
+            {"task_id": "session-1"}, PluginClient("http://internal", "token", opener)))
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"], SAFE_FAILURE)
+
+    def test_http_409_technical_rejection_does_not_reach_hermes(self):
+        body = json.dumps({
+            "ok": False,
+            "error": "database exception while committing payment",
+            "trace": "java.lang.IllegalStateException: internal stack",
+        }).encode("utf-8")
+
+        def opener(_req, timeout):
+            raise error.HTTPError("http://internal", 409, "technical conflict", {}, BytesIO(body))
+
+        payload = json.loads(dispatch_tool(
+            "prepare_payment", {"serviceType": "DECOR", "method": "PIX"},
+            {"task_id": "session-1"}, PluginClient("http://internal", "token", opener)))
+        rendered = json.dumps(payload, ensure_ascii=False).lower()
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"], SAFE_FAILURE)
+        for forbidden in ("database", "exception", "internal", "stack"):
+            self.assertNotIn(forbidden, rendered)
+
+    def test_http_500_technical_rejection_returns_generic_safe_failure(self):
+        body = json.dumps({
+            "ok": False,
+            "error": {
+                "code": "DATABASE_FAILURE",
+                "nextAction": "RETRY",
+                "missingFields": [],
+                "customerMessage": "database connection exception",
+            },
+            "stack": "java.lang.RuntimeException: internal details",
+        }).encode("utf-8")
+
+        def opener(_req, timeout):
+            raise error.HTTPError("http://internal", 500, "server failure", {}, BytesIO(body))
+
+        payload = json.loads(dispatch_tool(
+            "get_customer_profile", {}, {"task_id": "session-1"},
+            PluginClient("http://internal", "token", opener)))
+        rendered = json.dumps(payload, ensure_ascii=False).lower()
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"], SAFE_FAILURE)
+        for forbidden in ("database", "exception", "internal", "stack"):
+            self.assertNotIn(forbidden, rendered)
 
 
 if __name__ == "__main__":

--- a/integrations/hermes-agent/plugins/urbana-domain/tools.py
+++ b/integrations/hermes-agent/plugins/urbana-domain/tools.py
@@ -44,8 +44,48 @@ TECHNICAL_PRINCIPAL = "hermes-urbana-domain"
 FORBIDDEN_IDENTIFIERS = frozenset({"contactId", "turnId", "idempotencyKey", "phoneNumber"})
 
 
+SAFE_FAILURE = {
+    "code": "TEMPORARILY_UNAVAILABLE",
+    "nextAction": "WAIT_OR_HANDOFF",
+    "missingFields": [],
+    "customerMessage": "Não consegui concluir esta etapa agora. Posso tentar novamente ou chamar a arquiteta.",
+}
+SAFE_ERROR_FIELDS = frozenset({"code", "nextAction", "missingFields", "customerMessage"})
+
+
+def _is_structured_business_rejection(payload: Any) -> bool:
+    if not isinstance(payload, Mapping) or payload.get("ok") is not False:
+        return False
+    safe_error = payload.get("error")
+    if not isinstance(safe_error, Mapping) or set(safe_error) != SAFE_ERROR_FIELDS:
+        return False
+
+    code = safe_error["code"]
+    next_action = safe_error["nextAction"]
+    missing_fields = safe_error["missingFields"]
+    customer_message = safe_error["customerMessage"]
+    return (
+        isinstance(code, str) and bool(code.strip())
+        and isinstance(next_action, str) and bool(next_action.strip())
+        and isinstance(missing_fields, list)
+        and all(isinstance(field, str) and bool(field.strip()) for field in missing_fields)
+        and isinstance(customer_message, str) and bool(customer_message.strip())
+    )
+
+
 class PluginToolError(ValueError):
-    """Expected validation or domain rejection returned as JSON."""
+    """Safe validation or domain rejection returned as structured JSON."""
+
+    def __init__(self, safe_error: Mapping[str, Any] | None = None) -> None:
+        candidate = safe_error if isinstance(safe_error, Mapping) else {}
+        self.safe_error = {
+            "code": str(candidate.get("code") or "INVALID_REQUEST"),
+            "nextAction": str(candidate.get("nextAction") or "CORRECT_INPUT"),
+            "missingFields": list(candidate.get("missingFields") or []),
+            "customerMessage": str(candidate.get("customerMessage") or
+                                   "Preciso de dados válidos para continuar."),
+        }
+        super().__init__(self.safe_error["customerMessage"])
 
 
 @dataclass(frozen=True)
@@ -56,13 +96,13 @@ class PluginClient:
 
     def call(self, session_id: str, principal: str, tool_name: str, arguments: Mapping[str, Any]) -> Any:
         if tool_name not in TOOL_NAMES:
-            raise PluginToolError(f"tool is not allowlisted: {tool_name}")
+            raise PluginToolError()
         if not session_id or not isinstance(session_id, str):
-            raise PluginToolError("runtime session id is required")
+            raise PluginToolError()
         if not principal or not isinstance(principal, str):
-            raise PluginToolError("technical principal is required")
+            raise PluginToolError()
         if FORBIDDEN_IDENTIFIERS.intersection(arguments):
-            raise PluginToolError("model identifiers are not accepted")
+            raise PluginToolError()
         body = json.dumps({
             "sessionId": session_id,
             "principal": principal,
@@ -78,12 +118,25 @@ class PluginClient:
         try:
             with opener(req, timeout=15) as response:
                 payload = json.loads(response.read().decode("utf-8"))
+        except error.HTTPError as exc:
+            # Business rejections use HTTP 409 at the internal boundary. Keep
+            # their safe, structured envelope so Hermes can correct the turn
+            # instead of seeing a generic transport outage.
+            if exc.code != 409:
+                raise PluginToolError(SAFE_FAILURE) from exc
+            try:
+                payload = json.loads(exc.read().decode("utf-8"))
+            except (AttributeError, OSError, TypeError, UnicodeDecodeError, ValueError) as decode_error:
+                raise PluginToolError(SAFE_FAILURE) from decode_error
+            if not _is_structured_business_rejection(payload):
+                raise PluginToolError(SAFE_FAILURE)
+            raise PluginToolError(payload["error"])
         except (error.URLError, TimeoutError, ValueError) as exc:
-            raise PluginToolError(f"domain tool request failed: {exc}") from exc
+            raise PluginToolError(SAFE_FAILURE) from exc
         if not isinstance(payload, dict):
-            raise PluginToolError("domain tool returned a non-object JSON response")
+            raise PluginToolError(SAFE_FAILURE)
         if payload.get("ok") is False:
-            raise PluginToolError(str(payload.get("error") or "domain operation rejected"))
+            raise PluginToolError(payload.get("error"))
         return payload.get("result", payload)
 
 
@@ -94,15 +147,15 @@ def _runtime_identity(runtime: Mapping[str, Any]) -> tuple[str, str]:
     # or copied from arbitrary runtime metadata.
     principal = TECHNICAL_PRINCIPAL
     if not isinstance(session_id, str) or not session_id.strip():
-        raise PluginToolError("runtime task_id/session_id is required")
+        raise PluginToolError()
     if not isinstance(principal, str) or not principal.strip():
-        raise PluginToolError("technical principal is required")
+        raise PluginToolError()
     return session_id.strip(), principal.strip()
 
 
 def _validate(tool_name: str, arguments: Mapping[str, Any]) -> None:
     if not isinstance(arguments, Mapping):
-        raise PluginToolError("arguments must be an object")
+        raise PluginToolError()
     if tool_name == "get_customer_profile":
         GetCustomerProfileInput.from_payload(arguments)
     elif tool_name == "update_customer_fact":
@@ -116,7 +169,7 @@ def _validate(tool_name: str, arguments: Mapping[str, Any]) -> None:
     elif tool_name == "request_human_handoff":
         RequestHumanHandoffInput.from_payload(arguments)
     else:
-        raise PluginToolError(f"tool is not allowlisted: {tool_name}")
+        raise PluginToolError()
 
 
 def dispatch_tool(tool_name: str, arguments: Mapping[str, Any] | None = None,
@@ -133,8 +186,10 @@ def dispatch_tool(tool_name: str, arguments: Mapping[str, Any] | None = None,
         )
         result = active_client.call(session_id, principal, tool_name, arguments)
         return json.dumps({"ok": True, "result": result}, ensure_ascii=False, separators=(",", ":"))
-    except Exception as exc:  # plugin boundary must never leak an exception to Hermes
-        return json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False, separators=(",", ":"))
+    except PluginToolError as exc:
+        return json.dumps({"ok": False, "error": exc.safe_error}, ensure_ascii=False, separators=(",", ":"))
+    except Exception:  # plugin boundary must never leak an exception to Hermes
+        return json.dumps({"ok": False, "error": SAFE_FAILURE}, ensure_ascii=False, separators=(",", ":"))
 
 
 def handle_tool_call(tool_name: str, arguments: Mapping[str, Any] | None = None,

--- a/integrations/hermes-agent/profile/SOUL.md
+++ b/integrations/hermes-agent/profile/SOUL.md
@@ -1,9 +1,9 @@
 # Urba — recepcionista virtual da Urbana do Brasil
 
 Você é a Urba, assistente virtual da Urbana do Brasil. Seja cordial, objetiva,
-acolhedora e escreva em português brasileiro claro. Você pode se apresentar
-quando isso fizer sentido na conversa, mas não use frases fixas para preencher
-uma resposta.
+acolhedora e escreva em português brasileiro claro. Na primeira resposta de uma
+conversa, identifique-se como Urba, assistente virtual da Urbana do Brasil. Nas
+demais, não repita a apresentação sem necessidade.
 
 ## Conversa
 
@@ -14,9 +14,73 @@ uma resposta.
   conversa.
 - Use somente informações retornadas pelas ferramentas `urbana-domain` para
   serviços, preços, disponibilidade, prazos, condições e fatos do cliente.
+- Na abertura, quando a pessoa apenas cumprimentar, perguntar quais serviços
+  existem ou pedir ajuda para escolher, seja breve: identifique-se, cite os
+  quatro nomes (`Decor Pintura`, `Decor Fachada`, `Decor Reforma` e `Decor
+  Interiores`) e pergunte qual opção ela quer conhecer ou que necessidade deseja
+  resolver. Não liste preços, etapas, entregas, limites ou o catálogo rico nessa
+  primeira resposta. A intenção é iniciar a descoberta, não apresentar o pacote
+  completo antes de a pessoa demonstrar interesse em um serviço específico.
 - Se uma informação não estiver disponível, diga isso de forma natural e peça o
   esclarecimento necessário. Não invente uma oferta, preço, desconto, prazo ou
   forma de pagamento.
+- Quando a pessoa perguntar como um serviço funciona, o que recebe, etapas,
+  escopo, limites ou condições, consulte `list_available_services` e explique
+  progressivamente somente o serviço identificado ou a comparação solicitada.
+  Se a pergunta ainda for genérica, peça que a pessoa indique o serviço ou
+  descreva o ambiente antes de despejar detalhes de todos os pacotes. Essa é
+  uma conversa informativa: não apresente termos, não prepare pagamento e não
+  transfira para a arquiteta apenas por a pessoa pedir mais detalhes.
+- Ao explicar o funcionamento ou os detalhes de um serviço já identificado,
+  diga explicitamente que se trata de uma consultoria online e cubra, de forma
+  natural e proporcional à pergunta, o processo e as entregas comuns: Manual
+  em PDF, Tour Virtual, 3 opções de solução e até 2 rodadas consolidadas de
+  ajustes. Não omita esses pontos na primeira explicação relevante só porque o
+  cliente já escolheu o serviço.
+- Depois que o pacote já tiver sido explicado, responda somente à nova dúvida ou decisão.
+  Não repita a lista completa de entregas, etapas ou responsabilidades
+  sem necessidade; só recapitule se a pessoa pedir um resumo ou se uma
+  confirmação curta for indispensável para avançar.
+
+## Perfil durante a contratação
+
+- Só depois de o serviço estar confirmado e de a pessoa demonstrar intenção
+  explícita de contratar, consulte `get_customer_profile`. Reutilize os fatos
+  atuais do cliente e pergunte somente os campos ausentes entre
+  `PRONOUN_PREFERENCE`, `FIRST_TIME_HIRING` e `OCCUPATION`. Se não houver
+  campo ausente, não repita a coleta.
+- Faça a pergunta em uma mensagem curta, com uma pergunta por linha, incluindo
+  apenas os campos que faltam. Por exemplo:
+  `Para eu seguir:`
+  `Como prefere que eu me refira a você?`
+  `É sua primeira contratação de um serviço de design?`
+  `Qual é sua profissão ou área de atuação?`
+  Nunca use o termo técnico “ICP” ao falar com o cliente.
+- Dê a cada campo ausente no máximo uma segunda oportunidade. Uma recusa
+  explícita conclui o campo imediatamente; se não houver resposta na segunda
+  oportunidade, use `update_customer_fact` para registrar `NÃO INFORMADO`
+  somente nos campos que continuam ausentes e siga sem insistir.
+  `NÃO INFORMADO` é o valor canônico também para recusa de pronome; não use
+  `PREFER_NOT_TO_ANSWER` como valor persistido.
+  Não mantenha um contador ou uma máquina de diálogo no backend para controlar
+  essa regra.
+- Quando todos os campos ausentes tiverem sido respondidos, recusados ou
+  marcados como `NÃO INFORMADO`, avance automaticamente para `prepare_terms`.
+  O perfil não é bloqueio de pagamento: `prepare_payment` depende apenas de
+  termos apresentados e aceite textual claro. Nunca apresente termos antes de
+  serviço confirmado e intenção clara de contratação.
+- Registre silenciosamente declarações espontâneas e explícitas sobre esses
+  campos em qualquer etapa, sem interromper a conversa para repetir a pergunta.
+  Se a pessoa corrigir um valor, atualize silenciosamente o valor explícito
+  mais recente e não anuncie a substituição.
+- Se a pessoa responder outra dúvida durante a coleta, responda normalmente e
+  retome depois apenas os campos ainda ausentes. Um pedido de atendimento
+  humano interrompe a coleta; não execute termos ou pagamento enquanto a
+  responsabilidade for humana.
+- Depois da devolução do atendimento, use os fatos atuais e a thread completa,
+  incluindo as mensagens da pessoa, da Urba, da arquiteta e as mensagens de
+  contexto. Trate decisões da arquiteta como verdade operacional, não peça ao
+  cliente para repeti-las e não invente fatos a partir da fala humana.
 
 ## Controles operacionais
 
@@ -27,9 +91,23 @@ uma resposta.
   Connect. Nunca peça nem forneça esses identificadores técnicos.
 - Um comprovante pode ser recebido, mas nunca confirma pagamento. A aprovação é
   exclusivamente humana.
+- Não exponha ao cliente códigos de erro, nomes de ferramentas, estados
+  internos, indisponibilidade do sistema ou detalhes técnicos. Converta uma
+  falha operacional em uma orientação natural e segura, ou encaminhe para a
+  arquiteta quando não for possível avançar.
 - Quando a pessoa pedir atendimento humano, solicite
   `request_human_handoff` e não continue executando ações depois do handoff.
   Reserve o handoff para um pedido explícito de pessoa, assunto institucional,
-  conteúdo fora do escopo ou uma conversa que não consiga avançar.
+  conteúdo fora do escopo ou uma incapacidade real de avançar após usar as
+  informações disponíveis. Não faça handoff por inferência durante uma dúvida
+  informativa sobre serviço.
+- Use `prepare_terms` somente depois que a pessoa escolher claramente um
+  serviço e demonstrar intenção de contratação. Use `prepare_payment` somente
+  depois de os termos terem sido apresentados e aceitos de forma textual clara.
+  Se a forma de pagamento ainda não tiver sido informada, não chame `prepare_payment`:
+  pergunte, em uma mensagem curta, se a pessoa prefere PIX ou cartão de crédito. Ao chamar a ferramenta, use exatamente `PIX` ou `CARD`;
+  `link` é a instrução retornada depois do preparo, não uma forma de pagamento.
+  Depois de um preparo bem-sucedido, envie o link recebido e peça o comprovante;
+  só comunique que ele aguarda validação humana depois que o comprovante chegar.
 - Não use terminal, arquivos, navegador, web, mensagens, credenciais, banco de
   dados ou ferramentas que não estejam explicitamente expostas.

--- a/integrations/hermes-agent/scripts/run-local.sh
+++ b/integrations/hermes-agent/scripts/run-local.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-HERMES_VERSION="v2026.8.3"
-HERMES_COMMIT="3c27eb6234bf91b8ceee9e9071591b31e9b148cb"
-HERMES_PACKAGE_VERSION="0.20.0"
+HERMES_VERSION="v2026.8.3-pee-103"
+HERMES_COMMIT="2f5472a15a026b6bd5847ad65058f1565d2b40ba"
+DEFAULT_IMAGE="urbana-hermes-agent:pee-103-2f5472a15"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 COMPOSE_FILE="$REPO_ROOT/infra/local-poc/docker-compose.poc.yml"
 ENV_FILE="$REPO_ROOT/.env.poc"
-IMAGE="urbana-hermes-agent:${HERMES_PACKAGE_VERSION}"
+IMAGE=""
 
 file_mode() {
   if [[ "$(uname -s)" == "Darwin" ]]; then
@@ -38,7 +38,21 @@ image_label() {
     "$IMAGE" 2>/dev/null || true
 }
 
+compose_image() {
+  "${compose[@]}" config --format json | python3 -c '
+import json
+import sys
+
+services = json.load(sys.stdin).get("services", {})
+image = services.get("hermes", {}).get("image")
+if not image:
+    raise SystemExit("Hermes service image is missing from the resolved Compose config.")
+print(image)
+'
+}
+
 command -v docker >/dev/null 2>&1 || { echo "Docker is required." >&2; exit 2; }
+command -v python3 >/dev/null 2>&1 || { echo "Python 3 is required." >&2; exit 2; }
 [[ -f "$ENV_FILE" ]] || { echo "Create .env.poc from .env.poc.example first." >&2; exit 2; }
 env_mode="$(file_mode "$ENV_FILE")"
 [[ "$env_mode" == "600" ]] || {
@@ -56,10 +70,29 @@ if ! "${compose[@]}" config --quiet; then
   exit 3
 fi
 
+IMAGE="$(compose_image)"
+if [[ "$IMAGE" == "$DEFAULT_IMAGE" ]]; then
+  echo "Building validated Hermes image: $IMAGE"
+  "${compose[@]}" build hermes
+else
+  for argument in "$@"; do
+    if [[ "$argument" == "--build" ]]; then
+      echo "Do not use --build with an explicitly overridden HERMES_IMAGE ($IMAGE)." >&2
+      echo "Validate that image separately, then run without --build." >&2
+      exit 3
+    fi
+  done
+  docker image inspect "$IMAGE" >/dev/null 2>&1 || {
+    echo "Configured HERMES_IMAGE is not available locally: $IMAGE" >&2
+    exit 3
+  }
+fi
+
 revision="$(image_label 'org.opencontainers.image.revision')"
 version_label="$(image_label 'org.opencontainers.image.version')"
-if [[ "$revision" != "$HERMES_COMMIT" || "$version_label" != "$HERMES_VERSION" ]]; then
-  echo "Pinned Hermes image is not installed; run integrations/hermes-agent/scripts/install-local.sh first." >&2
+if [[ "$IMAGE" == "$DEFAULT_IMAGE" &&
+      ( "$revision" != "$HERMES_COMMIT" || "$version_label" != "$HERMES_VERSION" ) ]]; then
+  echo "Validated Hermes image labels do not match $HERMES_VERSION ($HERMES_COMMIT)." >&2
   exit 3
 fi
 

--- a/integrations/hermes-agent/scripts/run-local.sh
+++ b/integrations/hermes-agent/scripts/run-local.sh
@@ -10,6 +10,41 @@ COMPOSE_FILE="$REPO_ROOT/infra/local-poc/docker-compose.poc.yml"
 ENV_FILE="$REPO_ROOT/.env.poc"
 IMAGE=""
 
+app_source_revision() {
+  local revision
+  revision="$(git -C "$REPO_ROOT" rev-parse --short=12 HEAD 2>/dev/null || printf 'workspace-source')"
+  if ! git -C "$REPO_ROOT" diff --quiet -- apps/urbana-connect-api; then
+    revision="${revision}-dirty"
+  fi
+  printf '%s' "$revision"
+}
+
+wait_for_healthy_service() {
+  local service="$1"
+  local attempts=60
+  local container_id health_status
+
+  while (( attempts > 0 )); do
+    container_id="$("${compose[@]}" ps -q "$service")"
+    if [[ -n "$container_id" ]]; then
+      health_status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id")"
+      if [[ "$health_status" == "healthy" ]]; then
+        echo "$service is healthy."
+        return 0
+      fi
+      if [[ "$health_status" == "unhealthy" || "$health_status" == "exited" || "$health_status" == "dead" ]]; then
+        echo "$service did not become healthy (status: $health_status)." >&2
+        return 1
+      fi
+    fi
+    sleep 2
+    ((attempts--))
+  done
+
+  echo "Timed out waiting for $service to become healthy." >&2
+  return 1
+}
+
 file_mode() {
   if [[ "$(uname -s)" == "Darwin" ]]; then
     stat -f '%Lp' "$1"
@@ -71,17 +106,12 @@ if ! "${compose[@]}" config --quiet; then
 fi
 
 IMAGE="$(compose_image)"
+app_revision="$(app_source_revision)"
+app_build_created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 if [[ "$IMAGE" == "$DEFAULT_IMAGE" ]]; then
   echo "Building validated Hermes image: $IMAGE"
   "${compose[@]}" build hermes
 else
-  for argument in "$@"; do
-    if [[ "$argument" == "--build" ]]; then
-      echo "Do not use --build with an explicitly overridden HERMES_IMAGE ($IMAGE)." >&2
-      echo "Validate that image separately, then run without --build." >&2
-      exit 3
-    fi
-  done
   docker image inspect "$IMAGE" >/dev/null 2>&1 || {
     echo "Configured HERMES_IMAGE is not available locally: $IMAGE" >&2
     exit 3
@@ -96,4 +126,42 @@ if [[ "$IMAGE" == "$DEFAULT_IMAGE" &&
   exit 3
 fi
 
-exec "${compose[@]}" up "$@"
+echo "Building current Urbana Connect and POC chat images (source revision: $app_revision)."
+"${compose[@]}" build \
+  --build-arg "APP_SOURCE_REVISION=$app_revision" \
+  --build-arg "APP_BUILD_CREATED=$app_build_created" \
+  urbana-connect poc-chat
+
+up_args=(--force-recreate)
+detached=false
+for argument in "$@"; do
+  case "$argument" in
+    --build)
+      echo "Ignoring --build: selected images were built explicitly above."
+      ;;
+    -d|--detach)
+      detached=true
+      up_args+=("$argument")
+      ;;
+    --no-build)
+      ;;
+    *)
+      up_args+=("$argument")
+      ;;
+  esac
+done
+
+if [[ "$detached" != true ]]; then
+  exec "${compose[@]}" up --no-build "${up_args[@]}"
+fi
+
+"${compose[@]}" up --no-build "${up_args[@]}"
+wait_for_healthy_service urbana-connect
+wait_for_healthy_service poc-chat
+
+backend_image_id="$("${compose[@]}" images -q urbana-connect)"
+if [[ -n "$backend_image_id" ]]; then
+  docker image inspect --format \
+    'urbana-connect image={{.Id}} revision={{index .Config.Labels "org.opencontainers.image.revision"}} build={{index .Config.Labels "br.com.urbana.connect.build"}}' \
+    "$backend_image_id"
+fi

--- a/integrations/hermes-agent/scripts/smoke-isolation.sh
+++ b/integrations/hermes-agent/scripts/smoke-isolation.sh
@@ -15,10 +15,12 @@ import json, sys
 container = json.load(sys.stdin)[0]
 mounts = container.get("Mounts", [])
 binds = [m for m in mounts if m.get("Type") == "bind"]
-allowed = {"SOUL.md", "urbana-domain"}
-actual = {m.get("Source", "").rstrip("/").split("/")[-1] for m in binds}
-if actual != allowed or any(m.get("RW") for m in binds):
-    raise SystemExit(f"unexpected Hermes bind mounts: {binds}")
+if binds:
+    raise SystemExit(f"Hermes must not receive source bind mounts: {binds}")
+data_volumes = [m for m in mounts
+                if m.get("Type") == "volume" and m.get("Destination") == "/opt/data"]
+if len(data_volumes) != 1 or data_volumes[0].get("RW") is not True:
+    raise SystemExit(f"Hermes must use one writable named data volume: {mounts}")
 if any("docker.sock" in m.get("Source", "") for m in mounts):
     raise SystemExit("Docker socket must not be mounted")
 print("filesystem_isolation=ok")
@@ -31,8 +33,13 @@ import json, sys
 container = json.load(sys.stdin)[0]
 binds = [m for m in container.get("Mounts", []) if m.get("Type") == "bind"]
 actual = {m.get("Source", "").rstrip("/").split("/")[-1] for m in binds}
-if actual != {"config.yaml.example"} or any(m.get("RW") for m in binds):
+if actual != {"config.yaml.example", "SOUL.md", "urbana-domain"} \
+        or any(m.get("RW") for m in binds):
     raise SystemExit(f"unexpected profile init bind mounts: {binds}")
+data_volumes = [m for m in container.get("Mounts", [])
+                if m.get("Type") == "volume" and m.get("Destination") == "/opt/data"]
+if len(data_volumes) != 1 or data_volumes[0].get("RW") is not True:
+    raise SystemExit(f"profile init must stage into one writable named data volume: {container.get('Mounts', [])}")
 print("profile_config_staging=read-only")
 '
 

--- a/specs/008-complete-urba-service-flow/baseline.md
+++ b/specs/008-complete-urba-service-flow/baseline.md
@@ -1,0 +1,202 @@
+# Baseline local reconciliado com lacunas
+
+Este inventário impede que a execução da feature seja tratada como greenfield.
+Ele registra o estado observado antes da correção dos artefatos em 2026-08-26;
+não atribui autoria, não declara conclusão e não autoriza descartar arquivos.
+
+## Snapshot observado
+
+- branch no início do gate: `008-complete-urba-service-flow`; branch após o gate:
+  `feature/008-complete-urba-service-flow`;
+- Jira: `PEE-105`, subtarefa de PEE-23, status `Em andamento`;
+- relação: `hml` é ancestral da branch atual;
+- árvore: 53 arquivos rastreados modificados e 18 entradas não rastreadas;
+- diff rastreado no início da auditoria: 3.631 inserções e 438 remoções;
+- áreas afetadas: backend Reception/catálogo/persistência, plugin e SOUL Hermes,
+  POC React, proxy/compose local, testes e documentação.
+
+## Slices reconciliados
+
+| Slice | Evidência observada | Estado de aceite |
+|---|---|---|
+| Catálogo rico | modelos, política comercial, seed Mongo e testes estão modificados; testes focados do catálogo passaram | Aproveitável com delta: regras ICP/política e cobertura live ainda faltam |
+| Handoff e retomada | orquestrador, reconciliação, portas/adaptador Hermes e testes estão modificados; slice focado passou | Aproveitável com delta: aceite live e E2E ainda faltam |
+| POC da arquiteta | contratos, reducer, componentes, proxy e testes estão modificados; Vitest, typecheck e build passaram | Aproveitável |
+| Build local | Dockerfile, compose, script Hermes e README estão modificados; Docker daemon não estava disponível | Incompleto/bloqueado para validação de imagem e healthcheck |
+| SOUL/plugin | perfil e ferramentas do plugin estão modificados; 8 testes unitários passaram | Aproveitável com delta: fluxo live e redação final ainda faltam |
+| E2E de qualidade | `apps/poc-chat/e2e/quality-chat.spec.ts` existe e cobre descoberta/handoff | Incompleto para ICP/termos |
+| Fatos de ICP | tipos, políticas e testes existentes referenciam os três campos; 3 dos 36 testes adicionais falharam | Incompleto/conflitante com o contrato aprovado |
+| Evento de desvio | nenhuma ocorrência de `ICP_SKIPPED_BEFORE_TERMS` foi encontrada em `apps/` ou `integrations/` | Ausente |
+
+## Evidência de validação do Gate 0
+
+Os testes foram executados depois de separar falhas ambientais de falhas de
+produto:
+
+- Backend com JDK 21 Temurin temporário em `/tmp/urbana-connect-jdk21`:
+  `./gradlew clean test` com os testes focados de catálogo, ferramentas,
+  orquestração, handoff, reconciliação e controllers: **102 testes passaram**.
+  O primeiro resultado inválido foi causado por Java 11 e, depois, por classes
+  stale com sufixo ` 2` em `build`; `clean` removeu somente artefatos gerados.
+- Backend adicional de fatos/retomada: **36 testes executados, 3 falharam**:
+  `ReceptionResponsePolicyTest.keepsTheValidatedConversationalMessageAndNextActionAsSeparateFields`,
+  `ReturningCustomerServiceTest.asksOnlyForIcpFieldsThatAreTentativeStaleOrAbsentAndAcceptsPreferNotToAnswer`
+  e `ReturningCustomerServiceTest.keepsCorrectedFactHistoryAndNeverExposesTheSentinelContact`.
+  A causa observável é que `CommercialPolicyService.missingIcpFields` e
+  `isIcpComplete` ainda são placeholders (`[]`/`true`), além da política de
+  preço rejeitar o caso aprovado esperado pelo primeiro teste.
+- Plugin Hermes: `python3 -m unittest discover -s plugins/urbana-domain -p
+  'test*.py'`: **8 testes passaram**.
+- POC React: `npm test -- --run`: **19 arquivos/79 testes passaram**;
+  `npm run typecheck`: passou; `npm run build`: passou após reidratar em
+  `node_modules` os binários nativos do Rolldown e do Lightning CSS que estavam
+  como `.icloud`. `package.json` e `package-lock.json` não foram alterados.
+- Validação Docker/Playwright live não foi executada: o Docker daemon local não
+  estava disponível. O E2E existente permanece limitado à descoberta,
+  explicação inicial e handoff; ainda não cobre ICP, aceite, pagamento,
+  briefing, retorno humano → Urba ou `ICP_SKIPPED_BEFORE_TERMS`.
+
+## Delta congelado para os escritores
+
+- Writer A deve tratar a parte de catálogo/fatos de T007, T011, T013–T016,
+  T019–T020, T025 e T029, começando pelos três testes vermelhos e sem editar
+  os boundaries de ferramentas/orquestração.
+- Writer B deve tratar a parte de ferramentas de T007, T008–T010, T012,
+  T017, T021–T023, T026–T028 e T030–T044, incluindo
+  `ICP_SKIPPED_BEFORE_TERMS`, contexto integral e handoff visível.
+- Writer C deve tratar T024, T042 e T045–T048, ampliando o E2E sem assumir que
+  o backend está disponível no ambiente do writer.
+- Nenhum writer deve reverter o snapshot, reintroduzir o seeder duplicado ou
+  criar `ICPCheckpointState`/`attemptsByField`.
+
+## Alertas de preservação
+
+- O arquivo duplicado legado `ServiceCatalogSeeder 2.java` foi comparado com o
+  seeder canônico, retirado do source set para não declarar uma segunda classe
+  pública `ServiceCatalogSeeder` e preservado em
+  `docs/plans/legacy-review/ServiceCatalogSeeder 2.java`.
+- A existência de testes modificados não prova que foram escritos antes do
+  código nem que passam no estado atual.
+- Nenhum arquivo do baseline pode ser revertido, substituído em massa ou
+  marcado como concluído sem inspeção e evidência correspondente.
+- O backend não contém uma classe `ICPCheckpointState` no snapshot observado;
+  ela também não deve ser introduzida como autoridade conversacional.
+
+## Gate obrigatório antes dos escritores
+
+- [x] Inventário inicial e relação com `hml` registrados.
+- [x] Lacunas centrais conhecidas registradas nos artefatos.
+- [x] Associar cada slice existente às tarefas revisadas e executar os testes
+  focados correspondentes.
+- [x] Classificar o diff por slice como aproveitável, incompleto, conflitante ou
+  fora de escopo; registrar evidência neste arquivo.
+- [x] Resolver o arquivo de seeder suspeito sem perda de conteúdo; a versão
+  legada está preservada para consulta/revisão.
+- [x] Vincular `PEE-105` e movê-la para `Em andamento` no início efetivo da
+  execução.
+- [x] Migrar/renomear para `feature/008-complete-urba-service-flow`, preservando
+  a árvore e mantendo `hml` como base.
+
+Somente após esses itens o Tech Lead distribui ownership de escrita. O estado
+dos checkboxes de `tasks.md` deve refletir evidência, não aparência do diff.
+
+## Estado pós-escritores e QA local — 2026-08-26
+
+O delta foi implementado na branch `feature/008-complete-urba-service-flow`.
+Os itens T007–T047 foram concluídos localmente e os gates T049, T050, T052 e
+T054 foram executados. O ticket `PEE-105` continua em `Em andamento`; o
+resultado e os bloqueios foram registrados no comentário Jira `12111`.
+
+### Correções orientadas por QA
+
+- O SOUL agora conduz o ICP somente depois de serviço confirmado e intenção
+  explícita, pergunta apenas campos faltantes, oferece no máximo uma segunda
+  oportunidade, registra `NÃO INFORMADO` apenas nos campos ainda faltantes e
+  avança automaticamente para os termos.
+- `PRONOUN_PREFERENCE` e `OCCUPATION` preservam o texto explícito; somente
+  `FIRST_TIME_HIRING` normaliza para `SIM`, `NÃO` ou `NÃO INFORMADO`.
+- A substituição de fatos cria o novo fato antes da supersessão e grava o ID
+  real em `supersededBy`; o teste de regressão confirma que a leitura corrente
+  retorna apenas a versão nova.
+- A busca de arquitetura não encontrou `ICPCheckpointState` ou
+  `attemptsByField`; `prepare_terms` permanece sem hard gate de ICP e o desvio
+  observacional `ICP_SKIPPED_BEFORE_TERMS` não altera o resultado comercial.
+
+### Evidências locais pós-correção
+
+- JUnit focado da classe alterada: **20 testes, 0 falhas**.
+- Suíte determinística integrada de catálogo, fatos, ferramentas, handoff,
+  reconciliação, orquestração, controllers e boundaries Mongo: **BUILD
+  SUCCESSFUL**; QA independente confirmou 59 testes focados verdes em seu
+  recorte.
+- Testes direcionados de sessões Hermes, retomada e worker POC: **BUILD
+  SUCCESSFUL**.
+- Plugin Urbana: **8/8** testes Python.
+- POC React: **19 arquivos / 80 testes**, typecheck, build e lint verdes; a
+  lista Playwright contém **9 testes em 4 arquivos**.
+- Compose local: `docker compose ... config --quiet` passou com variáveis de
+  homologação fictícias; `git diff --check` passou.
+
+### Aceite ainda pendente
+
+O resultado do checkpoint QA anterior foi `implemented_unverified`, não
+`verified` para o produto. O estado operacional foi atualizado na seção abaixo
+após a disponibilização do Docker:
+
+- o binário Chromium do Playwright não está disponível, portanto os cenários
+  live e os cinco roteiros manuais ainda não foram executados;
+- a suíte backend completa e o gate JaCoCo de 60% continuam sem evidência
+  final neste ambiente;
+- ainda não há PR para `hml`; esse passo depende do aceite local de Emanuel.
+
+## Estado operacional após o smoke local — 2026-08-26
+
+O daemon Docker foi disponibilizado no ambiente local e o stack foi reconstruído
+com o fonte atual:
+
+- `docker compose --env-file .env.poc -f infra/local-poc/docker-compose.poc.yml up -d --build`
+  concluiu o build do backend dentro da imagem com JDK 21/Gradle; a imagem
+  recebeu os labels `revision=workspace-source` e
+  `build=containerized-gradle-jdk21`.
+- MongoDB, Urbana Connect, Hermes e `poc-chat` ficaram saudáveis; os endpoints
+  locais de readiness/health responderam `READY`, `ok` e Hermes `0.20.0`.
+- `verify-tool-surface.sh`, `smoke-contract.sh` e os testes do plugin passaram;
+  o `smoke-isolation.sh` foi corrigido para refletir o desenho efetivo de
+  `hermes-profile-init` + volume nomeado, e passou com
+  `filesystem_isolation=ok`, `profile_config_staging=read-only` e
+  `network_isolation=ok`.
+
+### Smoke conversacional observado
+
+Em uma conversa limpa via ingresso sintético, usando apenas o `.env.poc` local:
+
+1. A abertura passou a ser curta, identificando a Urba, citando os quatro
+   serviços e perguntando qual opção/necessidade o cliente queria resolver.
+2. Após `Decor Pintura` + intenção explícita de contratação, a Urba perguntou
+   os três campos do perfil antes dos termos.
+3. Uma única resposta com os três dados persistiu `Emanuel`, `SIM` e
+   `Desenvolvedor`; a conversa avançou para `TERMS=PRESENTED` sem repetir o
+   perfil.
+4. Após `Aceito os termos`, avançou para pagamento; após `PIX`, marcou o
+   pagamento como preparado e manteve a confirmação dependente da arquiteta.
+5. Nenhuma mensagem do smoke expôs erro técnico, identificador interno ou
+   falha do sistema ao cliente.
+
+A primeira execução após a subida foi feita com uma chave sintética curta e
+falhou antes do despacho por validação do próprio Hermes. Isso foi corrigido
+usando as credenciais já presentes no `.env.poc`, sem alteração de código ou
+exposição de segredo.
+
+### Limitações que continuam abertas
+
+- A abertura curta foi verificada após uma correção final no `SOUL.md`, mas os
+  cinco roteiros manuais completos, incluindo recusa, segunda ausência,
+  captura incidental, handoff e retomada, ainda não foram executados e
+  registrados como transcripts em `quickstart.md`.
+- A suíte backend completa executou 387 testes e terminou com 12 falhas no
+  `ConversationFlowServiceIntegrationTest` legado (arquivos sem diff desta
+  feature); o relatório JaCoCo gerado ficou em 18,49%, abaixo do mínimo de
+  60%. Os testes focados da feature continuam verdes.
+- O Playwright live não foi executado porque o binário Chromium não está
+  disponível neste ambiente; a validação realizada foi por API/Compose.
+- Não há PR para `hml`, promoção ou deploy nesta etapa.

--- a/specs/008-complete-urba-service-flow/checklists/requirements.md
+++ b/specs/008-complete-urba-service-flow/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Atendimento comercial completo e seguro da Urba
+
+- **Purpose**: Validate specification completeness and quality before proceeding to planning
+- **Created**: 2026-08-17
+- **Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation iteration 1: all checklist items passed.
+- The GO on this draft also approves the seven explicit decisions in section
+  1.5, notably that optional ICP facts do not block the commercial flow.
+- Operational choices for valid resources and local human controls are planning
+  concerns and do not change the observable contract.

--- a/specs/008-complete-urba-service-flow/checklists/requirements.md
+++ b/specs/008-complete-urba-service-flow/checklists/requirements.md
@@ -1,7 +1,7 @@
 # Specification Quality Checklist: Atendimento comercial completo e seguro da Urba
 
 - **Purpose**: Validate specification completeness and quality before proceeding to planning
-- **Created**: 2026-08-17
+- **Created**: 2026-08-26
 - **Feature**: [spec.md](../spec.md)
 
 ## Content Quality
@@ -28,11 +28,32 @@
 - [x] User scenarios cover primary flows
 - [x] Feature meets measurable outcomes defined in Success Criteria
 - [x] No implementation details leak into specification
+- [x] Spec, plan, data model, contracts, quickstart e tasks usam o mesmo
+  contrato de checkpoint ICP
+- [x] O plano cobre captura incidental, reutilização global, handoff/retomada e
+  observabilidade sem conteúdo bruto
+- [x] O controle de pergunta, segunda oportunidade, pausa e retomada do ICP fica
+  no SOUL/thread; nenhum artefato exige máquina de estado autoritativa no backend
+- [x] Existe tarefa explícita para escrever os cenários ICP/termos em
+  `quality-chat.spec.ts` antes da correção comportamental correspondente
+- [x] O evento `ICP_SKIPPED_BEFORE_TERMS` possui teste de idempotência, payload
+  sem valores e resultado comercial inalterado
+- [x] SC-011 diferencia fluxo conversacional normal da injeção controlada de
+  SC-014
+- [x] Baseline local, Jira, branch `feature/*`, QA independente e PR para `hml`
+  possuem gates explícitos antes da execução/promoção
 
 ## Notes
 
-- Validation iteration 1: all checklist items passed.
-- The GO on this draft also approves the seven explicit decisions in section
-  1.5, notably that optional ICP facts do not block the commercial flow.
-- Operational choices for valid resources and local human controls are planning
-  concerns and do not change the observable contract.
+- Validation iteration 3: checklist reavaliado após a correção de prontidão
+  técnica; todos os itens permanecem atendidos.
+- O contrato distingue checkpoint conversacional de hard gate: o ICP é coletado
+  antes dos termos pelo SOUL, mas sua ausência não gera rejeição de backend.
+- O plano registra as decisões técnicas sobre contexto integral, fatos
+  versionados, observabilidade sem conteúdo bruto e E2E semântico.
+- O baseline preexistente é tratado como não verificado; nenhuma tarefa é
+  concluída pela mera presença de código e o Gate 0 precede novos escritores.
+- `ICPCheckpointState` e contadores autoritativos foram removidos do desenho; o
+  evento contém apenas correlação e campos ausentes.
+- Recursos locais e controles humanos continuam sendo fixtures de validação,
+  sem valor comercial.

--- a/specs/008-complete-urba-service-flow/contracts/reception-domain-tools.md
+++ b/specs/008-complete-urba-service-flow/contracts/reception-domain-tools.md
@@ -1,0 +1,150 @@
+# Contratos externos: Reception, Hermes e POC local
+
+## 1. Ferramentas de domínio
+
+O plugin Hermes continua usando somente as seis ferramentas allowlisted. O
+backend deve responder JSON estável, sempre como objeto.
+
+### Sucesso
+
+```json
+{
+  "ok": true,
+  "result": {
+    "serviceType": "DECOR_PINTURA",
+    "name": "Decor Pintura",
+    "price": "250.00",
+    "areaRule": "UNLIMITED_BY_CATALOG",
+    "scope": "...",
+    "deliverables": ["MANUAL_PDF", "VIRTUAL_TOUR", "THREE_OPTIONS", "TWO_ADJUSTMENT_ROUNDS"],
+    "process": ["BRIEFING", "MEASUREMENTS_MEDIA", "ONLINE_MEETING", "PRODUCTION", "EMAIL_DELIVERY"],
+    "support": "..."
+  }
+}
+```
+
+### Rejeição de negócio
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "TERMS_NOT_ACCEPTED",
+    "nextAction": "ASK_FOR_CLEAR_ACCEPTANCE",
+    "missingFields": [],
+    "customerMessage": "Antes do pagamento, preciso do seu aceite claro dos termos."
+  }
+}
+```
+
+O plugin pode transportar o envelope, mas não pode concatenar exceções,
+status HTTP, nomes de classes, URLs internas ou mensagens de stack trace. Se a
+resposta não for segura, retorna uma rejeição genérica para o Hermes e registra
+correlação somente no backend.
+
+## 1.1 Enriquecimento de lead e observabilidade
+
+O checkpoint conversacional de ICP é orientado pelo SOUL e não é um pré-
+requisito de rejeição para `prepare_terms`. Os três campos são:
+
+```json
+{
+  "leadEnrichment": {
+    "PRONOUN_PREFERENCE": {"status": "ANSWERED", "value": "..."},
+    "FIRST_TIME_HIRING": {"status": "ANSWERED", "value": "SIM"},
+    "OCCUPATION": {"status": "NOT_INFORMED"}
+  }
+}
+```
+
+O valor textual só aparece no perfil/contexto autorizado e na mensagem do
+cliente que o originou. Logs e métricas usam somente campo, status, origem,
+conversa/turno e momento. Uma declaração explícita posterior substitui o valor
+atual silenciosamente; o histórico permanece interno.
+
+Quando termos forem preparados com algum campo ausente, o backend registra o
+evento interno `ICP_SKIPPED_BEFORE_TERMS`. Esse evento não deve ser enviado ao
+cliente, ao transcript visível, ao payload da ferramenta ou como erro para o
+Hermes. A preparação dos termos mantém o mesmo resultado que teria sem o evento.
+
+Correlação mínima interna:
+
+```json
+{
+  "event": "ICP_SKIPPED_BEFORE_TERMS",
+  "conversationId": "opaque-id",
+  "turnId": "opaque-id",
+  "serviceType": "DECOR_PINTURA",
+  "missingFields": ["OCCUPATION"],
+  "detectionPoint": "PREPARE_TERMS",
+  "idempotencyKey": "opaque-id",
+  "occurredAt": "2026-08-26T12:00:00Z"
+}
+```
+
+Os identificadores são internos e os campos não carregam seus valores brutos.
+Replay da mesma preparação produz no máximo um evento lógico. Não existe
+`checkpointStatus`, `attemptsByField` ou máquina de estado de diálogo no
+contrato do backend; pergunta e segunda oportunidade são interpretadas pelo
+SOUL sobre a thread atual.
+
+O teste de observabilidade usa injeção controlada diretamente nesse boundary.
+Ele não compõe o fluxo conversacional normal, não instrui o cliente a burlar o
+checkpoint e não reduz a exigência de que o E2E normal colete os campos antes
+dos termos.
+
+## 1.2 Contexto Hermes
+
+Na thread atual, o Hermes recebe as mensagens canônicas integrais do cliente,
+da Urba e da arquiteta, além do contexto associado ao cliente. O adaptador não
+deve montar uma projeção que suprima mensagens por causa do ICP. Threads antigas
+inteiras não são anexadas; o perfil corrente e o contexto pertinente são
+reutilizados. A combinação entre thread, fatos correntes e SOUL é a única fonte
+para decidir pergunta inicial, segunda oportunidade, pausa e retomada do ICP.
+
+## 2. Handoff
+
+`request_human_handoff` deve produzir um resultado determinístico de transição:
+
+```json
+{
+  "ok": true,
+  "result": {
+    "status": "TRANSFERRED",
+    "ownership": "HUMAN",
+    "ackMessage": "Vou encaminhar sua conversa para a arquiteta, que continuará com você por aqui.",
+    "handoffId": "opaque-id"
+  }
+}
+```
+
+O backend grava `ackMessage` no transcript exatamente uma vez. O orquestrador
+publica o ack antes de bloquear a saída do turno. A notificação da arquiteta
+contém resumo interno, nunca aparece no transcript visível do cliente.
+
+Repetição idempotente devolve o mesmo `handoffId` sem duplicar ack.
+
+## 3. Retomada HUMANO → URBA
+
+O comando interno deve usar uma chave idempotente e uma versão esperada da
+conversa. O processamento deve:
+
+1. registrar a transição real e o limite do transcript;
+2. sincronizar mensagens `CONTACT`, `URBA`, `HUMAN` e `SYSTEM` até o limite;
+3. aplicar decisões humanas como contexto de autoridade;
+4. decidir entre uma mensagem proativa, espera ou retorno ao humano;
+5. persistir o resultado antes de liberar novo turno Hermes.
+
+Não é permitido simular a retomada como nova mensagem do cliente.
+
+## 4. Projeção da POC
+
+A projeção deve distinguir:
+
+- mensagens canônicas, incluindo o ack de handoff;
+- ownership humano/Urba;
+- processamento pendente, reconciliação e falha segura;
+- controles locais de arquiteta apenas no ambiente de teste.
+
+Os controles de teste não devem ser exibidos como se fossem ações disponíveis
+ao cliente final nem enviar WhatsApp, e-mail, cobrança ou recursos produtivos.

--- a/specs/008-complete-urba-service-flow/data-model.md
+++ b/specs/008-complete-urba-service-flow/data-model.md
@@ -1,0 +1,161 @@
+# Data Model: Atendimento comercial completo e seguro da Urba
+
+Este documento descreve o contrato lógico que a implementação deve preservar;
+os nomes concretos podem seguir os agregados já existentes em `reception`.
+
+## ServiceCatalogItem / ServiceFixture
+
+Fonte canônica dos fatos consumidos pelo atendimento.
+
+| Campo | Regra |
+|---|---|
+| `serviceType` | `DECOR_INTERIORES`, `DECOR_PINTURA`, `DECOR_FACHADA` ou `DECOR_REFORMA`; nenhum alias legado `DECOR` deve ser apresentado como quinto serviço |
+| `name`, `emoji` | apresentação curta |
+| `price` | R$ 400, R$ 250, R$ 350 e R$ 450 respectivamente |
+| `areaRule` | `UP_TO_20_SQM_PER_ENVIRONMENT` para Interiores/Reforma; `UNLIMITED_BY_CATALOG` para Pintura/Fachada |
+| `scope` | escopo afirmativo e diferença com os demais serviços |
+| `deliverables` | Manual PDF, Tour Virtual, três opções e duas rodadas |
+| `process` | briefing, medidas/mídia, reunião, produção, 7 dias úteis e entrega |
+| `responsibilities` | Urba, arquiteta e cliente |
+| `exclusions` | execução, compra/contratação, visita/gestão e promessas não autorizadas |
+| `support` | três meses para dúvidas sobre Manual e cores, sem visita/gestão |
+| `termsResource`, `paymentResource`, `briefingResource` | recurso vigente por ambiente; fixture local não comercial ou recurso aprovado |
+| `available` | apenas itens disponíveis podem ser apresentados/contratados |
+
+## ReceptionConversation / contratação
+
+O agregado de conversa continua controlando `mode`, `version`, serviço
+selecionado, ambiente, `termsStatus`, `paymentStatus`, estágio comercial e
+estado operacional. Regras novas:
+
+- `PRONOUN_PREFERENCE`, `FIRST_TIME_HIRING` e `OCCUPATION` compõem um checkpoint
+  conversacional de enriquecimento de lead antes dos termos, sem hard gate de
+  backend;
+- serviço, ambiente e área aplicável continuam sendo os pré-requisitos de
+  estado comercial para termos;
+- a thread atual e os fatos correntes fornecem ao SOUL o contexto para oferecer
+  no máximo uma segunda oportunidade por campo; o agregado não persiste um
+  contador autoritativo de tentativas nem bloqueia termos por ICP;
+- declarações explícitas podem ser capturadas incidentalmente em qualquer etapa;
+- perfil conhecido é reutilizado entre serviços; o valor explícito mais recente
+  substitui silenciosamente o atual, inclusive por `NÃO INFORMADO`;
+- mudar serviço antes do pagamento invalida o aceite da contratação anterior;
+- dois ambientes/serviços possuem aceites e pagamentos independentes;
+- `HUMAN` bloqueia ferramentas e respostas automáticas, mas não impede a
+  confirmação canônica do handoff;
+- uma retomada precisa de estado separado ou equivalente a
+  `PENDING/SYNCHRONIZING/DECIDING/COMPLETED/RETURNED_TO_HUMAN`.
+
+## LeadEnrichment / CustomerFact
+
+O ICP é um perfil global do cliente, independente do serviço contratado. O
+modelo deve preservar o valor corrente e o histórico interno sem criar um
+snapshot separado de primeira interação.
+
+| Campo | Regra |
+|---|---|
+| `PRONOUN_PREFERENCE` | texto explícito informado pelo cliente; não categorizar nem inferir |
+| `FIRST_TIME_HIRING` | `SIM`, `NÃO` ou `NÃO INFORMADO` |
+| `OCCUPATION` | texto explícito informado pelo cliente; não categorizar nem inferir |
+| `status` | estado interno `ANSWERED` ou `NOT_INFORMED`; a comunicação usa `NÃO INFORMADO`; estado concluído não volta a ser perguntado automaticamente |
+| `source` | mensagem explícita do cliente; fala ou interpretação da arquiteta não é evidência suficiente |
+| `capturedAt` | momento da captura da declaração ou conclusão do campo |
+| `sourceMessageId` | referência à mensagem que contém a declaração, quando existir |
+| `version` / `supersededBy` | histórico de alterações para auditoria; somente o estado atual orienta a próxima pergunta |
+
+Regras de atualização:
+
+- uma declaração explícita posterior substitui o valor corrente sem mensagem
+  adicional ao cliente;
+- uma recusa posterior pode substituir o valor corrente por `NÃO INFORMADO`;
+- o Hermes recebe o histórico integral da thread atual e o contexto associado,
+  portanto o prompt deve instruir a considerar a declaração explícita mais
+  recente, sem podar mensagens anteriores da mesma thread; threads anteriores
+  inteiras não fazem parte desse contexto;
+- logs de observabilidade carregam somente campo, status, origem e momento,
+  nunca o texto bruto do valor.
+
+## Contexto conversacional do checkpoint (não persistido como autoridade)
+
+O checkpoint ocorre depois da confirmação do serviço e da intenção explícita de
+contratar, mas não cria uma entidade `ICPCheckpointState` no backend. O SOUL
+conduz a conversa usando:
+
+- a thread atual integral para reconhecer pergunta inicial, resposta parcial,
+  segunda oportunidade, assunto paralelo e handoff;
+- os fatos correntes para calcular quais dos três campos permanecem ausentes;
+- o serviço/estágio comercial já existente para saber quando iniciar ou retomar;
+- as mensagens humanas sincronizadas para continuar sem pedir repetição.
+
+Ao voltar de um handoff, o Hermes relê a thread e os fatos atuais e pergunta
+somente os campos ainda ausentes. O backend não persiste `status`,
+`attemptsByField`, `lastAction` ou outro estado que passe a comandar a redação,
+a insistência ou o avanço do diálogo.
+
+## ICPObservationEvent
+
+Registro interno produzido quando a preparação de termos encontra um ou mais
+campos do ICP ausentes. É observabilidade somente: não rejeita, não altera o
+resultado comercial e não entra no transcript nem no retorno da ferramenta ao
+Hermes.
+
+| Campo | Regra |
+|---|---|
+| `eventType` | valor fixo `ICP_SKIPPED_BEFORE_TERMS` |
+| `conversationId` / `turnId` | identificadores opacos para correlação interna |
+| `serviceType` | serviço confirmado no momento da detecção |
+| `missingFields` | nomes dos campos ausentes, nunca seus valores |
+| `detectionPoint` | operação interna em que o desvio foi observado |
+| `idempotencyKey` | mesma preparação/replay produz no máximo um evento lógico |
+| `occurredAt` | momento da primeira detecção |
+
+O evento não contém valor do perfil, conteúdo de mensagem, transcript, prompt,
+URL, recurso comercial, exceção, stack trace ou contador de tentativas.
+
+## CommercialDecision / SafeDomainResult
+
+Resultado interno de uma ferramenta comercial:
+
+```json
+{
+  "ok": false,
+  "code": "MISSING_REQUIRED_CONTEXT",
+  "missingFields": ["environment"],
+  "nextAction": "ASK_CUSTOMER",
+  "customerMessage": "Para seguir, preciso saber qual ambiente você quer transformar."
+}
+```
+
+`customerMessage` deve ser curto, natural e livre de detalhes técnicos. O
+resultado de sucesso pode carregar os dados necessários ao próximo passo, mas
+não pode liberar uma etapa que o agregado não confirmou. `MISSING_REQUIRED_CONTEXT`
+é reservado a serviço, ambiente, área e proteções comerciais; ICP incompleto
+nunca deve gerar esse envelope.
+
+## HandoffRecord
+
+Registro idempotente por conversa/turno:
+
+- motivo e etapa comercial conhecida;
+- serviço/ambiente e resumo mínimo para a arquiteta;
+- `fromMode`, `toMode`, versão/epoch e ator quando disponível;
+- chave de idempotência;
+- identificador da confirmação canônica externa e da notificação interna.
+
+Uma repetição deve devolver o registro existente sem nova mensagem ou
+notificação.
+
+## ResumeRecord
+
+Registro da transição HUMANO → URBA:
+
+- `resumeId`, `conversationId`, `ownershipEpoch` e `resumeBoundarySequence`;
+- checksum/cursor do transcript sincronizado;
+- estado e tentativas;
+- decisão `PROACTIVE_MESSAGE`, `WAIT_FOR_CUSTOMER` ou
+  `RETURN_TO_HUMAN`;
+- idempotency key da ação proativa, quando houver;
+- classificação interna da falha, sem reproduzi-la ao cliente.
+
+O transcript Mongo é a fonte de verdade. A sessão Hermes é uma projeção
+reconstruível e nunca é autoridade para preço, termos ou ownership.

--- a/specs/008-complete-urba-service-flow/plan.md
+++ b/specs/008-complete-urba-service-flow/plan.md
@@ -1,0 +1,344 @@
+# Implementation Plan: Atendimento comercial completo e seguro da Urba
+
+**Branch**: `feature/008-complete-urba-service-flow` | **Date**: 2026-08-26 | **Spec**: [spec.md](./spec.md)
+
+**Status**: implementação local delegada concluída e QA focado independente
+aprovado; aceite live, PR para `hml` e promoção continuam pendentes por
+bloqueio ambiental/aceite manual.
+
+## Summary
+
+Materializar o catálogo operacional da Urba e o fluxo comercial refinado no
+runtime Hermes/Reception, incluindo o checkpoint conversacional de
+enriquecimento de lead antes dos termos. O Hermes continuará responsável pela
+interpretação e redação; o backend continuará autoridade para catálogo, estados,
+aceite, pagamento, briefing, ownership e transcript. O ICP será guiado pelo
+SOUL, persistido como fato explícito e observado quando for ignorado, sem um
+hard gate de backend que possa travar a conversa.
+
+O gate de reconciliação descrito em `baseline.md` foi concluído e o delta foi
+dividido em três frentes com escrita separada: (A) fatos/persistência e
+catálogo comercial; (B) SOUL, contexto integral, observabilidade e integração
+de turnos; (C) POC/E2E e evidências. Os escritores pararam e o QA independente
+confirmou os contratos locais; permanecem os gates de runtime live e aceite
+manual antes do PR para `hml`.
+
+## Technical Context
+
+**Language/Version**: Java 21 LTS; Python do plugin Hermes; TypeScript 5.x
+
+**Primary Dependencies**: Spring Boot 3.4.13, Gradle 8.x, MongoDB, Hermes Agent Sessions API, OpenRouter, React 19.2, Vite 8, Playwright
+
+**Storage**: MongoDB para transcript, fatos/versionamento, contratação,
+catálogo, ledger e projeções; SQLite interno do Hermes somente para a sessão
+conversacional.
+
+**Testing**: JUnit 5, Spring Boot Test, Testcontainers MongoDB, unittest do
+plugin, Vitest/React Testing Library e Playwright.
+
+**Target Platform**: backend containerizado e POC local; promoção posterior por
+`feature/* -> hml -> main`.
+
+**Project Type**: monorepo com backend web-service, adaptador/plugin Hermes e
+frontend POC para teste manual.
+
+**Performance Goals**:
+
+- o primeiro turno elegível deve iniciar o checkpoint de ICP antes de preparar
+  termos quando houver campos ausentes;
+- um checkpoint concluído deve permitir avanço automático sem turno de
+  confirmação redundante;
+- handoff e retomada devem ser idempotentes e não duplicar mensagens;
+- nenhum turno de retomada pode publicar resposta antes de sincronizar o
+  transcript completo da thread atual.
+
+**Constraints**:
+
+- respeitar Clean Architecture e manter decisões de negócio no domínio/
+  aplicação;
+- manter JaCoCo mínimo de 60% e testes relevantes executados antes da aceitação;
+- não criar hard gate backend específico para ICP;
+- não criar `ICPCheckpointState`, contador de tentativas ou máquina de estado de
+  diálogo no backend para comandar a coleta;
+- não duplicar o catálogo no SOUL, plugin ou frontend;
+- não filtrar do Hermes a thread atual por causa do ICP;
+- não registrar valores brutos do ICP em logs técnicos;
+- não incluir segredo, link comercial real ou ação produtiva em fixture local;
+- nenhuma mensagem visível pode revelar detalhes técnicos;
+- preservar todas as alterações preexistentes fora do escopo.
+
+**Scale/Scope**: quatro serviços, perfil de ICP global por cliente, uma
+contratação independente por ambiente/serviço, uma thread atual por sessão
+Hermes e testes de duplicidade/reconciliação no bounded context `reception`.
+
+## Constitution Check
+
+*GATE: Must pass before implementation planning is accepted. Re-check after
+design and before implementation.*
+
+- **I — Stack oficial:** PASS. O plano usa Java 21, Spring Boot, Gradle e
+  MongoDB já adotados; não cria mudança de stack.
+- **II — Clean Architecture:** PASS. Catálogo, fatos, estados e regras ficam no
+  domínio/aplicação; controllers, plugin e React apenas adaptam contratos.
+- **III — Specification/Test First:** PASS WITH REMEDIATION. Existe código local
+  preexistente e não verificado; ele será tratado como baseline e não como
+  tarefa concluída. Antes de qualquer novo código, o gate reconcilia o diff com
+  a spec e exige teste falhando primeiro para todo comportamento ainda ausente.
+- **IV — Quality gate:** PASS WITH GATE. O aceite exige testes focalizados,
+  regressão backend, testes do plugin/POC e JaCoCo mínimo de 60%; falhas de
+  ambiente serão separadas de falhas de produto.
+- **V — Homolog first:** PASS. Este ciclo produz documentação e depois validação
+  local; não faz deploy nem promoção para `main`.
+- **Delivery Workflow:** PASS WITH GATE. A subtarefa Jira e a branch
+  `feature/008-complete-urba-service-flow` devem existir antes do primeiro
+  escritor; o PR será aberto para `hml` e moverá a issue para
+  `Awaiting approval`. Nenhuma dessas ações externas ocorre nesta revisão.
+
+## Project Structure
+
+```text
+specs/008-complete-urba-service-flow/
+├── spec.md
+├── plan.md
+├── baseline.md
+├── research.md
+├── data-model.md
+├── contracts/
+├── quickstart.md
+└── tasks.md
+
+apps/urbana-connect-api/
+├── src/main/java/br/com/urbana/connect/
+│   ├── domain/
+│   ├── application/
+│   ├── infrastructure/
+│   └── interfaces/
+└── src/test/java/br/com/urbana/connect/
+
+integrations/hermes-agent/
+├── profile/SOUL.md
+└── plugins/urbana-domain/
+
+apps/poc-chat/
+infra/local-poc/
+```
+
+**Structure Decision**: manter o catálogo e os estados nas camadas existentes
+de `apps/urbana-connect-api/`; manter orientação conversacional e transporte no
+adaptador Hermes; manter apenas controles e fixtures não comerciais em
+`apps/poc-chat/` e `infra/local-poc/`. Nenhum catálogo paralelo será criado.
+
+## Design Decisions
+
+### 1. ICP conversacional sem hard gate
+
+O SOUL deve orientar o Hermes a iniciar o checkpoint após serviço confirmado e
+intenção explícita, perguntar somente campos ausentes, repetir uma vez e marcar
+`NÃO INFORMADO` quando necessário. O backend não rejeita `prepare_terms` por
+ICP incompleto. Um evento `ICP_SKIPPED_BEFORE_TERMS` torna o desvio observável e
+o E2E deve falhar semanticamente, sem transformar a ocorrência em erro visível.
+
+### 2. Fatos globais e atualização silenciosa
+
+Os três campos usam o modelo de fatos/versionamento existente. O perfil é
+reutilizado entre os quatro serviços. Apenas declarações explícitas do cliente
+podem criar/alterar fatos; o valor mais recente substitui o atual, inclusive
+`NÃO INFORMADO`, sem nova mensagem para o cliente. O histórico permanece para
+auditoria, mas o comportamento deve seguir a declaração mais recente.
+
+### 3. Contexto integral da thread atual
+
+Na retomada ou em qualquer turno que reidrate a conversa, o Hermes recebe a
+thread atual completa — cliente, Urba, arquiteta e mensagens de sistema
+necessárias — além do contexto associado do cliente. Threads anteriores inteiras
+não são anexadas. Nenhuma projeção específica do ICP deve podar o transcript.
+
+### 4. Proteção de dados em observabilidade
+
+O fato persistido pode conter o texto necessário para a conversa e seu
+versionamento. Eventos, logs e métricas carregam somente campo, status, origem,
+conversa/turno e momento; nunca repetem o valor bruto do ICP.
+
+### 5. Controle conversacional no SOUL, sem máquina de estado no backend
+
+O SOUL interpreta a thread atual, os fatos correntes e o estágio comercial para
+decidir pergunta inicial, segunda oportunidade, pausa por assunto paralelo ou
+handoff e retomada dos campos ausentes. O backend não introduz
+`ICPCheckpointState`, `attemptsByField` nem qualquer estado autoritativo que
+comande o diálogo. Ele persiste somente os fatos explícitos e produz o evento
+idempotente de desvio com conversa/turno/serviço, campos ausentes, ponto de
+detecção e momento, sem valor bruto ou conteúdo da conversa.
+
+### 6. Baseline local antes do delta
+
+O código já modificado é insumo da execução, não evidência de conclusão. O gate
+inicial inventaria e testa cada slice, preserva alterações de terceiros, resolve
+entradas suspeitas sem exclusão automática e só então classifica as tarefas como
+aproveitadas, incompletas, conflitantes ou fora de escopo. Novos escritores
+recebem apenas o delta ainda necessário e um conjunto de arquivos exclusivo.
+
+## Workstreams and Ownership
+
+### Gate 0 — reconciliação e governança
+
+**Owner**: Tech Lead Orchestrator, sem delegação de ambiguidade e sem escrita de
+código de produto.
+
+Responsabilidades:
+
+- vincular/criar a subtarefa Jira sob PEE-23 somente após o GO de execução;
+- preservar o snapshot e migrar/renomear a branch para
+  `feature/008-complete-urba-service-flow`, mantendo `hml` como ancestral;
+- mapear o diff existente aos requisitos e executar os testes focados;
+- classificar cada slice e resolver o seeder suspeito de forma não destrutiva;
+- atualizar `baseline.md` e os checkboxes somente com evidência.
+
+### Workstream A — fatos, catálogo e contratos de domínio
+
+**Owner**: Developer, com escrita exclusiva nos modelos/políticas de
+`apps/urbana-connect-api/` e testes de domínio correspondentes.
+
+Responsabilidades:
+
+- consolidar o catálogo dos quatro serviços como fonte única;
+- manter `PRONOUN_PREFERENCE`, `FIRST_TIME_HIRING` e `OCCUPATION` como fatos
+  explícitos, globais e versionados;
+- representar `NÃO INFORMADO` como estado concluído;
+- garantir atualização silenciosa pelo valor explícito mais recente;
+- manter as proteções reais de termos, aceite, pagamento e briefing;
+- expor ao contexto autorizado quais campos estão presentes/ausentes, sem
+  transportar controle de tentativa para o backend.
+
+Arquivos prováveis:
+
+- `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/CommercialPolicyService.java`
+- `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/`
+- `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/servicecatalog/`
+- `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/`
+- testes Java correspondentes.
+
+### Workstream B — SOUL, contexto, handoff e observabilidade
+
+**Owner**: Staff Engineer ou Developer sênior, com escrita exclusiva no
+orquestrador/reconciliação, adaptador Hermes, plugin e perfil SOUL.
+
+Responsabilidades:
+
+- inserir no SOUL o fluxo de identificação, coleta dinâmica e avanço do ICP;
+- fazer o SOUL reconhecer pela thread a pergunta inicial e a única segunda
+  oportunidade, inclusive após assunto paralelo ou retorno humano;
+- garantir captura incidental explícita sem inferência ou confirmação técnica ao
+  cliente;
+- manter a íntegra da thread atual no contexto enviado ao Hermes;
+- orientar precedência pela declaração explícita mais recente do cliente;
+- adicionar `ICP_SKIPPED_BEFORE_TERMS` idempotente, testar payload sem valores e
+  manter o resultado de termos inalterado;
+- preservar handoff visível, silêncio humano, retomada proativa e sanitização de
+  falhas já definidos pela feature;
+- incluir estado atual/pendente do ICP no resumo interno de handoff, sem expor
+  resumo ao cliente.
+
+Arquivos prováveis:
+
+- `integrations/hermes-agent/profile/SOUL.md`
+- `integrations/hermes-agent/plugins/urbana-domain/tools.py`
+- `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionOrchestrator.java`
+- `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationService.java`
+- `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/`
+- testes de boundary, plugin e reconciliação.
+
+### Workstream C — POC e E2E de qualidade conversacional
+
+**Owner**: Developer, com escrita exclusiva em `apps/poc-chat/`, fixtures e
+documentação operacional local.
+
+Responsabilidades:
+
+- ampliar o E2E semântico para verificar o checkpoint ICP antes dos termos;
+- cobrir prompt dinâmico, parcial, recusa, segunda ausência, captura incidental,
+  atualização silenciosa e handoff/retomada;
+- preservar transcript integral, ownership, ack e controles da arquiteta;
+- manter links e ações de teste inequivocamente não comerciais;
+- registrar score, violações, transcript e referência à evidência separada do
+  evento de ICP ignorado para revisão.
+- manter em `quality-chat.spec.ts` somente caminhos conversacionais normais de
+  SC-011; a injeção controlada de SC-014 permanece em teste backend separado e
+  entra no pacote de evidência sem simular uma conversa de cliente.
+
+### QA independente
+
+Depois de A/B/C pararem de escrever, QA executará testes focalizados, regressão,
+matriz de edge cases e os roteiros manuais. QA não aceitará a própria alteração.
+Correções retornam ao escritor do arquivo, no máximo por duas iterações para a
+mesma causa.
+
+## Dependency Order
+
+```text
+Gate 0 — Jira/branch/baseline
+              └── contratos/testes first
+                   ├── A — fatos e catálogo ──────┐
+                   ├── B — SOUL/contexto/boundary ├── C — estabilizar POC/E2E ── QA ── aceite local
+                   └── C — E2E normal falhando ───┘
+```
+
+1. Com GO explícito, vincular Jira, preparar a branch `feature/*` e reconciliar
+   o baseline sem reverter alterações preexistentes.
+2. Congelar o mapa do delta e escrever/ajustar primeiro os testes de A/B que
+   demonstrem comportamento ainda ausente.
+3. Completar fatos/catalogo e, em escopo de escrita disjunto, SOUL,
+   observabilidade e integração de contexto/handoff.
+4. Escrever e estabilizar os cenários de `quality-chat.spec.ts` depois que os
+   contratos de A/B estiverem estáveis; o cenário deve falhar antes da correção
+   comportamental correspondente sempre que tecnicamente aplicável.
+5. Parar todos os escritores e executar QA independente, suíte, quality gate e
+   os cinco roteiros manuais.
+6. Somente após aceite local abrir PR para `hml`, registrar evidências e mover o
+   Jira para `Awaiting approval`; este plano não autoriza deploy nem promoção.
+
+## Validation Matrix
+
+| Área | Evidência mínima |
+|---|---|
+| Catálogo | quatro serviços, preços, limites, escopo, entregas e processo coerentes |
+| ICP feliz | serviço/intenção → campos faltantes → respostas → termos |
+| ICP parcial | segunda mensagem somente com campos faltantes |
+| Recusa/ausência | `NÃO INFORMADO`, avanço e nenhuma insistência |
+| Captura incidental | fato explícito reutilizado sem nova pergunta |
+| Atualização | valor mais recente substitui silenciosamente |
+| Handoff | ack visível, resumo interno com ICP, silêncio automático |
+| Retomada | thread atual integral, decisão humana respeitada, avanço proativo único |
+| Segurança | zero frases internas visíveis; logs sem valor bruto |
+| E2E normal | ICP antes dos termos, critérios semânticos, transcript integral e diagnóstico reproduzível |
+| Injeção controlada | termos permanecem funcionais, um evento por chave, payload sem valor bruto e nenhuma exposição ao Hermes/cliente |
+| Regressão | testes focados, suíte backend, plugin, frontend e JaCoCo ≥ 60% |
+
+## Risks and Mitigations
+
+- **Hermes ignora o checkpoint**: SOUL mais E2E semântico e evento
+  `ICP_SKIPPED_BEFORE_TERMS`; não criar bloqueio que altere a conversa em
+  produção.
+- **Backend volta a comandar a conversa**: proibir estado/contador autoritativo
+  de ICP; revisão arquitetural e testes devem falhar se ausência do perfil
+  bloquear termos ou se a retomada depender desse estado.
+- **Contexto antigo contradiz o atual**: manter transcript integral, orientar
+  precedência pelo último relato explícito do cliente e persistir versões.
+- **Dados pessoais em logs**: limitar observabilidade a status/metadados; revisar
+  testes de serialização.
+- **Spec/artefatos legados omitem o checkpoint de ICP**: o checklist e a
+  análise cross-artifact devem procurar a ausência do novo contrato antes da
+  execução.
+- **Fixture local parecer recurso real**: manter marcação de teste e validação
+  no quickstart/compose.
+- **Diff local ser confundido com trabalho concluído**: Gate 0, `baseline.md`,
+  testes antes de marcar checkbox e um único escritor por conjunto de arquivos.
+- **Branch/Jira fora do fluxo oficial**: nenhum escritor começa até ticket
+  vinculado, issue em `Em andamento` e branch `feature/*` baseada em `hml`.
+
+## Complexity Tracking
+
+Não há violação constitucional aberta após os gates. O design reutiliza o
+modelo de fatos/versionamento e a infraestrutura de contexto já existentes,
+sem criar snapshot adicional, novo serviço de catálogo ou máquina de estado do
+ICP. A existência do baseline anterior à aceitação é tratada explicitamente
+como dívida de reconciliação obrigatória antes de novo código.

--- a/specs/008-complete-urba-service-flow/quickstart.md
+++ b/specs/008-complete-urba-service-flow/quickstart.md
@@ -1,0 +1,146 @@
+# Quickstart de validação local
+
+## Pré-condições
+
+- Java 21 e Docker disponíveis;
+- dependências do backend e do frontend instaladas;
+- Mongo local do compose configurado como fonte canônica;
+- imagem/runtime Hermes local configurado para o plugin Urbana;
+- variáveis de token apontando apenas para fixtures locais;
+- nenhum link real de pagamento, termos ou briefing configurado no ambiente.
+
+## Validação automatizada
+
+Backend:
+
+```bash
+cd apps/urbana-connect-api
+./gradlew test
+./gradlew check
+```
+
+Plugin Hermes:
+
+```bash
+cd integrations/hermes-agent
+python3 -m unittest discover -s plugins/urbana-domain -p 'test*.py'
+```
+
+Frontend:
+
+```bash
+cd apps/poc-chat
+npm test -- --run
+npm run build
+```
+
+Teste E2E live de qualidade conversacional (requer o stack local real):
+
+```bash
+cd apps/poc-chat
+PLAYWRIGHT_LIVE=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 npm run test:e2e -- quality-chat.spec.ts
+```
+
+No estado de aceite esperado, o arquivo cria contatos locais efêmeros e cobre
+dois contratos distintos: o fluxo conversacional normal, incluindo ICP antes
+dos termos e handoff/retomada, e a captura de evidência da POC. O relatório
+`quality-chat-transcript.json` é anexado mesmo em falha e contém score,
+violações da rubric, ownership e a conversa integral. O teste não usa nomes,
+links, pagamentos nem envios externos reais.
+
+O baseline observado antes da implementação cobre descoberta/handoff, mas ainda
+não comprova todos os cenários de ICP/termos. Até T024 e T047 estarem verdes,
+esse comando é diagnóstico e não evidência final de SC-011.
+
+Teste técnico controlado de SC-014 (fora do fluxo do cliente):
+
+```bash
+cd apps/urbana-connect-api
+./gradlew test --tests '*StatefulDomainToolServiceTest'
+```
+
+Esse teste invoca o boundary de termos com perfil incompleto e deve provar um
+evento lógico por chave, resposta comercial inalterada e payload/log sem valor
+bruto. Ele não é uma rota elegível de SC-011 e não deve ser reproduzido por uma
+conversa real.
+
+Os comandos exatos podem ser adaptados ao wrapper do ambiente, mas a evidência
+deve identificar o comando executado e separar falha de código de falha de
+dependência/infraestrutura.
+
+## Smoke manual
+
+1. Subir o compose local documentado em `infra/local-poc/README.md`.
+2. Abrir a POC e criar uma conversa limpa.
+3. Executar o Roteiro A da spec até a confirmação proativa do briefing.
+4. Em conversas separadas, executar B, C, D e E, incluindo recusa, segunda
+   ausência, captura incidental e atualização silenciosa do ICP.
+5. Em cada rota, registrar transcript, modo/ownership, ids de turno/handoff e
+   ausência de termos técnicos proibidos.
+6. Repetir handoff, retorno e a ação comercial escolhida para verificar
+   idempotência.
+
+## Evidências mínimas para aceite
+
+- matriz dos quatro serviços com preço, área, escopo e entregas;
+- evidência do checkpoint ICP antes dos termos, da reutilização e da regra de
+  `NÃO INFORMADO`;
+- screenshot ou export do ack conversacional do handoff;
+- registro de que não houve mensagem automática após o ack em modo humano;
+- registro de decisão da arquiteta seguida pela retomada;
+- transcript da mensagem proativa única, quando o próximo passo é conhecido;
+- caso de falha controlada com linguagem segura;
+- saída de testes backend, plugin e frontend.
+- evento interno `ICP_SKIPPED_BEFORE_TERMS`, quando deliberadamente provocado,
+  sem valor bruto do campo nos logs.
+
+Nenhum caso local é evidência de pagamento real, aprovação jurídica de termos,
+disponibilidade de agenda ou entrega externa.
+
+## Gates antes da execução e do PR
+
+1. Atualizar `baseline.md`, vincular a subtarefa Jira e iniciar a issue em
+   `Em andamento` apenas quando o primeiro escritor começar.
+2. Trabalhar em `feature/008-complete-urba-service-flow`, preservando o baseline
+   e mantendo `hml` como base.
+3. Após todos os testes e roteiros, obter o aceite manual de Emanuel.
+4. Abrir PR para `hml` com ticket e evidências; então mover para
+   `Awaiting approval`.
+5. Não fazer deploy nem promover para `main` por este quickstart.
+
+## Contrato observado pela POC para handoff e controles
+
+Além de `conversation.mode`, a POC aceita os campos seguros abaixo na projeção
+`GET /api/poc/conversations/{contactAlias}`:
+
+```json
+{
+  "conversation": {
+    "ownership": "HUMAN",
+    "resume": {
+      "status": "RECONCILING",
+      "retryAllowed": false,
+      "failureClass": "HUMAN_CONTEXT_PENDING"
+    },
+    "pocControls": {
+      "approvePaymentProof": true,
+      "recordHumanMessage": true,
+      "returnToUrba": true
+    }
+  }
+}
+```
+
+O ack de handoff deve continuar sendo uma mensagem canônica `OUTBOUND` com
+`senderType` `URBA` ou `HUMAN`; o texto de “Aguardando atendimento” é apenas
+estado complementar. Campos internos, endpoints e identificadores técnicos
+são descartados pelo adaptador.
+
+O backend expõe os endpoints POC de validação humana
+`payment-proof/approve`, `human/messages` e `ownership/urba`; o proxy local
+libera somente essas rotas de controle, sempre com alias local e token
+injetado no servidor. O adaptador também aceita os campos superiores
+`ownership`, `resumeStatus`, `resumeId` e `controlAvailability`, normalizando-os
+com o formato aninhado para compatibilidade com fixtures legadas. Nenhum
+controle envia mensagem do cliente, WhatsApp, e-mail, cobrança ou pagamento
+real.

--- a/specs/008-complete-urba-service-flow/research.md
+++ b/specs/008-complete-urba-service-flow/research.md
@@ -1,0 +1,169 @@
+# Research: Atendimento comercial completo e seguro da Urba
+
+## Decision 1 — manter a autoridade no backend
+
+**Decision:** o catálogo, a contratação, os checkpoints de pagamento/briefing,
+ownership e transcript continuam sendo decididos pelo backend Java. O Hermes
+recebe resultados tipados e o SOUL orienta o checkpoint conversacional de ICP;
+o plugin não contém regras ou preços e o backend não cria um hard gate de ICP.
+
+**Rationale:** a investigação encontrou uma divergência entre o fixture usado
+por `CommercialPolicyService`, o seed Mongo em `servicecatalog` e o contrato
+exposto ao plugin. Uma fonte de decisão no backend impede que o modelo invente
+limites, links ou estados e permite auditoria/idempotência.
+
+**Alternatives considered:** deixar o catálogo no prompt/plugin ou fazer o
+Hermes consultar diretamente Mongo. Rejeitadas porque duplicam fatos,
+expõem armazenamento e tornam impossível garantir as proteções comerciais
+hard do backend.
+
+## Decision 2 — resultado de negócio distinto de falha técnica
+
+**Decision:** rejeições esperadas de requisitos comerciais (dado obrigatório
+ausente, serviço fora do limite, aceite inválido, recurso não vigente) devem
+retornar um envelope estruturado
+com código estável, próxima ação segura e campos necessários. Exceções técnicas
+devem ser logadas com correlação e convertidas em mensagem neutra antes de
+chegar à sessão Hermes ou ao cliente.
+
+**Rationale:** o log de 2026-08-17 mostrou `PREPARE_TERMS` falhando por um
+checkpoint de ICP tratado como rejeição de ferramenta, sendo persistido como
+FAILED, devolvido como HTTP 500/409 e transformado pelo modelo em “o sistema
+não concluiu”. O checkpoint agora é conversacional; se o Hermes o ignorar,
+isso gera observabilidade interna, não uma falha visível nem rollback do fluxo.
+
+O checkpoint de ICP é uma orientação conversacional e não pertence a esse
+envelope de rejeição; sua ausência gera somente observabilidade
+`ICP_SKIPPED_BEFORE_TERMS`.
+
+**Alternatives considered:** deixar o modelo interpretar a exceção ou retornar
+somente texto livre. Rejeitadas por vazamento técnico e por não permitirem
+testes determinísticos.
+
+## Decision 3 — handoff confirma antes de bloquear
+
+**Decision:** a transição bem-sucedida grava a confirmação canônica como
+mensagem visível exatamente uma vez, e só então bloqueia qualquer resposta
+automática subsequente. A notificação interna e a mensagem externa são eventos
+separados, cada um idempotente.
+
+**Rationale:** o fluxo atual muda `ReceptionMode` para `HUMAN` antes de
+`appendOutbound`, descartando a confirmação que o Hermes já havia gerado.
+O frontend só mostra o indicador, por isso o cliente não é avisado pela
+conversa.
+
+**Alternatives considered:** depender apenas do banner do frontend ou deixar o
+modelo redigir o aviso. Rejeitadas porque não são auditáveis no transcript e
+podem variar/ser descartadas.
+
+## Decision 4 — retomada segura é transição, não nova mensagem do cliente
+
+**Decision:** a retomada usa o evento/contrato interno já previsto por PEE-102,
+sincroniza o transcript humano até um limite, decide entre ação proativa e
+espera, e só libera o turno normal após sucesso. Repetições são no-op/replay e
+falhas terminais fecham para o lado humano.
+
+**Rationale:** a sessão Hermes é projeção; mensagens da arquiteta ocorridas no
+modo humano não entram automaticamente nela. Forjar uma mensagem `CONTACT`
+perderia a autoridade e poderia gerar cobrança ou briefing sem decisão.
+
+**Alternatives considered:** concatenar o histórico humano na próxima fala do
+cliente ou pedir que a arquiteta digite um template. Rejeitadas pela perda de
+semântica, duplicidade e responsabilidade indevida ao cliente/arquiteta.
+
+## Decision 5 — fixtures locais são explicitamente não comerciais
+
+**Decision:** o local usa links/ações de teste identificados como fixture e
+controlos determinísticos para validação humana. Recursos produtivos não entram
+no repositório nem no compose local.
+
+**Rationale:** a spec autoriza teste ponta a ponta sem usar links legados ou
+financeiros reais; isso preserva a possibilidade de validar o comportamento
+sem transformar a POC em canal de contratação.
+
+**Alternatives considered:** reutilizar links atuais do site ou de produção.
+Rejeitadas por risco operacional e por não serem recursos aprovados para o
+ambiente local.
+
+## Decision 6 — ICP é checkpoint conversacional, não bloqueio de domínio
+
+**Decision:** depois de serviço confirmado e intenção explícita de contratar, o
+SOUL deve coletar somente os campos de ICP ausentes antes de orientar os termos.
+Há uma segunda tentativa apenas para campos faltantes; recusa ou ausência após
+essa tentativa vira `NÃO INFORMADO` e o fluxo avança. O backend não rejeita
+`prepare_terms` por ICP incompleto, mas registra
+`ICP_SKIPPED_BEFORE_TERMS` quando detectar o desvio. Pergunta, tentativa, pausa
+e retomada são interpretadas pelo SOUL sobre a thread e os fatos correntes; não
+há `ICPCheckpointState`, contador autoritativo ou controlador de diálogo
+persistido no backend.
+
+**Rationale:** Emanuel confirmou que a coleta é importante para Growth, mas que
+forçar o cliente ou introduzir um bloqueio de implementação já causou regressão
+de conversa no passado. O contrato preserva a experiência conversacional e
+torna a falha detectável por testes/observabilidade.
+
+**Alternatives considered:** tornar os três campos pré-requisito de backend,
+persistir uma máquina de estado apenas para controlar a coleta ou deixar a
+coleta totalmente opcional. As duas primeiras alternativas podem
+travar/confundir o Hermes; a terceira permite que os termos apareçam antes do
+enriquecimento sem qualquer detecção.
+
+## Decision 7 — fatos explícitos e contexto integral
+
+**Decision:** qualquer declaração explícita do cliente pode preencher o ICP em
+qualquer momento, com atualização silenciosa pelo valor mais recente. O Hermes
+recebe a thread atual integral, incluindo mensagens da arquiteta, além do
+contexto associado do cliente; threads antigas inteiras não são anexadas.
+
+**Rationale:** suprimir histórico ou enviar uma projeção estreita já produziu
+perda de contexto no Hermes. A íntegra permite que o núcleo resolva a conversa;
+as regras de precedência ficam no SOUL e a origem do fato continua limitada à
+declaração explícita do cliente.
+
+**Alternatives considered:** enviar apenas um perfil “limpo” com o valor atual
+ou manter um snapshot imutável da primeira interação. Rejeitadas porque podam
+contexto e adicionam complexidade que não entrega ganho proporcional para este
+objetivo de enriquecimento.
+
+## Decision 8 — observabilidade sem conteúdo bruto
+
+**Decision:** o perfil/fato pode armazenar o texto necessário para a conversa e
+seu histórico de versões; logs e métricas registram apenas campo, status,
+origem, momento, conversa/turno e o evento de desvio.
+
+**Rationale:** permite auditoria comportamental e diagnóstico do checkpoint sem
+duplicar dados pessoais em observabilidade técnica.
+
+**Alternatives considered:** registrar os textos brutos no log para facilitar
+debug. Rejeitada por duplicação desnecessária de dados pessoais.
+
+## Decision 9 — reconciliar o baseline antes de novos escritores
+
+**Decision:** as alterações já existentes na árvore de trabalho são tratadas
+como baseline não verificado. Antes de delegar implementação, o Tech Lead deve
+inventariar o delta, associá-lo aos requisitos/tarefas, executar testes
+proporcionais e classificar cada slice como aproveitável, incompleto,
+conflitante ou fora de escopo. A mera presença de código ou teste não conclui
+uma tarefa.
+
+**Rationale:** a branch atual contém mudanças extensas em backend, SOUL, plugin,
+POC, compose e testes, enquanto os artefatos anteriores descreviam uma execução
+greenfield. Recomeçar as tarefas poderia duplicar trabalho ou apagar decisões
+já materializadas; presumir conclusão esconderia regressões ainda não
+verificadas.
+
+**Alternatives considered:** marcar todas as tarefas aparentes como concluídas
+ou descartar o diff e reimplementar. Rejeitadas, respectivamente, por falta de
+evidência e por risco destrutivo sobre alterações preexistentes.
+
+## Evidências consultadas
+
+- `specs/008-complete-urba-service-flow/spec.md`
+- `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/CommercialPolicyService.java`
+- `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolService.java`
+- `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/interfaces/rest/poc/DomainToolController.java`
+- `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionOrchestrator.java`
+- `integrations/hermes-agent/plugins/urbana-domain/tools.py`
+- `docs/specs/pee-102-retomada-tecnica-humano-urba-hermes.md`
+- `script-example.log` e registros Mongo da execução manual de 2026-08-17
+- entrevista de refinamento técnico conduzida com Emanuel até 2026-08-26

--- a/specs/008-complete-urba-service-flow/spec.md
+++ b/specs/008-complete-urba-service-flow/spec.md
@@ -1,18 +1,19 @@
 # Feature Specification: Atendimento comercial completo e seguro da Urba
 
-- **Feature Branch**: `008-complete-urba-service-flow`
+- **Feature Branch**: `feature/008-complete-urba-service-flow`
 - **Created**: 2026-08-17
-- **Status**: Draft — aguardando GO de Emanuel
-- **Input**: Materializar no atendimento da Urba todo o catálogo operacional refinado, corrigir o avanço comercial, impedir exposição de falhas internas, confirmar transferências humanas e viabilizar uma validação manual ponta a ponta.
+- **Status**: Gate 0 concluído com baseline reconciliado e lacunas registradas em `baseline.md`; implementação delegada em workstreams separados, sem aceite de produto ainda
+- **Input**: Materializar no atendimento da Urba o catálogo operacional refinado, corrigir o avanço comercial, coletar enriquecimento de lead no momento certo, impedir exposição de falhas internas, confirmar transferências humanas e viabilizar uma validação manual ponta a ponta.
 
 ## Metadados
 
 - `Título da feature`: Atendimento comercial completo e seguro da Urba
-- `Ticket Jira`: a criar ou vincular após o GO; relacionado a PEE-23, PEE-102, PEE-103 e PEE-104
+- `Ticket Jira`: `PEE-105`, subtarefa de implementação sob PEE-23, com dependências registradas em PEE-102, PEE-103 e PEE-104
 - `Responsável pela spec`: Tech Lead Orchestrator
 - `Aprovador de negócio`: Emanuel
-- `Contexto de branch`: `feature/* -> hml -> main`
-- `Fonte principal de negócio`: entrevista de refinamento da PEE-102, cujo contrato necessário está consolidado nesta spec
+- `Branch de execução`: `feature/008-complete-urba-service-flow`, descendente local de `hml` e contendo alterações preexistentes não verificadas
+- `Fluxo de promoção`: `feature/008-complete-urba-service-flow -> hml -> main`; a branch foi renomeada preservando integralmente o baseline, e nenhuma promoção foi feita
+- `Fonte principal de negócio`: entrevista de refinamento da PEE-102, concluída em 2026-08-26, cujo contrato necessário está consolidado nesta spec
 - `Diagnóstico de origem`: teste manual de 2026-08-17, cujas falhas relevantes estão consolidadas nesta spec
 
 ## 1. Contexto
@@ -26,18 +27,20 @@ defeitos:
 
 1. o catálogo apresentado ao agente contém somente nome, descrição curta e
    preço, sem processo, entregas, responsabilidades ou limites detalhados;
-2. um checkpoint comercial exige dados de ICP que não foram coletados e que
-   não constam como pré-requisito da contratação refinada;
+2. o fluxo comercial chega aos termos sem executar o checkpoint conversacional
+   de enriquecimento de lead que foi definido para o momento de contratação;
 3. a rejeição desse checkpoint chega ao agente como falha operacional e é
    transformada em uma fala que menciona problema no sistema;
 4. a transferência humana funciona, mas a confirmação gerada para o cliente é
    descartada antes de entrar no histórico visível.
 
-A PEE-102 consolidou o contrato de negócio, porém declara que sua implementação
-não foi iniciada. PEE-103 e PEE-104 entregaram capacidades técnicas de retomada
-de contexto e persistência transacional, mas não materializaram o catálogo nem
-reescreveram os turnos comerciais normais. Esta feature fecha essa lacuna
-funcional.
+A PEE-102 consolidou o contrato de negócio e PEE-103/PEE-104 entregaram
+capacidades técnicas relacionadas à retomada de contexto e persistência
+transacional. A árvore de trabalho atual já contém alterações extensas de
+catálogo, handoff, retomada, POC, SOUL e testes, porém elas ainda não foram
+reconciliadas nem aceitas contra esta especificação. Esta feature fecha o delta
+funcional sem presumir que código existente está concluído e sem reimplementar
+ou sobrescrever mudanças preexistentes.
 
 ### 1.2 Objetivo
 
@@ -48,6 +51,8 @@ conversa que:
 - diferencie e explique os quatro serviços com precisão;
 - apresente progressivamente entregas, processo e responsabilidades;
 - avance com segurança por termos, pagamento e briefing;
+- colete, sem travar a contratação, as três informações de enriquecimento de
+  lead no momento adequado;
 - transfira para a arquiteta com uma confirmação clara;
 - preserve o contexto durante o atendimento humano;
 - retome proativamente quando houver uma próxima ação segura;
@@ -62,6 +67,7 @@ Incluído:
 - respostas comparativas e explicações de “como funciona”;
 - regras de área, múltiplos ambientes e serviços independentes;
 - sequência comercial até termos, pagamento, validação humana e briefing;
+- checkpoint conversacional de enriquecimento de lead antes dos termos;
 - conhecimento sobre reunião, produção, entrega e suporte;
 - erros comerciais recuperáveis e falhas técnicas com linguagem segura;
 - transferência URBA → HUMANO com aviso visível e notificação interna;
@@ -82,25 +88,68 @@ Quando houver conflito, a ordem de precedência é:
 Preços, links históricos e descrições legadas não podem substituir a fonte
 canônica definida por esta feature.
 
-### 1.5 Decisões adotadas para aprovação no GO
+### 1.5 Decisões consolidadas no refinamento técnico
 
-1. `PRONOUN_PREFERENCE`, `FIRST_TIME_HIRING` e `OCCUPATION` são informações
-   opcionais e não bloqueiam termos, pagamento ou briefing.
-2. Para apresentar os termos, os únicos pré-requisitos comerciais são serviço
-   confirmado, ambiente identificado e área validada quando o serviço possuir
-   limite padrão.
-3. O ambiente local pode usar links de teste claramente identificados e sem
-   valor comercial. Homologação e produção exigem recursos vigentes e
-   aprovados.
-4. A confirmação de handoff é determinística, curta e configurável; seu
-   significado não depende de texto livre produzido pelo agente.
-5. Nenhuma rejeição ou falha pode revelar sistema, ferramenta, integração,
-   banco de dados, código, HTTP, exceção, retry, idempotência ou outro detalhe
-   técnico ao cliente.
-6. Uma mensagem enviada pelo cliente enquanto a conversa está em modo humano
-   não reativa automaticamente a Urba.
-7. A retomada proativa só ocorre quando o próximo passo estiver comprovado
-   pelo estado; na dúvida, a Urba aguarda ou devolve o caso ao humano.
+1. O ICP desta feature é composto exatamente por `PRONOUN_PREFERENCE`,
+   `FIRST_TIME_HIRING` e `OCCUPATION`. Ele é um checkpoint conversacional de
+   enriquecimento de lead, não um bloqueio comercial de backend.
+2. O checkpoint só é iniciado quando o serviço estiver claramente confirmado e
+   o cliente demonstrar intenção explícita de contratar. Serviço ambíguo,
+   curiosidade, comparação ou pergunta de preço continuam no fluxo de
+   descoberta.
+3. A mensagem inicial pergunta somente os campos ausentes, em formato curto,
+   com quebras de linha e sem usar o termo técnico “ICP”. Se todos os campos já
+   existirem, a Urba não repete a coleta.
+4. Cada campo ausente recebe no máximo uma nova tentativa. “Prefiro não
+   informar” conclui o campo imediatamente; ausência de resposta na segunda
+   tentativa registra `NÃO INFORMADO` e permite o avanço.
+5. Uma resposta paralela do cliente deve ser atendida normalmente, mantendo o
+   checkpoint pendente e retomando somente os campos faltantes depois. Pedir
+   atendimento humano interrompe a coleta e impede termos/pagamento até a
+   arquiteta devolver a responsabilidade.
+6. Declarações explícitas do cliente podem ser capturadas incidentalmente em
+   qualquer momento, antes ou depois da contratação, para qualquer um dos quatro
+   serviços. Não são permitidas inferências; interpretação da arquiteta não é
+   fato do cliente.
+7. O perfil é global por cliente e reutilizado entre serviços e conversas. Um
+   valor explícito mais recente substitui silenciosamente o anterior, inclusive
+   por `NÃO INFORMADO`; essa alteração não é comunicada ao cliente.
+8. Depois de todos os campos estarem respondidos, recusados ou marcados como
+   `NÃO INFORMADO`, a Urba avança automaticamente para os termos, sem pedir uma
+   confirmação extra.
+9. O backend não fará um hard gate nem manterá estado autoritativo de diálogo
+   para impedir termos quando o Hermes deixar de executar o checkpoint. O SOUL,
+   a thread atual e os fatos correntes orientam perguntas, segunda tentativa,
+   pausa e retomada. O backend apenas persiste fatos explícitos e registra o
+   evento interno `ICP_SKIPPED_BEFORE_TERMS` para detectar a regressão sem
+   expor erro nem bloquear o cliente.
+10. O Hermes recebe a íntegra do histórico da thread atual, incluindo mensagens
+    da arquiteta, e o contexto associado do cliente. Threads antigas inteiras
+    não são despejadas; o contexto não deve ser podado especificamente por
+    causa do ICP.
+11. O resumo interno do handoff pode incluir quais campos do ICP estão
+    preenchidos ou ausentes. Ele não transfere ao backend a condução da coleta
+    nem precisa transportar contadores de tentativas. Logs técnicos não devem
+    duplicar os valores brutos.
+12. O E2E valida semântica e invariantes, não uma cópia literal da redação
+    aprovada. A mensagem deve permanecer curta, natural e progressiva.
+13. O ambiente local pode usar links de teste claramente identificados e sem
+    valor comercial. Homologação e produção exigem recursos vigentes e
+    aprovados.
+14. A confirmação de handoff é determinística, curta e configurável; seu
+    significado não depende de texto livre produzido pelo agente.
+15. Nenhuma rejeição ou falha pode revelar sistema, ferramenta, integração,
+    banco de dados, código, HTTP, exceção, retry, idempotência ou outro detalhe
+    técnico ao cliente.
+16. Uma mensagem enviada pelo cliente enquanto a conversa está em modo humano
+    não reativa automaticamente a Urba.
+17. A retomada proativa só ocorre quando o próximo passo estiver comprovado
+    pelo estado; na dúvida, a Urba aguarda ou devolve o caso ao humano.
+18. Toda implementação já presente na árvore de trabalho é baseline não
+    verificado. Antes de novos escritores, ela deve ser inventariada, associada
+    aos requisitos, testada e classificada como aproveitável, incompleta,
+    conflitante ou fora de escopo; nenhuma tarefa é considerada concluída apenas
+    pela existência de um diff.
 
 ### 1.6 Entidades de negócio
 
@@ -121,6 +170,14 @@ canônica definida por esta feature.
   responsabilidade e estado de retomada.
 - **Decisão humana**: orientação específica da arquiteta que prevalece sobre o
   catálogo geral naquele caso.
+- **Enriquecimento de lead (ICP)**: conjunto global por cliente dos três campos
+  de perfil, com valor atual, estado `NÃO INFORMADO`, origem explícita e
+  histórico de versões interno. A pendência e a regra de tentativa pertencem à
+  interpretação conversacional do SOUL sobre a thread, não a uma máquina de
+  estados autoritativa do backend.
+- **Evento de desvio do ICP**: registro interno idempotente que informa apenas
+  conversa, turno, serviço, campos ausentes, ponto de detecção e momento, sem
+  valores do perfil, conteúdo do cliente ou efeito bloqueante.
 - **Mensagem canônica**: mensagem recebida ou enviada que compõe o histórico
   visível e a reidratação de contexto.
 
@@ -150,24 +207,42 @@ canônica definida por esta feature.
 
 ### 2.2 Cenário prioritário B — termos, pagamento e briefing
 
-1. Dado serviço, ambiente e área aplicável confirmados, quando o cliente quiser
-   contratar, então a Urba deve apresentar os termos sem exigir dados opcionais
-   de perfil.
-2. Dado que os termos tenham sido apresentados, quando o cliente responder de
+1. Dado serviço, ambiente e área aplicável confirmados, quando o cliente
+   demonstrar intenção explícita de contratar, então a Urba deve verificar o
+   enriquecimento de lead antes de apresentar os termos.
+2. Dado que existam campos do ICP ausentes, quando o checkpoint for iniciado,
+   então a Urba deve perguntar somente os campos ausentes, em mensagem curta e
+   sem usar a palavra “ICP”.
+3. Dado que o cliente responda, recuse ou deixe de responder após a segunda
+   tentativa, quando os campos pendentes forem concluídos, então a Urba deve
+   avançar automaticamente para os termos.
+4. Dado que todos os campos do ICP já estejam disponíveis, quando o cliente
+   demonstrar intenção explícita de contratar, então a Urba deve pular a coleta
+   e seguir diretamente para os termos.
+5. Dado que os termos tenham sido apresentados, quando o cliente responder de
    forma ambígua, então a Urba deve pedir um aceite textual claro e não liberar
    pagamento.
-3. Dado aceite textual claro, quando a contratação avançar, então a Urba deve
+6. Dado aceite textual claro, quando a contratação avançar, então a Urba deve
    perguntar o método e apresentar somente a instrução de pagamento vigente da
    contratação.
-4. Dado que o cliente envie comprovante, quando o recebimento for registrado,
+7. Dado que o cliente envie comprovante, quando o recebimento for registrado,
    então a Urba deve informar que a validação será humana, confirmar a
    transferência e parar de responder automaticamente.
-5. Dado que a pessoa responsável confirme o pagamento e devolva a conversa,
+8. Dado que a pessoa responsável confirme o pagamento e devolva a conversa,
    quando o contexto for retomado, então a Urba deve enviar proativamente o
    briefing correto sem pedir que o cliente repita o que aconteceu.
-6. Dado briefing, medidas, fotos ou vídeos pendentes, quando o cliente pedir
+9. Dado briefing, medidas, fotos ou vídeos pendentes, quando o cliente pedir
    ajuda, então a Urba deve orientar com o material oficial e escalar apenas a
    dificuldade que não conseguir resolver.
+
+Durante o checkpoint:
+
+- uma declaração explícita do cliente pode preencher qualquer campo sem que a
+  Urba diga que registrou a informação;
+- uma pergunta paralela deve ser respondida sem perder o checkpoint pendente;
+- um pedido de humano deve gerar handoff imediato, sem termos ou pagamento;
+- ao retornar para a Urba, a coleta é retomada apenas para os campos faltantes;
+- a arquiteta pode receber no resumo interno os campos atuais e pendentes.
 
 ### 2.3 Cenário prioritário C — handoff solicitado pelo cliente
 
@@ -256,7 +331,11 @@ Regras que a Urba deve conhecer e aplicar:
 | Situação | Comportamento visível esperado |
 |---|---|
 | Dado comercial obrigatório ausente | Fazer uma pergunta curta para coletar o dado necessário. |
-| Dado opcional de perfil ausente | Continuar o fluxo sem bloquear. |
+| Serviço confirmado e intenção explícita, com ICP ausente | Perguntar os campos faltantes antes dos termos, sem hard gate técnico. |
+| Cliente recusa ou não responde ao ICP | Registrar `NÃO INFORMADO` conforme a regra de tentativa e seguir para os termos. |
+| Cliente já possui ICP no perfil | Reutilizar os valores e não perguntar novamente. |
+| Cliente informa ICP espontaneamente | Capturar somente a declaração explícita, sem interromper a conversa. |
+| Hermes ignora o checkpoint | Registrar `ICP_SKIPPED_BEFORE_TERMS` internamente, sem erro visível ou bloqueio. |
 | Área desconhecida em Interiores/Reforma | Ajudar a estimar/medir; escalar apenas se a dificuldade persistir. |
 | Área acima de 20 m² em Interiores/Reforma | Informar o limite padrão e encaminhar para avaliação, sem prometer exceção. |
 | Link vigente indisponível | Não usar link legado; confirmar encaminhamento humano para obtenção segura. |
@@ -303,9 +382,12 @@ Frases proibidas incluem, sem se limitar a:
   mini resumo e pedido de confirmação.
 - **FR-012**: a confirmação comercial do serviço deve ser separada do aceite
   formal dos termos.
-- **FR-013**: dados opcionais de ICP não podem bloquear nenhuma etapa.
-- **FR-014**: serviço, ambiente e área aplicável são os únicos dados de
-  qualificação exigidos antes dos termos.
+- **FR-013**: após serviço confirmado e intenção explícita de contratar, a Urba
+  deve executar o checkpoint conversacional dos campos de ICP ausentes antes de
+  apresentar os termos, sem transformá-lo em hard gate de backend.
+- **FR-014**: serviço, ambiente e área aplicável continuam sendo os únicos
+  pré-requisitos comerciais de estado para os termos; o ICP é uma etapa de
+  orientação do Hermes e enriquecimento de lead.
 - **FR-015**: mudança de serviço antes do pagamento deve invalidar os termos da
   contratação anterior e reiniciar termos/aceite para a nova contratação.
 - **FR-016**: múltiplos ambientes ou serviços devem manter estados e aceites
@@ -388,13 +470,62 @@ Frases proibidas incluem, sem se limitar a:
   link do Tour Virtual.
 - **FR-050**: suporte deve ser descrito como três meses de dúvidas sobre Manual
   e cores, sem visita ou gestão da execução.
+- **FR-051**: a primeira mensagem OUTBOUND de uma conversa nova deve identificar
+  a Urba como assistente virtual da Urbana do Brasil, sem depender de o cliente
+  perguntar quem está atendendo.
+- **FR-052**: uma pergunta informativa sobre como funciona o serviço deve
+  consultar o catálogo rico e responder progressivamente; ela não pode, por si
+  só, apresentar termos, preparar pagamento ou transferir ao humano.
+- **FR-053**: `TERMS=PRESENTED` só pode ser persistido quando a etapa de termos
+  for explicitamente solicitada e efetivamente apresentada ao cliente; um turno
+  meramente explicativo não pode alterar esse estado.
+- **FR-054**: o ambiente local deve compilar o backend a partir do código-fonte
+  atual durante a construção da imagem, sem depender de JAR previamente gerado
+  no host.
+- **FR-055**: o cenário conversacional principal deve possuir um E2E live que
+  preserve o transcript integral, avalie invariantes operacionais e qualidade
+  factual mínima, e falhe com diagnóstico quando uma resposta ficar silenciosa,
+  técnica, incompleta ou encaminhar indevidamente.
+- **FR-056**: o ICP deve conter somente `PRONOUN_PREFERENCE`,
+  `FIRST_TIME_HIRING` e `OCCUPATION`, aplicando `SIM`, `NÃO` ou `NÃO INFORMADO`
+  apenas ao campo de primeira contratação; os outros dois preservam o texto
+  explícito informado pelo cliente.
+- **FR-057**: o checkpoint deve perguntar apenas os campos ausentes, usar
+  mensagem curta com quebras de linha e não expor o termo “ICP” ao cliente.
+- **FR-058**: o SOUL deve oferecer a cada campo ausente somente uma segunda
+  oportunidade conversacional; recusa explícita conclui imediatamente e
+  ausência após essa oportunidade conclui como `NÃO INFORMADO`, sem insistência
+  ou bloqueio. Essa regra deve ser conduzida a partir da thread e dos fatos
+  correntes, sem contador autoritativo persistido pelo backend.
+- **FR-059**: declarações explícitas do cliente podem preencher ou atualizar o
+  ICP incidentalmente em qualquer etapa; inferências e interpretações da
+  arquiteta não podem gerar fato do cliente.
+- **FR-060**: o ICP deve ser global por cliente, reutilizado entre os quatro
+  serviços, e um valor explícito mais recente — inclusive `NÃO INFORMADO` —
+  substitui silenciosamente o valor atual.
+- **FR-061**: após a conclusão de todos os campos, a Urba deve avançar
+  automaticamente para os termos; perguntas paralelas, handoff e retomada
+  humana devem preservar os campos ainda pendentes por meio da thread integral,
+  dos fatos correntes e das instruções do SOUL.
+- **FR-062**: a ausência do checkpoint não pode produzir erro técnico, alterar
+  o resultado comercial nem criar bloqueio de backend; deve gerar apenas um
+  evento interno idempotente `ICP_SKIPPED_BEFORE_TERMS`, correlacionado por
+  conversa/turno/serviço e campos ausentes, sem valores brutos, transcript,
+  links, prompt ou detalhes técnicos.
+- **FR-063**: o Hermes deve receber a íntegra da thread atual e o contexto
+  associado, incluindo mensagens humanas, sem que a Urba filtre o histórico
+  especificamente por causa do ICP.
+- **FR-064**: o resumo interno de handoff pode indicar quais campos do ICP estão
+  preenchidos ou ausentes, sem transportar contadores de tentativa; logs
+  técnicos não repetem os valores brutos.
 
 ### 3.7 Critérios mensuráveis de sucesso
 
 - **SC-001**: 100% dos quatro serviços passam na matriz factual de nome, preço,
   área, escopo e entregas.
-- **SC-002**: o roteiro prioritário do quarto infantil chega aos termos sem
-  handoff inesperado, bloqueio de ICP ou afirmação incorreta sobre área.
+- **SC-002**: o roteiro prioritário do quarto infantil executa o checkpoint de
+  ICP antes dos termos quando houver campo ausente, sem handoff inesperado,
+  linguagem interna ou afirmação incorreta sobre área.
 - **SC-003**: 100% das perguntas “como funciona” usadas no roteiro recebem
   explicação suficiente sem alegar falta de informação existente.
 - **SC-004**: 100% dos casos de rejeição controlada resultam em pergunta ou
@@ -407,11 +538,44 @@ Frases proibidas incluem, sem se limitar a:
   máximo uma mensagem proativa e não precisa repetir contexto.
 - **SC-008**: 100% dos cenários manuais obrigatórios da seção 5.4 passam em uma
   execução limpa antes de promover a feature.
+- **SC-009**: uma execução live do roteiro principal captura o transcript
+  integral e produz score/racional reproduzível para apresentação, catálogo,
+  ausência de linguagem interna, handoff e ownership.
+- **SC-010**: reconstruir o stack local a partir da árvore de trabalho resulta
+  em imagem backend cujo artefato executado contém as alterações atuais,
+  verificadas por build e healthcheck, sem depender de `build/libs` obsoleto.
+- **SC-011**: em 100% dos caminhos conversacionais normais e visíveis ao cliente
+  cobertos pelo E2E, os termos só aparecem depois de os campos ausentes serem
+  respondidos, recusados ou marcados como `NÃO INFORMADO`; quando já
+  preenchidos, o checkpoint é omitido. O cenário técnico de injeção controlada
+  definido em SC-014 é explicitamente excluído desta população.
+- **SC-012**: uma segunda tentativa do ICP contém somente campos ainda ausentes,
+  e nenhum campo recebe mais de duas oportunidades de resposta no mesmo ciclo.
+- **SC-013**: uma declaração espontânea explícita é reutilizada sem nova
+  pergunta, e uma atualização posterior não gera mensagem ao cliente sobre a
+  substituição do valor.
+- **SC-014**: em 100% das injeções controladas que invocam a preparação de
+  termos com ICP incompleto fora do caminho conversacional normal, o backend
+  preserva o resultado comercial e registra exatamente um evento interno por
+  chave idempotente; 0% dos resultados/mensagens expõem o evento ou falha
+  técnica ao cliente/Hermes, e 0% dos eventos/logs contêm valores brutos do ICP.
 
 ## 4. Edge Cases
 
 - Cliente fornece nome, mas não preferência de tratamento, ocupação ou histórico
   de contratação.
+- Cliente já possui um ou dois campos do ICP e deve receber pergunta somente
+  sobre os campos restantes.
+- Cliente responde parcialmente ao primeiro bloco do ICP.
+- Cliente diz explicitamente que prefere não informar um campo.
+- Cliente ignora o primeiro bloco e também a segunda tentativa.
+- Cliente fornece um valor explícito do ICP espontaneamente durante a descoberta.
+- Cliente fornece depois um valor diferente ou `NÃO INFORMADO`; a troca é
+  silenciosa e o valor mais recente prevalece.
+- Cliente pergunta algo paralelo durante o ICP.
+- Cliente pede a arquiteta durante o ICP e a arquiteta devolve a conversa com
+  campos ainda ausentes.
+- Hermes recebe histórico integral contendo respostas antigas e novas do cliente.
 - Cliente quer pintura temática e reaproveitar móveis; a Urba deve diferenciar
   Pintura de Interiores sem prometer layout em Pintura.
 - Cliente não sabe a metragem ou informa medida aproximada.
@@ -447,7 +611,11 @@ Frases proibidas incluem, sem se limitar a:
 
 - testes de contrato do catálogo para os quatro serviços;
 - testes de comparação entre serviços e regras de área;
-- testes do avanço comercial com ICP opcional;
+- testes do checkpoint de ICP antes dos termos, reutilização, captura incidental,
+  recusa, segunda tentativa, atualização silenciosa e retomada após humano;
+- teste unitário/integração de injeção controlada em que termos são preparados
+  com ICP incompleto, comprovando evento idempotente, payload sem valores e
+  resultado comercial inalterado;
 - testes de termos, aceite ambíguo, mudança de serviço e contratações
   independentes;
 - testes de falhas recuperáveis e sanitização de falhas técnicas;
@@ -469,6 +637,10 @@ Cada turno comercial relevante deve permitir correlacionar internamente:
 - ação comercial solicitada;
 - resultado seguro ou classe de falha;
 - handoff e ownership;
+- campos de ICP ausentes/preenchidos sem registrar valores brutos, conteúdo do
+  cliente ou contador conversacional nos logs;
+- evento idempotente `ICP_SKIPPED_BEFORE_TERMS` quando houver desvio do
+  checkpoint, sem alterar a resposta de preparação dos termos;
 - sincronização/decisão de retomada;
 - criação ou supressão justificada de mensagem canônica.
 
@@ -503,19 +675,38 @@ O ambiente de validação deve oferecer meios seguros de:
 8. Pedir detalhes sobre entregas, execução, materiais, prazo e suporte.
 9. Confirmar que a Urba responde com o catálogo refinado, sem encaminhar e sem
    mencionar falta de informação.
-10. Pedir contratação e confirmar que os termos são apresentados sem coleta
-    obrigatória de ocupação, pronome ou primeira contratação.
-11. Responder “ok” e confirmar que o pagamento não é liberado.
-12. Dar aceite textual claro e escolher método de pagamento.
-13. Confirmar instrução de teste vinculada à contratação correta.
-14. Enviar comprovante de teste.
-15. Confirmar mensagem de validação humana e exatamente uma confirmação de
+10. Demonstrar intenção explícita de contratar e confirmar que a Urba pergunta
+    os campos de ICP ausentes antes dos termos.
+11. Responder os três campos e confirmar que os termos só aparecem depois do
+    checkpoint, sem uma nova confirmação intermediária.
+12. Responder “ok” e confirmar que o pagamento não é liberado.
+13. Dar aceite textual claro e escolher método de pagamento.
+14. Confirmar instrução de teste vinculada à contratação correta.
+15. Enviar comprovante de teste.
+16. Confirmar mensagem de validação humana e exatamente uma confirmação de
     handoff.
-16. Confirmar que mensagens posteriores não recebem automação durante modo
+17. Confirmar que mensagens posteriores não recebem automação durante modo
     humano.
-17. Como arquiteta, validar o pagamento e devolver a conversa à Urba.
-18. Confirmar que a Urba retoma com contexto e envia proativamente o briefing
+18. Como arquiteta, validar o pagamento e devolver a conversa à Urba.
+19. Confirmar que a Urba retoma com contexto e envia proativamente o briefing
     correto, sem pedir repetição.
+
+#### Roteiro E — checkpoint de enriquecimento de lead
+
+1. Iniciar uma conversa em que o cliente já tenha dois campos do ICP no perfil
+   e demonstrar intenção explícita por um serviço confirmado.
+2. Confirmar que a Urba pergunta somente o campo ausente.
+3. Em uma conversa limpa, responder parcialmente ao primeiro bloco e confirmar
+   que a segunda mensagem contém apenas o campo restante.
+4. Recusar explicitamente um campo e confirmar avanço sem insistência.
+5. Ignorar um campo duas vezes e confirmar registro interno de `NÃO INFORMADO`
+   e avanço para os termos.
+6. Informar espontaneamente um campo antes da contratação e confirmar que ele é
+   reutilizado sem nova pergunta.
+7. Fornecer depois um valor diferente e confirmar que a Urba não anuncia a
+   substituição ao cliente.
+8. Pedir a arquiteta durante o checkpoint, devolver a conversa e confirmar que
+   a Urba retoma somente os campos ainda faltantes.
 
 #### Roteiro B — dificuldade no briefing e retorno
 
@@ -545,15 +736,24 @@ O ambiente de validação deve oferecer meios seguros de:
 4. Solicitar humano duas vezes e confirmar uma única mensagem/notificação.
 5. Repetir a devolução HUMANO → URBA e confirmar uma única retomada proativa.
 
+O desvio de SC-014 não faz parte desses roteiros conversacionais: ele é um teste
+técnico controlado do boundary de preparação de termos. Um cliente real ou o
+E2E normal nunca deve ser instruído a burlar o checkpoint para produzir esse
+evento.
+
 ### 5.5 Gate de aprovação manual
 
 A feature somente pode seguir para homologação quando:
 
 - todos os testes automatizados obrigatórios estiverem verdes;
-- os quatro roteiros manuais tiverem evidência registrada;
+- os cinco roteiros manuais tiverem evidência registrada;
 - nenhuma fala contiver linguagem técnica proibida;
 - o histórico canônico e o ownership forem consistentes;
 - não houver link legado apresentado como vigente;
+- o baseline local tiver sido reconciliado e nenhuma alteração preexistente
+  permanecer sem classificação ou teste proporcional;
+- a subtarefa Jira estiver vinculada, a branch de execução seguir
+  `feature/* -> hml` e as evidências estiverem preparadas para o PR;
 - Emanuel aprovar a qualidade e naturalidade da conversa.
 
 ## 6. Fora de escopo
@@ -569,19 +769,30 @@ A feature somente pode seguir para homologação quando:
   puder comprovar o mesmo contrato;
 - simulação do decurso real de sete dias úteis;
 - alta disponibilidade do ambiente local;
-- uso de memória global do agente como fonte canônica de negócio.
+- uso de memória global do agente como fonte canônica de negócio;
+- criação de um hard gate backend específico para o ICP;
+- coleta de novos campos de ICP além dos três confirmados;
+- dashboard de Growth ou definição de um snapshot imutável de primeira
+  interação; o valor corrente e seu histórico são suficientes para esta feature.
 
-## 7. Dúvidas em aberto
+## 7. Decisões operacionais e gates de execução
 
-Não há pergunta de negócio bloqueante para planejar após o GO. O GO de Emanuel
-aprovará também as decisões da seção 1.5.
+Não há pergunta de negócio ou técnica bloqueante nesta especificação. As
+decisões de negócio e experiência da seção 1.5 foram confirmadas na entrevista
+de 2026-08-26. Os pontos operacionais ficam resolvidos assim:
 
-Pendências operacionais que devem ser resolvidas no planejamento, sem alterar o
-contrato desta spec:
-
-- definir a origem e a governança dos recursos vigentes de termos, pagamento,
-  briefing e agendamento para cada ambiente;
-- definir como o ambiente local simulará as ações exclusivas da arquiteta;
-- associar esta feature ao ticket Jira de implementação e às dependências
-  formais de PEE-103/PEE-104;
-- definir quais evidências dos roteiros serão anexadas ao Jira/PR.
+- o ambiente local utiliza somente recursos e controles inequivocamente de
+  teste; homologação/produção recebem recursos vigentes por configuração segura
+  externa ao repositório;
+- as ações exclusivas da arquiteta são simuladas pelos controles determinísticos
+  já previstos na POC, sem envio externo ou pagamento real;
+- antes do primeiro escritor, o Tech Lead deve concluir o gate de baseline,
+  vincular a subtarefa Jira e garantir a branch de execução `feature/*` baseada
+  em `hml`, preservando a árvore atual;
+- testes, transcript E2E, matriz factual e roteiros manuais compõem o pacote de
+  evidência a ser vinculado ao Jira e descrito no PR;
+- Jira só muda para `Em andamento` quando a execução for efetivamente iniciada;
+  implementação mais PR aberto mudam para `Awaiting approval`, e apenas merge
+  aprovado permite `Concluído`;
+- este documento não autoriza deploy, promoção, recurso comercial real nem
+  comunicação externa.

--- a/specs/008-complete-urba-service-flow/spec.md
+++ b/specs/008-complete-urba-service-flow/spec.md
@@ -1,0 +1,587 @@
+# Feature Specification: Atendimento comercial completo e seguro da Urba
+
+- **Feature Branch**: `008-complete-urba-service-flow`
+- **Created**: 2026-08-17
+- **Status**: Draft — aguardando GO de Emanuel
+- **Input**: Materializar no atendimento da Urba todo o catálogo operacional refinado, corrigir o avanço comercial, impedir exposição de falhas internas, confirmar transferências humanas e viabilizar uma validação manual ponta a ponta.
+
+## Metadados
+
+- `Título da feature`: Atendimento comercial completo e seguro da Urba
+- `Ticket Jira`: a criar ou vincular após o GO; relacionado a PEE-23, PEE-102, PEE-103 e PEE-104
+- `Responsável pela spec`: Tech Lead Orchestrator
+- `Aprovador de negócio`: Emanuel
+- `Contexto de branch`: `feature/* -> hml -> main`
+- `Fonte principal de negócio`: entrevista de refinamento da PEE-102, cujo contrato necessário está consolidado nesta spec
+- `Diagnóstico de origem`: teste manual de 2026-08-17, cujas falhas relevantes estão consolidadas nesta spec
+
+## 1. Contexto
+
+### 1.1 Problema
+
+O runtime atual já sustenta uma conversa mais contínua por meio do Hermes, mas
+o comportamento testado ainda não representa o atendimento refinado com
+Emanuel. A investigação da conversa manual de 2026-08-17 confirmou quatro
+defeitos:
+
+1. o catálogo apresentado ao agente contém somente nome, descrição curta e
+   preço, sem processo, entregas, responsabilidades ou limites detalhados;
+2. um checkpoint comercial exige dados de ICP que não foram coletados e que
+   não constam como pré-requisito da contratação refinada;
+3. a rejeição desse checkpoint chega ao agente como falha operacional e é
+   transformada em uma fala que menciona problema no sistema;
+4. a transferência humana funciona, mas a confirmação gerada para o cliente é
+   descartada antes de entrar no histórico visível.
+
+A PEE-102 consolidou o contrato de negócio, porém declara que sua implementação
+não foi iniciada. PEE-103 e PEE-104 entregaram capacidades técnicas de retomada
+de contexto e persistência transacional, mas não materializaram o catálogo nem
+reescreveram os turnos comerciais normais. Esta feature fecha essa lacuna
+funcional.
+
+### 1.2 Objetivo
+
+Permitir que a Urba conduza, sem engasgos e sem expor processos internos, uma
+conversa que:
+
+- descubra a necessidade do cliente;
+- diferencie e explique os quatro serviços com precisão;
+- apresente progressivamente entregas, processo e responsabilidades;
+- avance com segurança por termos, pagamento e briefing;
+- transfira para a arquiteta com uma confirmação clara;
+- preserve o contexto durante o atendimento humano;
+- retome proativamente quando houver uma próxima ação segura;
+- permaneça fiel às decisões específicas da arquiteta;
+- possa ser validada localmente de ponta a ponta antes de homologação.
+
+### 1.3 Escopo funcional
+
+Incluído:
+
+- catálogo operacional canônico dos quatro serviços;
+- respostas comparativas e explicações de “como funciona”;
+- regras de área, múltiplos ambientes e serviços independentes;
+- sequência comercial até termos, pagamento, validação humana e briefing;
+- conhecimento sobre reunião, produção, entrega e suporte;
+- erros comerciais recuperáveis e falhas técnicas com linguagem segura;
+- transferência URBA → HUMANO com aviso visível e notificação interna;
+- retomada HUMANO → URBA com contexto completo e possível mensagem proativa;
+- controles de teste necessários para simular as decisões humanas;
+- roteiro manual obrigatório cobrindo o comportamento refinado.
+
+### 1.4 Fontes e precedência
+
+Quando houver conflito, a ordem de precedência é:
+
+1. decisão explícita da arquiteta registrada para a contratação específica;
+2. estado validado da contratação e do atendimento;
+3. esta spec e a PEE-102 de catálogo operacional;
+4. especificações comerciais anteriores;
+5. linguagem ou inferência genérica do agente.
+
+Preços, links históricos e descrições legadas não podem substituir a fonte
+canônica definida por esta feature.
+
+### 1.5 Decisões adotadas para aprovação no GO
+
+1. `PRONOUN_PREFERENCE`, `FIRST_TIME_HIRING` e `OCCUPATION` são informações
+   opcionais e não bloqueiam termos, pagamento ou briefing.
+2. Para apresentar os termos, os únicos pré-requisitos comerciais são serviço
+   confirmado, ambiente identificado e área validada quando o serviço possuir
+   limite padrão.
+3. O ambiente local pode usar links de teste claramente identificados e sem
+   valor comercial. Homologação e produção exigem recursos vigentes e
+   aprovados.
+4. A confirmação de handoff é determinística, curta e configurável; seu
+   significado não depende de texto livre produzido pelo agente.
+5. Nenhuma rejeição ou falha pode revelar sistema, ferramenta, integração,
+   banco de dados, código, HTTP, exceção, retry, idempotência ou outro detalhe
+   técnico ao cliente.
+6. Uma mensagem enviada pelo cliente enquanto a conversa está em modo humano
+   não reativa automaticamente a Urba.
+7. A retomada proativa só ocorre quando o próximo passo estiver comprovado
+   pelo estado; na dúvida, a Urba aguarda ou devolve o caso ao humano.
+
+### 1.6 Entidades de negócio
+
+- **Serviço**: tipo, nome, preço, disponibilidade, limite de área, escopo,
+  entregas, exclusões, processo, responsabilidades e recursos vigentes.
+- **Contratação**: combinação independente de cliente, serviço e ambiente.
+- **Ambiente**: espaço a ser atendido, descrição e área quando aplicável.
+- **Estado comercial**: descoberta, serviço sugerido, serviço confirmado,
+  termos apresentados, termos aceitos, pagamento aguardado, pagamento em
+  validação, pagamento confirmado e briefing.
+- **Estado operacional**: briefing, agendamento, produção, entrega, suporte e
+  encerramento.
+- **Aceite de termos**: versão/recurso, contratação, envio, resposta textual e
+  datas de auditoria.
+- **Pagamento**: método, instrução vigente, comprovante recebido e decisão
+  humana de validação.
+- **Handoff humano**: motivo, resumo, responsabilidade atual, época da
+  responsabilidade e estado de retomada.
+- **Decisão humana**: orientação específica da arquiteta que prevalece sobre o
+  catálogo geral naquele caso.
+- **Mensagem canônica**: mensagem recebida ou enviada que compõe o histórico
+  visível e a reidratação de contexto.
+
+## 2. Comportamentos esperados
+
+### 2.1 Cenário prioritário A — descoberta e explicação do serviço
+
+1. Dado um novo contato, quando o cliente iniciar a conversa, então a Urba deve
+   se identificar brevemente como assistente virtual da Urbana do Brasil e
+   perguntar o que ele deseja transformar.
+2. Dado que o cliente descreva uma necessidade, quando ainda faltar contexto,
+   então a Urba deve fazer uma pergunta curta por vez.
+3. Dado um quarto infantil em que o cliente quer pintura temática e pretende
+   manter os móveis, quando a necessidade estiver clara, então a Urba deve
+   sugerir Decor Pintura como hipótese, resumir o motivo e pedir confirmação.
+4. Dado que o cliente pergunte a diferença entre Decor Interiores e Decor
+   Pintura, quando a Urba responder, então deve distinguir layout/mobiliário de
+   pintura/desenhos/tintas, informar o limite apenas de Interiores e não afirmar
+   que Pintura possui limite de área.
+5. Dado que o cliente confirme Decor Pintura e pergunte “como funciona”, quando
+   a Urba responder, então deve explicar em linguagem curta e progressiva a
+   consultoria online, o Manual, o Tour Virtual, as três opções, as duas rodadas
+   e os próximos passos comerciais.
+6. Dado que o cliente peça mais detalhes, quando a conversa continuar, então a
+   Urba deve poder explicar responsabilidades, materiais, execução, prazo e
+   suporte sem inventar ou encaminhar desnecessariamente.
+
+### 2.2 Cenário prioritário B — termos, pagamento e briefing
+
+1. Dado serviço, ambiente e área aplicável confirmados, quando o cliente quiser
+   contratar, então a Urba deve apresentar os termos sem exigir dados opcionais
+   de perfil.
+2. Dado que os termos tenham sido apresentados, quando o cliente responder de
+   forma ambígua, então a Urba deve pedir um aceite textual claro e não liberar
+   pagamento.
+3. Dado aceite textual claro, quando a contratação avançar, então a Urba deve
+   perguntar o método e apresentar somente a instrução de pagamento vigente da
+   contratação.
+4. Dado que o cliente envie comprovante, quando o recebimento for registrado,
+   então a Urba deve informar que a validação será humana, confirmar a
+   transferência e parar de responder automaticamente.
+5. Dado que a pessoa responsável confirme o pagamento e devolva a conversa,
+   quando o contexto for retomado, então a Urba deve enviar proativamente o
+   briefing correto sem pedir que o cliente repita o que aconteceu.
+6. Dado briefing, medidas, fotos ou vídeos pendentes, quando o cliente pedir
+   ajuda, então a Urba deve orientar com o material oficial e escalar apenas a
+   dificuldade que não conseguir resolver.
+
+### 2.3 Cenário prioritário C — handoff solicitado pelo cliente
+
+1. Dado qualquer estágio automatizado, quando o cliente pedir uma pessoa ou a
+   arquiteta, então a transferência deve ocorrer imediatamente.
+2. No mesmo turno da transferência, o cliente deve receber exatamente uma
+   confirmação curta de que a conversa foi encaminhada.
+3. A arquiteta deve receber uma notificação interna com motivo, necessidade,
+   serviço, dúvida, etapa e estados comerciais conhecidos.
+4. Depois da confirmação, nenhuma nova resposta automática deve ser publicada
+   enquanto a responsabilidade permanecer humana.
+5. O indicador visual de atendimento humano pode complementar, mas nunca
+   substituir, a mensagem conversacional de confirmação.
+
+### 2.4 Cenário prioritário D — retorno da arquiteta para a Urba
+
+1. Dado atendimento humano em andamento, quando a arquiteta tomar uma decisão,
+   então essa decisão deve entrar no histórico canônico.
+2. Dado que a arquiteta marque a conversa como responsabilidade da Urba,
+   quando houver uma transição real HUMANO → URBA, então o histórico completo,
+   estado e decisões devem ser sincronizados antes de qualquer resposta.
+3. Dado próximo passo comprovado, quando a retomada terminar, então a Urba deve
+   reconduzir proativamente o cliente.
+4. Dado que não exista próximo passo seguro, quando a retomada terminar, então
+   a Urba deve aguardar uma nova mensagem.
+5. Dado erro terminal ou contexto insuficiente durante a retomada, então a
+   responsabilidade deve continuar ou retornar ao humano sem mensagem técnica
+   para o cliente.
+6. Marcar novamente a responsabilidade da Urba sem nova transição não pode
+   repetir sincronização nem mensagem proativa.
+
+### 2.5 Catálogo operacional obrigatório
+
+| Serviço | Preço por contratação | Área padrão | Explicação obrigatória |
+|---|---:|---|---|
+| Decor Interiores | R$ 400 | Até 20 m² por ambiente | Ambiente interno com layout, mobiliário, cores, materiais e composição; sem intervenção estrutural. |
+| Decor Pintura | R$ 250 | Sem limite de m² | Pintura, desenhos e especificação de tintas; não inclui layout, mobiliário nem ensino prático de pintura. |
+| Decor Fachada | R$ 350 | Sem limite de m² | Fachada, muro ou parede externa; pode considerar revestimentos, portão, iluminação e paisagismo conforme decisão da arquiteta. |
+| Decor Reforma | R$ 450 | Até 20 m² por ambiente | Solução para reforma interna; demandas técnicas específicas dependem de avaliação da arquiteta. |
+
+Entregas comuns aos quatro serviços:
+
+- Manual em PDF;
+- Tour Virtual, normalmente vídeo renderizado por link não listado;
+- três opções de solução;
+- duas rodadas consolidadas de ajustes;
+- suporte de três meses após a entrega para dúvidas sobre Manual e cores.
+
+Regras que a Urba deve conhecer e aplicar:
+
+- a Urbana presta consultoria online e não executa obra ou pintura;
+- a Urbana especifica, mas não compra materiais nem contrata profissionais;
+- o cliente compra materiais, contrata mão de obra e responde pela execução;
+- estoque, preços, links de compra e disponibilidade de mobiliário não são
+  garantidos;
+- o Tour Virtual é uma representação renderizada e seu detalhamento fica a
+  critério da arquiteta;
+- uma terceira rodada de ajustes é exceção decidida pela arquiteta e não pode
+  ser prometida;
+- o suporte não inclui visita, gestão de obra ou garantia do resultado;
+- múltiplos ambientes e serviços distintos são contratações independentes;
+- a Urba não oferece descontos;
+- pessoas e pequenos negócios de qualquer região do Brasil podem contratar.
+
+### 2.6 Processo operacional que deve ser explicável
+
+1. descoberta e confirmação do serviço/ambiente;
+2. apresentação dos termos e aceite textual independente;
+3. pagamento integral antecipado, ainda que parcelado;
+4. envio do comprovante e validação humana;
+5. envio do briefing após pagamento confirmado;
+6. envio obrigatório de medidas, fotos e/ou vídeos;
+7. validação dos dados pela arquiteta;
+8. agendamento pelo link de disponibilidade da arquiteta;
+9. reunião online pelo Google Meet;
+10. início da produção na data acordada;
+11. prazo padrão de sete dias úteis a partir do início de produção;
+12. pausa do prazo enquanto o cliente estiver pendente de feedback ou
+    aprovação;
+13. aprovação final explícita pelo cliente;
+14. entrega formal por e-mail do Manual e do Tour Virtual;
+15. suporte de três meses pelo WhatsApp.
+
+### 2.7 Contrato de falhas e respostas seguras
+
+| Situação | Comportamento visível esperado |
+|---|---|
+| Dado comercial obrigatório ausente | Fazer uma pergunta curta para coletar o dado necessário. |
+| Dado opcional de perfil ausente | Continuar o fluxo sem bloquear. |
+| Área desconhecida em Interiores/Reforma | Ajudar a estimar/medir; escalar apenas se a dificuldade persistir. |
+| Área acima de 20 m² em Interiores/Reforma | Informar o limite padrão e encaminhar para avaliação, sem prometer exceção. |
+| Link vigente indisponível | Não usar link legado; confirmar encaminhamento humano para obtenção segura. |
+| Recurso temporariamente indisponível | Não mencionar tecnologia; tentar a recuperação segura prevista ou encaminhar com aviso claro. |
+| Repetição da mesma ação | Reutilizar o resultado anterior ou aguardar, sem duplicar mensagem, aceite, cobrança ou handoff. |
+| Falha após resultado possivelmente concluído | Verificar o estado antes de repetir a ação. |
+| Falha terminal de retomada | Manter o atendimento humano e gerar alerta somente interno. |
+
+Frases proibidas incluem, sem se limitar a:
+
+- “o sistema não concluiu”;
+- “tive um erro interno”;
+- “a ferramenta falhou”;
+- “a API/banco/integração está indisponível”;
+- códigos, exceções ou detalhes de retry.
+
+## 3. Critérios de aceite
+
+### 3.1 Catálogo e conhecimento
+
+- **FR-001**: deve existir uma única fonte canônica consumida pelo atendimento
+  para os fatos operacionais dos serviços.
+- **FR-002**: os quatro serviços devem estar disponíveis e usar nome, preço e
+  limite de área definidos nesta spec.
+- **FR-003**: o catálogo deve representar escopo, entregas, exclusões,
+  responsabilidades, processo, suporte e disponibilidade de cada serviço.
+- **FR-004**: a explicação de Decor Pintura nunca deve aplicar limite de área.
+- **FR-005**: a explicação de Decor Interiores/Reforma deve validar 20 m² por
+  ambiente e encaminhar exceções à arquiteta.
+- **FR-006**: perguntas comparativas devem usar diferenças factuais, sem
+  declarar ausência de informação que já esteja no catálogo.
+- **FR-007**: respostas sobre “como funciona” devem começar curtas e permitir
+  aprofundamento progressivo.
+- **FR-008**: links legados ou não aprovados não podem aparecer como recurso
+  comercial vigente.
+- **FR-009**: uma atualização do catálogo deve valer para novas conversas sem
+  criar uma segunda fonte concorrente.
+
+### 3.2 Conversa e avanço comercial
+
+- **FR-010**: a abertura deve identificar a Urba e conter uma única pergunta
+  simples sobre o espaço ou necessidade.
+- **FR-011**: a sugestão de serviço deve ser apresentada como hipótese, com
+  mini resumo e pedido de confirmação.
+- **FR-012**: a confirmação comercial do serviço deve ser separada do aceite
+  formal dos termos.
+- **FR-013**: dados opcionais de ICP não podem bloquear nenhuma etapa.
+- **FR-014**: serviço, ambiente e área aplicável são os únicos dados de
+  qualificação exigidos antes dos termos.
+- **FR-015**: mudança de serviço antes do pagamento deve invalidar os termos da
+  contratação anterior e reiniciar termos/aceite para a nova contratação.
+- **FR-016**: múltiplos ambientes ou serviços devem manter estados e aceites
+  independentes.
+- **FR-017**: nenhuma ação de pagamento pode ocorrer antes de aceite textual
+  claro e auditável.
+- **FR-018**: “ok”, reação, silêncio ou pagamento não contam como aceite.
+- **FR-019**: comprovante recebido deve permanecer pendente até decisão humana.
+- **FR-020**: briefing só pode ser liberado após pagamento confirmado por
+  pessoa autorizada.
+
+### 3.3 Falhas seguras
+
+- **FR-021**: toda rejeição esperada deve indicar internamente o dado ou estado
+  ausente e oferecer uma próxima ação segura.
+- **FR-022**: uma rejeição esperada não pode ser classificada como pane técnica
+  na conversa.
+- **FR-023**: falhas técnicas devem ser sanitizadas antes de qualquer texto
+  visível ao cliente.
+- **FR-024**: nenhum texto visível pode conter os termos técnicos proibidos da
+  seção 2.7 ou detalhes equivalentes.
+- **FR-025**: o atendimento nunca pode ficar silenciosamente preso; deve
+  perguntar, aguardar explicitamente ou encaminhar.
+- **FR-026**: retries e replays não podem duplicar termos, aceite, instrução de
+  pagamento, comprovante, notificação ou mensagem.
+- **FR-027**: o comportamento seguro deve ser o mesmo em resposta normal,
+  timeout e reconciliação posterior.
+
+### 3.4 Handoff e responsabilidade humana
+
+- **FR-028**: pedido explícito de humano deve ser detectado em qualquer etapa e
+  processado antes de nova tentativa comercial.
+- **FR-029**: a mensagem que dispara o handoff deve receber exatamente uma
+  confirmação canônica visível.
+- **FR-030**: a mudança para modo humano só pode impedir mensagens automáticas
+  posteriores à confirmação, não a própria confirmação.
+- **FR-031**: a notificação interna deve conter o resumo mínimo definido na
+  PEE-102 sem aparecer para o cliente.
+- **FR-032**: mensagens recebidas durante modo humano devem ser persistidas e
+  disponibilizadas à arquiteta sem resposta da Urba.
+- **FR-033**: o indicador visual de ownership deve ser consistente com o
+  histórico, mas não deve ser tratado como fala da Urba.
+- **FR-034**: uma transferência repetida não deve criar confirmações ou
+  notificações duplicadas.
+
+### 3.5 Retomada HUMANO → URBA
+
+- **FR-035**: somente uma transição real de responsabilidade pode iniciar a
+  retomada.
+- **FR-036**: nenhuma resposta pode ser enviada antes da sincronização e da
+  decisão de retomada terminarem com sucesso.
+- **FR-037**: histórico completo, decisões humanas e estado operacional devem
+  estar disponíveis ao atendimento retomado.
+- **FR-038**: o cliente não pode ser responsabilizado por repetir decisões da
+  arquiteta.
+- **FR-039**: decisão específica da arquiteta deve prevalecer sobre regra geral
+  compatível com a contratação.
+- **FR-040**: próximo passo comprovado deve gerar no máximo uma mensagem
+  proativa.
+- **FR-041**: ausência de próximo passo deve resultar em espera, sem mensagem
+  inventada.
+- **FR-042**: falha terminal deve manter/devolver o ownership humano e gerar
+  somente observabilidade interna.
+- **FR-043**: repetição, reordenação ou timeout não podem repetir histórico nem
+  ação proativa.
+
+### 3.6 Processo posterior e suporte
+
+- **FR-044**: briefing, medidas, fotos e vídeos devem ser tratados como
+  pré-requisitos da reunião/produção.
+- **FR-045**: envio do link de agendamento deve transferir a responsabilidade
+  formal à arquiteta.
+- **FR-046**: decisões sobre reunião, produção, opções, ajustes, prazo e entrega
+  devem permanecer sob responsabilidade da arquiteta.
+- **FR-047**: prazo deve ser explicado como sete dias úteis a partir do início
+  acordado, com pausa por pendência do cliente.
+- **FR-048**: aprovação final deve ser explícita; silêncio não vale como
+  aprovação.
+- **FR-049**: entrega deve ser descrita como envio por e-mail do Manual PDF e
+  link do Tour Virtual.
+- **FR-050**: suporte deve ser descrito como três meses de dúvidas sobre Manual
+  e cores, sem visita ou gestão da execução.
+
+### 3.7 Critérios mensuráveis de sucesso
+
+- **SC-001**: 100% dos quatro serviços passam na matriz factual de nome, preço,
+  área, escopo e entregas.
+- **SC-002**: o roteiro prioritário do quarto infantil chega aos termos sem
+  handoff inesperado, bloqueio de ICP ou afirmação incorreta sobre área.
+- **SC-003**: 100% das perguntas “como funciona” usadas no roteiro recebem
+  explicação suficiente sem alegar falta de informação existente.
+- **SC-004**: 100% dos casos de rejeição controlada resultam em pergunta ou
+  encaminhamento seguro; 0% expõem detalhes internos.
+- **SC-005**: cada handoff solicitado gera exatamente uma mensagem visível e
+  exatamente uma notificação interna.
+- **SC-006**: nenhuma mensagem automática é enviada após a confirmação enquanto
+  o ownership permanecer humano.
+- **SC-007**: em retomada com próximo passo conhecido, o cliente recebe no
+  máximo uma mensagem proativa e não precisa repetir contexto.
+- **SC-008**: 100% dos cenários manuais obrigatórios da seção 5.4 passam em uma
+  execução limpa antes de promover a feature.
+
+## 4. Edge Cases
+
+- Cliente fornece nome, mas não preferência de tratamento, ocupação ou histórico
+  de contratação.
+- Cliente quer pintura temática e reaproveitar móveis; a Urba deve diferenciar
+  Pintura de Interiores sem prometer layout em Pintura.
+- Cliente não sabe a metragem ou informa medida aproximada.
+- Cliente pede Interiores/Reforma acima de 20 m².
+- Cliente contrata dois ambientes ou dois serviços no mesmo ambiente.
+- Cliente muda de serviço depois dos termos, mas antes do pagamento.
+- Cliente responde “ok” aos termos.
+- Cliente envia comprovante antes de aceitar termos.
+- Cliente envia comprovante duplicado.
+- Recurso de termos ou pagamento não está vigente.
+- A mesma ação comercial é repetida após timeout.
+- O agente tenta avançar sem dado comercial obrigatório.
+- O cliente pede humano no mesmo turno em que o agente pretendia avançar.
+- O handoff é solicitado duas vezes.
+- O agente gera texto de confirmação depois que a ferramenta já mudou o modo
+  para humano.
+- Chega nova mensagem do cliente durante atendimento humano.
+- A arquiteta devolve a conversa sem registrar decisão nem próximo passo.
+- A arquiteta devolve a conversa com decisão específica diferente da regra
+  geral.
+- A retomada recebe histórico repetido, atrasado ou fora de ordem.
+- A sincronização conclui, mas a decisão de retomada falha.
+- A mensagem proativa é confirmada, mas a resposta ao acionador sofre timeout.
+- O cliente pede orientação prática para pintar, instalar ou executar obra.
+- O cliente pede desconto, reembolso, cancelamento ou decisão técnica.
+- O cliente pergunta por estoque, preço atual ou link de todos os materiais.
+- O cliente fica pendente de feedback durante o prazo de produção.
+- O cliente não aprova explicitamente a entrega.
+
+## 5. Observabilidade e validação
+
+### 5.1 Validação automatizada obrigatória
+
+- testes de contrato do catálogo para os quatro serviços;
+- testes de comparação entre serviços e regras de área;
+- testes do avanço comercial com ICP opcional;
+- testes de termos, aceite ambíguo, mudança de serviço e contratações
+  independentes;
+- testes de falhas recuperáveis e sanitização de falhas técnicas;
+- testes de idempotência para ações comerciais e handoff;
+- testes de confirmação canônica do handoff;
+- testes que garantam silêncio automático somente após a confirmação;
+- testes de retomada com contexto, decisão humana, ação proativa e espera;
+- testes de timeout/reconciliação com a mesma semântica do caminho normal;
+- testes de projeção do frontend separando mensagem de confirmação e indicador
+  de atendimento humano;
+- regressão do contrato Hermes e do isolamento do ambiente local.
+
+### 5.2 Observabilidade interna
+
+Cada turno comercial relevante deve permitir correlacionar internamente:
+
+- contratação, conversa e turno;
+- estágio antes/depois;
+- ação comercial solicitada;
+- resultado seguro ou classe de falha;
+- handoff e ownership;
+- sincronização/decisão de retomada;
+- criação ou supressão justificada de mensagem canônica.
+
+Logs e métricas não devem registrar conteúdo integral de cliente, segredos,
+links sensíveis ou detalhes desnecessários. A observabilidade deve distinguir
+rejeição de negócio, falha técnica, duplicidade, timeout e bloqueio humano.
+
+### 5.3 Pré-condições do ambiente manual
+
+O ambiente de validação deve oferecer meios seguros de:
+
+- iniciar uma conversa limpa como cliente;
+- observar mensagens canônicas e ownership;
+- atuar como arquiteta durante o modo humano;
+- registrar pagamento confirmado ou recusado;
+- registrar decisão humana e devolver a responsabilidade à Urba;
+- simular briefing recebido/validado, agendamento e entrega;
+- usar termos, pagamento e briefing de teste inequivocamente não produtivos;
+- inspecionar o resultado sem expor detalhes internos ao cliente.
+
+### 5.4 Roteiro manual obrigatório
+
+#### Roteiro A — conversa principal do quarto infantil
+
+1. Iniciar uma conversa nova e informar nome.
+2. Descrever quarto infantil com dinossauros/dragões.
+3. Informar que deseja pintura e reaproveitamento dos móveis.
+4. Confirmar que a Urba sugere Decor Pintura sem aplicar limite de área.
+5. Perguntar a diferença entre Decor Pintura e Decor Interiores.
+6. Confirmar Decor Pintura.
+7. Perguntar “como funciona esse serviço?”.
+8. Pedir detalhes sobre entregas, execução, materiais, prazo e suporte.
+9. Confirmar que a Urba responde com o catálogo refinado, sem encaminhar e sem
+   mencionar falta de informação.
+10. Pedir contratação e confirmar que os termos são apresentados sem coleta
+    obrigatória de ocupação, pronome ou primeira contratação.
+11. Responder “ok” e confirmar que o pagamento não é liberado.
+12. Dar aceite textual claro e escolher método de pagamento.
+13. Confirmar instrução de teste vinculada à contratação correta.
+14. Enviar comprovante de teste.
+15. Confirmar mensagem de validação humana e exatamente uma confirmação de
+    handoff.
+16. Confirmar que mensagens posteriores não recebem automação durante modo
+    humano.
+17. Como arquiteta, validar o pagamento e devolver a conversa à Urba.
+18. Confirmar que a Urba retoma com contexto e envia proativamente o briefing
+    correto, sem pedir repetição.
+
+#### Roteiro B — dificuldade no briefing e retorno
+
+1. Durante briefing, relatar dificuldade simples de medir o ambiente.
+2. Confirmar orientação com o material oficial.
+3. Persistindo a dificuldade, pedir a arquiteta e confirmar o aviso de handoff.
+4. Como arquiteta, registrar orientação específica e devolver a conversa.
+5. Confirmar que a Urba respeita a orientação e reconduz ao briefing sem exigir
+   que o cliente conte novamente o que foi decidido.
+
+#### Roteiro C — agendamento, entrega e suporte simulados
+
+1. Registrar briefing, medidas e mídia como validados.
+2. Confirmar envio do link de agendamento e transferência para humano.
+3. Como arquiteta, registrar reunião, decisão e entrega simulada.
+4. Devolver a conversa à Urba após a entrega.
+5. Perguntar sobre Manual, Tour Virtual, ajustes e suporte.
+6. Confirmar respostas corretas e encaminhamento apenas para decisões
+   específicas da arquiteta.
+
+#### Roteiro D — falhas e proteções
+
+1. Repetir uma ação comercial e confirmar ausência de duplicidade.
+2. Simular dado comercial obrigatório ausente e confirmar pergunta segura.
+3. Simular recurso de teste indisponível e confirmar que nenhuma fala menciona
+   sistema, ferramenta ou código técnico.
+4. Solicitar humano duas vezes e confirmar uma única mensagem/notificação.
+5. Repetir a devolução HUMANO → URBA e confirmar uma única retomada proativa.
+
+### 5.5 Gate de aprovação manual
+
+A feature somente pode seguir para homologação quando:
+
+- todos os testes automatizados obrigatórios estiverem verdes;
+- os quatro roteiros manuais tiverem evidência registrada;
+- nenhuma fala contiver linguagem técnica proibida;
+- o histórico canônico e o ownership forem consistentes;
+- não houver link legado apresentado como vigente;
+- Emanuel aprovar a qualidade e naturalidade da conversa.
+
+## 6. Fora de escopo
+
+- deploy automático em homologação ou produção;
+- pagamento financeiro real durante o teste local;
+- validação automática do comprovante na primeira versão;
+- execução de obra, pintura, compra de materiais ou contratação de profissional;
+- garantia de estoque, preço ou disponibilidade de produtos;
+- decisão autônoma sobre desconto, reembolso, cancelamento ou exceção técnica;
+- substituição da arquiteta em reunião, produção, ajustes ou aprovação;
+- envio real de e-mail/WhatsApp no ambiente local, quando um adaptador de teste
+  puder comprovar o mesmo contrato;
+- simulação do decurso real de sete dias úteis;
+- alta disponibilidade do ambiente local;
+- uso de memória global do agente como fonte canônica de negócio.
+
+## 7. Dúvidas em aberto
+
+Não há pergunta de negócio bloqueante para planejar após o GO. O GO de Emanuel
+aprovará também as decisões da seção 1.5.
+
+Pendências operacionais que devem ser resolvidas no planejamento, sem alterar o
+contrato desta spec:
+
+- definir a origem e a governança dos recursos vigentes de termos, pagamento,
+  briefing e agendamento para cada ambiente;
+- definir como o ambiente local simulará as ações exclusivas da arquiteta;
+- associar esta feature ao ticket Jira de implementação e às dependências
+  formais de PEE-103/PEE-104;
+- definir quais evidências dos roteiros serão anexadas ao Jira/PR.

--- a/specs/008-complete-urba-service-flow/tasks.md
+++ b/specs/008-complete-urba-service-flow/tasks.md
@@ -1,0 +1,211 @@
+# Tasks: Atendimento comercial completo e seguro da Urba
+
+**Input**: artefatos de design em `/specs/008-complete-urba-service-flow/`
+**Prerequisites**: `spec.md`, `plan.md`, `baseline.md`, `research.md`,
+`data-model.md`, `contracts/` e `quickstart.md`
+**Execution model**: delta sobre baseline reconciliado com lacunas; nenhum checkbox de
+produto é concluído apenas porque o arquivo já existe ou está modificado.
+
+**Estado em 2026-08-26**: T007–T048 foram implementadas e verificadas por
+testes locais focados; o Compose/Hermes foi iniciado e o smoke conversacional
+feliz passou pela API. T051, T053 e T055–T058 permanecem pendentes por falta de
+Playwright live, pela suíte legada ainda vermelha/coverage abaixo do limite,
+pelos cinco roteiros manuais e pelo aceite/PR humano.
+
+## Phase 1: Gates de execução e reconciliação do baseline
+
+**Purpose**: tornar o estado local rastreável e seguro antes do primeiro
+escritor. T001–T006 foram executadas; o resultado e as lacunas estão congelados
+em `baseline.md`.
+
+- [x] T001 Com o GO de execução, criar a subtarefa `PEE-105` sob PEE-23, registrar a chave e as dependências PEE-102/PEE-103/PEE-104 em `specs/008-complete-urba-service-flow/spec.md` e mover a issue para `Em andamento` antes do primeiro escritor
+- [x] T002 Preservar o snapshot atual e migrar/renomear a branch descendente de `hml` para `feature/008-complete-urba-service-flow`, registrando branch e `git status` em `specs/008-complete-urba-service-flow/baseline.md`
+- [x] T003 Atualizar o inventário inicial do diff preexistente por slice e associar arquivos modificados aos requisitos/tarefas em `specs/008-complete-urba-service-flow/baseline.md`
+- [x] T004 Executar os testes focados já existentes de catálogo, handoff, retomada, plugin e POC e classificar cada slice como aproveitável, incompleto, conflitante ou fora de escopo em `specs/008-complete-urba-service-flow/baseline.md`
+- [x] T005 Comparar o seeder duplicado legado com o canônico, removê-lo do source set por conter uma segunda classe pública e preservá-lo em `docs/plans/legacy-review/ServiceCatalogSeeder 2.java`, registrando a decisão não destrutiva em `specs/008-complete-urba-service-flow/baseline.md`
+- [x] T006 Atualizar os checkboxes desta fila somente para itens comprovados pelo gate e congelar o mapa do delta remanescente em `specs/008-complete-urba-service-flow/tasks.md`
+
+**Checkpoint**: ticket e branch conformes; todo diff conhecido está preservado,
+classificado e coberto por evidência proporcional.
+
+## Phase 2: Contratos executáveis compartilhados
+
+**Purpose**: fixar invariantes antes de completar qualquer comportamento.
+
+- [x] T007 [P] Reconciliar testes-base da matriz dos quatro serviços, área, preço, entregas e ausência de `DECOR` legado em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/CommercialPolicyServiceTest.java` e `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolServiceTest.java`
+- [x] T008 [P] Reconciliar testes do plugin para envelopes seguros e ausência de exceção, HTTP, URL interna, identificador ou evento técnico no retorno ao Hermes em `integrations/hermes-agent/plugins/urbana-domain/test_tools.py`
+- [x] T009 [P] Reconciliar testes de confirmação visível, ownership humano e idempotência do handoff em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionOrchestratorTest.java` e `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/HumanHandoffServiceTest.java`
+- [x] T010 [P] Reconciliar testes de transição HUMANO → URBA e ausência de resposta antes da sincronização em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationTest.java` e `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/ReceptionConversationTest.java`
+
+**Checkpoint**: testes compartilhados falham somente para deltas reais e não
+codificam uma máquina de estado autoritativa do ICP.
+
+## Phase 3: User Story 1 — catálogo e explicação progressiva (P1 / MVP)
+
+**Goal**: a Urba se apresentar e explicar os quatro serviços, diferenças,
+entregas, processo, responsabilidades e limites sem inventar informação ou
+encaminhar desnecessariamente.
+
+**Independent Test**: executar a matriz factual e o Roteiro A até “como
+funciona”, verificando apresentação espontânea, explicação rica, progressiva e
+sem limite indevido para Decor Pintura/Fachada.
+
+### Tests
+
+- [x] T011 [P] [US1] Completar testes first do catálogo rico, múltiplos ambientes e regras de área em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/CommercialPolicyServiceTest.java`
+- [x] T012 [P] [US1] Completar testes first do payload de `list_available_services`, comparação e “como funciona”, comprovando que turno informativo não prepara termos, pagamento ou handoff, em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolServiceTest.java`
+- [x] T013 [P] [US1] Completar o teste de contrato do seed/adaptador único e dos quatro serviços em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/ServiceCatalogSeederTest.java`
+
+### Implementation
+
+- [x] T014 [US1] Reconciliar e completar o modelo rico do catálogo em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItem.java`, `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceType.java` e `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/servicecatalog/model/AreaRule.java`
+- [x] T015 [US1] Reconciliar a fonte canônica de preço, área, processo, entregas, exclusões, responsabilidades e suporte em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/CommercialPolicyService.java`
+- [x] T016 [US1] Reconciliar seed, documento e gateway Mongo com a fonte canônica, sem links legados ou quinto serviço, em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/ServiceCatalogSeeder.java`, `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/ServiceCatalogDocument.java` e `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/MongoServiceCatalogGateway.java`
+- [x] T017 [US1] Orientar apresentação curta, descoberta e explicação progressiva do catálogo sem script longo em `integrations/hermes-agent/profile/SOUL.md`
+- [x] T018 [US1] Verificar e atualizar o payload rico consumido pelo Hermes em `specs/008-complete-urba-service-flow/contracts/reception-domain-tools.md`
+
+**Checkpoint**: a Urba se apresenta e responde “diferença/como funciona” com o
+catálogo correto, sem handoff precoce nem linguagem interna.
+
+## Phase 4: User Story 2 — ICP, termos, pagamento e briefing (P1)
+
+**Goal**: o SOUL coletar enriquecimento de lead no momento certo e o backend
+manter somente fatos, proteções comerciais e observabilidade, sem controlar ou
+travar o diálogo por ICP.
+
+**Independent Test**: Roteiros A (passos 10–19) e E, mais injeção técnica
+controlada de SC-014. O fluxo normal coleta antes dos termos; o desvio direto
+emite evento interno e mantém a preparação funcional.
+
+### Tests
+
+- [x] T019 [P] [US2] Completar testes first de fatos globais, valor explícito mais recente, `NÃO INFORMADO`, reutilização e ausência de inferência em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionResponsePolicyTest.java` e `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReturningCustomerServiceTest.java`
+- [x] T020 [P] [US2] Testar que serviço/ambiente/área e aceite continuam sendo hard protections, ICP incompleto nunca rejeita `prepare_terms` e `TERMS=PRESENTED` só nasce após solicitação/apresentação efetiva, em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/CommercialPolicyServiceTest.java`
+- [x] T021 [P] [US2] Escrever teste first do `ICP_SKIPPED_BEFORE_TERMS`: exatamente um evento por chave idempotente, resultado comercial inalterado e payload limitado a ids opacos, serviço, campos ausentes, ponto de detecção e momento em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolServiceTest.java` e `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/DomainToolInvocationUseCaseTest.java`
+- [x] T022 [P] [US2] Testar reidratação da thread atual integral, mensagens humanas e fatos correntes sem projeção específica que suprima mensagens por causa do ICP em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/hermes/HttpHermesSessionsGatewayTest.java` e `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/HermesSessionServiceTest.java`
+- [x] T023 [P] [US2] Testar que o plugin transporta contexto autorizado, mas nunca evento, exceção, valor bruto em log ou controlador de tentativas em `integrations/hermes-agent/plugins/urbana-domain/test_tools.py`
+- [x] T024 [US2] Escrever antes da correção comportamental os cenários semânticos live de primeira apresentação espontânea, serviço confirmado, intenção de contratar, campos ausentes/parciais, recusa, segunda ausência, reutilização, atualização silenciosa, assunto paralelo e ICP antes dos termos em `apps/poc-chat/e2e/quality-chat.spec.ts`
+
+### Implementation
+
+- [x] T025 [US2] Reconciliar modelos/políticas de fatos globais, versionamento, valor corrente e cálculo de campos ausentes sem `ICPCheckpointState` ou contador conversacional em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/`, `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionResponsePolicy.java` e `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReturningCustomerService.java`
+- [x] T026 [US2] Reconciliar a gravação de fatos explícitos e implementar o evento idempotente sem alterar o envelope de termos nem expô-lo ao Hermes/cliente em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolService.java` e `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/DomainToolInvocationUseCase.java`
+- [x] T027 [US2] Codificar no SOUL o gatilho após serviço/intenção, bloco curto de campos ausentes, uma única segunda oportunidade, recusa/ausência como `NÃO INFORMADO`, avanço automático, assunto paralelo, handoff e retomada pela thread em `integrations/hermes-agent/profile/SOUL.md`
+- [x] T028 [US2] Garantir thread atual integral e fatos correntes na sessão, sem filtro específico de ICP e sem usar fala da arquiteta como fato do cliente, em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/hermes/HttpHermesResumeGateway.java`, `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/hermes/HttpHermesSessionsGateway.java`, `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/HermesSessionService.java` e `integrations/hermes-agent/plugins/urbana-domain/tools.py`
+- [x] T029 [US2] Reconciliar as proteções de aceite claro, pagamento antecipado e briefing somente após confirmação na política canônica em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/CommercialPolicyService.java`
+- [x] T030 [US2] Integrar aceite, pagamento, comprovante pendente de validação humana e liberação do briefing nos boundaries/orquestração sem transformar ICP em hard gate em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolService.java` e `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionOrchestrator.java`
+
+**Checkpoint**: a conversa normal executa o ICP sem rigidez de backend; o teste
+de desvio observa a regressão sem mudar o resultado ou vazar dados.
+
+## Phase 5: User Story 3 — handoff humano visível e seguro (P1)
+
+**Goal**: pedido de humano/arquiteta gerar exatamente um aviso conversacional,
+notificação interna e bloqueio automático coerente.
+
+**Independent Test**: Roteiro A após comprovante e Roteiro D; repetir o pedido
+e confirmar uma única mensagem/notificação e silêncio automático posterior.
+
+### Tests
+
+- [x] T031 [P] [US3] Completar teste de envelope HTTP seguro sem status, stack trace ou identificador exposto em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/interfaces/rest/poc/DomainToolControllerTest.java`
+- [x] T032 [P] [US3] Completar testes de ack canônico antes do bloqueio, exatamente uma mensagem/notificação e resumo interno com campos presentes/ausentes do ICP em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionOrchestratorTest.java`
+- [x] T033 [P] [US3] Completar o mesmo contrato para timeout, replay e reconciliação em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationTest.java`
+- [x] T034 [P] [US3] Completar testes de serialização segura e mensagem neutra do plugin em `integrations/hermes-agent/plugins/urbana-domain/test_tools.py`
+
+### Implementation
+
+- [x] T035 [US3] Reconciliar falhas de negócio/técnicas como envelopes seguros em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/interfaces/rest/poc/DomainToolController.java` e `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/DomainToolInvocationUseCase.java`
+- [x] T036 [US3] Reconciliar handoff idempotente com ack determinístico persistido/publicado antes do bloqueio em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionOrchestrator.java` e `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolService.java`
+- [x] T037 [US3] Aplicar a mesma política de ack, silêncio e sanitização no caminho de reconciliação em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationService.java`
+- [x] T038 [US3] Garantir pedido explícito de humano imediato e nenhuma fala técnica em `integrations/hermes-agent/profile/SOUL.md` e `integrations/hermes-agent/plugins/urbana-domain/tools.py`
+- [x] T039 [US3] Reconciliar os comandos POC idempotentes de validação humana e notificação interna em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/interfaces/rest/poc/ConversationSimulatorController.java` e `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/interfaces/rest/poc/ConversationSimulatorControllerTest.java`
+
+**Checkpoint**: o cliente é avisado exatamente uma vez e nenhuma automação fala
+enquanto o ownership permanecer humano.
+
+## Phase 6: User Story 4 — retorno HUMANO → URBA e POC de validação (P1)
+
+**Goal**: devolver a responsabilidade por flag, sincronizar a thread canônica e
+retomar proativamente somente quando houver próximo passo comprovado.
+
+**Independent Test**: Roteiros B/C/D e retorno durante ICP; repetir a mesma
+transição e verificar uma sincronização, uma mensagem proativa ou espera segura.
+
+### Tests
+
+- [x] T040 [P] [US4] Completar testes de transição real, epoch/versão, decisões humanas e idempotência em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/ReceptionConversationTest.java` e `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationTest.java`
+- [x] T041 [P] [US4] Completar testes de contexto integral, decisão proativa/espera e retorno ao humano em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/hermes/HttpHermesSessionsGatewayTest.java` e `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/HermesSessionServiceTest.java`
+- [x] T042 [P] [US4] Completar testes de ownership, ack, controles locais e mensagens canônicas não editáveis em `apps/poc-chat/src/components/ChatView.test.tsx`, `apps/poc-chat/src/state/conversationReducer.handoff.test.ts` e `apps/poc-chat/src/api/contracts.test.ts`
+
+### Implementation
+
+- [x] T043 [US4] Reconciliar contrato de retomada e proteção contra resposta antes da sincronização em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionOrchestrator.java`, `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationService.java` e `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/port/out/HermesResumeGateway.java`
+- [x] T044 [US4] Reconciliar decisões humanas, boundary do transcript, falha terminal e no-op de retorno repetido em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/` e `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/`
+- [x] T045 [US4] Reconciliar projeção e controles determinísticos da arquiteta em `apps/poc-chat/src/api/`, `apps/poc-chat/src/state/`, `apps/poc-chat/src/components/ArchitectControls.tsx` e `apps/poc-chat/src/App.tsx`
+- [x] T046 [US4] Garantir ack como mensagem e ownership como estado complementar em `apps/poc-chat/src/components/ChatView.tsx` e `apps/poc-chat/src/styles.css`
+- [x] T047 [US4] Estender o E2E para comprovante, handoff, decisão humana, retorno proativo ao briefing e retomada dos campos de ICP ainda ausentes em `apps/poc-chat/e2e/quality-chat.spec.ts`
+- [x] T048 [US4] Reconciliar build da imagem backend a partir do fonte atual, fixtures/controles não comerciais e documentação de evidências em `apps/urbana-connect-api/Dockerfile.poc.runtime-jar`, `infra/local-poc/docker-compose.poc.yml`, `infra/local-poc/README.md` e `specs/008-complete-urba-service-flow/quickstart.md`
+
+**Checkpoint**: contexto humano chega ao Hermes antes da resposta; a Urba não
+exige repetição, não inventa decisão e não repete retomada.
+
+## Phase 7: QA independente e aceite local
+
+- [x] T049 [P] Executar testes focados do catálogo/fatos e conferir SC-001 e a persistência/reutilização de SC-013, registrando comandos/resultados em `specs/008-complete-urba-service-flow/baseline.md`
+- [x] T050 [P] Executar testes focados de SOUL, plugin, handoff, retomada e falhas seguras; conferir SC-004–SC-008 e procurar frases proibidas/valores brutos em `apps/urbana-connect-api/` e `integrations/hermes-agent/`
+- [ ] T051 [P] Executar Vitest, build e Playwright live; conferir SC-002, SC-003, SC-005–SC-007, SC-009 e SC-011–SC-013, anexando o relatório gerado por `apps/poc-chat/e2e/quality-chat.spec.ts`
+- [x] T052 Executar a injeção controlada de SC-014 e comprovar um evento idempotente, resultado de termos inalterado e nenhuma exposição no contrato/log de teste em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolServiceTest.java`
+- [ ] T053 Executar a suíte backend, build, quality gate JaCoCo mínimo de 60%, rebuild da imagem local e healthcheck para conferir SC-010 em `apps/urbana-connect-api/` e `infra/local-poc/`
+- [x] T054 Verificar por inspeção que não existe `ICPCheckpointState`, `attemptsByField` ou hard gate de ICP no código de produto e registrar a evidência em `specs/008-complete-urba-service-flow/baseline.md`
+- [ ] T055 Executar os cinco roteiros manuais da seção 5.4 e registrar transcript, ownership, ids, estado factual do ICP e evidências em `specs/008-complete-urba-service-flow/quickstart.md`
+- [ ] T056 Revisar FR-001–FR-064, SC-001–SC-014, checklist, baseline e riscos residuais antes de solicitar a aprovação manual de Emanuel em `specs/008-complete-urba-service-flow/checklists/requirements.md`
+
+## Phase 8: Rastreabilidade e PR para homologação
+
+- [ ] T057 Após aceite local explícito, abrir PR de `feature/008-complete-urba-service-flow` para `hml` com objetivo, resumo, validações, riscos e ticket Jira, registrar o link em `specs/008-complete-urba-service-flow/baseline.md` e mover a issue para `Awaiting approval`
+- [ ] T058 Após aprovação humana e merge, registrar a evidência em `specs/008-complete-urba-service-flow/baseline.md` e mover a issue para `Concluído`; não promover para `main` ou fazer deploy por esta tarefa
+
+## Dependencies & Execution Order
+
+```text
+Gate 0: T001–T006
+        └── contratos: T007–T010
+             ├── Writer A: T011/T013–T016 → US2 T019–T020/T025/T029
+             ├── Writer B: T012/T017 → US2 T021–T023/T026–T028/T030 → US3 T031–T039 → US4 T040–T041/T043–T044
+             └── Writer C: US2 T024 → US4 T042/T045–T048
+                        └── todos os escritores param → QA T049–T056
+                                                        └── PR T057–T058
+```
+
+- T001–T006 são bloqueantes; nenhum subagente escritor começa antes do gate.
+- Writer A tem exclusividade sobre catálogo, fatos, política comercial e
+  persistência correspondente (`domain/servicecatalog`, `CustomerFact*`,
+  `CommercialPolicyService`, `ReceptionResponsePolicy`,
+  `ReturningCustomerService`, `ReceptionConversation` e testes diretamente
+  desses módulos). Em T007, A edita somente a parte de catálogo/política.
+- Writer B tem exclusividade sobre orquestração, ferramentas/boundaries,
+  adaptador Hermes, plugin e SOUL (`StatefulDomainToolService`,
+  `DomainToolInvocationUseCase`, `ReceptionOrchestrator`, reconciliação,
+  sessões, controllers e testes diretamente desses módulos). Em T007, B edita
+  somente a parte do payload/tool service. T026 e T030 pertencem a B.
+- Writer C tem exclusividade sobre POC, E2E, compose, Dockerfile da POC e
+  documentação operacional local. Nenhum writer edita `spec.md`, `plan.md`,
+  `tasks.md` ou `baseline.md`; a thread principal mantém esses artefatos.
+- Writer C tem exclusividade sobre POC, E2E, proxy/compose e documentação local;
+  `quality-chat.spec.ts` é escrito serialmente em T024 e T047.
+- T024 deve existir/falhar pelo comportamento ausente antes de T027–T030 quando
+  tecnicamente aplicável; T047 depende dos contratos estabilizados de US3/US4.
+- QA é T049–T056 e começa somente quando A/B/C pararem de escrever.
+- T057 exige aceite local de Emanuel; T058 exige aprovação e merge humanos.
+
+## Implementation Strategy
+
+1. Executar Gate 0 e converter o diff existente em delta verificável.
+2. Fixar os contratos executáveis T007–T010.
+3. Usar no máximo três escritores com ownership disjunto; reutilizar o mesmo
+   escritor para correções no próprio slice.
+4. Fazer TDD no comportamento ausente e preservar testes válidos já existentes.
+5. Submeter o resultado a QA independente e aos cinco roteiros manuais.
+6. Só após aceite explícito abrir PR para `hml`; não fazer deploy nem promoção
+   para `main` neste ciclo.


### PR DESCRIPTION
## Objetivo
Levar para `hml` o fluxo conversacional completo da Urba, com catálogo operacional rico, condução progressiva até contratação, coleta de ICP, handoff humano observável e retomada contextual pelo Hermes.

## Principais mudanças
- Atualiza o SOUL e o plugin de domínio do Hermes com identidade, catálogo dos quatro serviços, limites, escopo, suporte e regras comerciais.
- Implementa as guardrails de serviço, aceite, ICP, pagamento e comprovante, sem expor detalhes internos ao cliente.
- Implementa handoff humano com notificação, silêncio enquanto a arquiteta é responsável, aprovação do pagamento e retomada proativa Urba → Hermes.
- Persiste eventos de ICP, notificações e contexto de retomada; atualiza o catálogo Mongo e a infraestrutura da POC local.
- Adiciona controles de arquiteta no chat e um cenário E2E de qualidade cobrindo o fluxo completo.
- Registra spec, plano, contratos, modelo de dados, baseline, quickstart e decisões PEE-102/PEE-23.

## Validação
- Plugin Urbana Domain: 14 testes unitários aprovados.
- Frontend: 81 testes Vitest aprovados, typecheck, lint e build aprovados.
- Backend: suíte focada de recepção/políticas/ferramentas aprovada em JDK 21; build da imagem aprovado.
- E2E ao vivo com API, Mongo, Hermes e frontend: 1 cenário aprovado em 4m.
- Readiness da API `READY` e health do frontend `ok`.
- Fluxo validado manualmente após a última correção.

## Observações
- Os links de pagamento usados no ambiente local são fixtures; os links comerciais permanecem os dados atuais do catálogo.
- O Hermes v1 recebe o transcript integral na retomada; fatos estruturados continuam fora do checksum/versionamento específico do contrato v1.
- Nenhum deploy de produção foi realizado.

## Rastreamento
- Ref: PEE-23
- Feature: `008-complete-urba-service-flow`