### PR TITLE
feat(urba): refine sales dialogue and consent guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,8 @@ leitura e as classes negadas são proibidas; qualquer escrita exige o gate
 separado da Fase 3.
 
 ## Active Technologies
+- Java 21 LTS; Python 3 do runtime Hermes para testes do plugin; Markdown para o perfil + Spring Boot 3.4.x, Gradle 8.x, JUnit 5, pytest/unittest do plugin, runtime Hermes existente (010-refine-urba-sales-dialogue)
+- MongoDB e transcript/invocações existentes; coleção aditiva de auditoria de aceite (010-refine-urba-sales-dialogue)
 
 - Java 21 LTS na Urbana Connect; Python fornecido pelo runtime oficial do Hermes apenas para o plugin de extensão + Spring Boot 3.4.13, Gradle 8.x, Hermes Agent Sessions API, OpenRouter (001-hermes-conversational-core)
 - MongoDB para transcript, fatos, mapeamento de sessões e execuções do corpus; SQLite interno do Hermes para sessões (001-hermes-conversational-core)

--- a/apps/poc-chat/e2e/quality-chat.spec.ts
+++ b/apps/poc-chat/e2e/quality-chat.spec.ts
@@ -135,7 +135,7 @@ test.describe('qualidade conversacional ao vivo', () => {
         latestProjection,
       );
       const initialIcpReply = lastOutboundTextFor(latestProjection, /quero contratar|contratar o decor pintura/i);
-      evidence.icpPrompt = hasAllIcpTopics(initialIcpReply)
+      evidence.icpPrompt = hasExactlyOneIcpTopic(initialIcpReply)
         && !hasTermsBeenPresented(latestProjection)
         && !hasPaymentBeenPrepared(latestProjection);
       evidence.observations.push(`campos solicitados no primeiro checkpoint: ${icpTopics(initialIcpReply).join(', ') || 'nenhum sinal semântico'}`);
@@ -143,11 +143,11 @@ test.describe('qualidade conversacional ao vivo', () => {
       latestProjection = await sendAndWait(
         page,
         alias,
-        'Pode me chamar de Dani.',
+        'Prefiro que use ela/dela.',
         latestProjection,
       );
-      const partialIcpReply = lastOutboundTextFor(latestProjection, /pode me chamar de dani/i);
-      evidence.partialIcp = hasRemainingIcpTopics(partialIcpReply)
+      const partialIcpReply = lastOutboundTextFor(latestProjection, /prefiro que use ela\/dela/i);
+      evidence.partialIcp = hasExactlyOneIcpTopic(partialIcpReply)
         && !hasTopic(partialIcpReply, 'pronoun');
       evidence.observations.push(`campos restantes após resposta parcial: ${icpTopics(partialIcpReply).join(', ') || 'nenhum sinal semântico'}`);
 
@@ -167,12 +167,7 @@ test.describe('qualidade conversacional ao vivo', () => {
         && paymentStatus(latestProjection) === 'NOT_STARTED'
         && !paymentInstructionPattern.test(normalize(ambiguousReply));
 
-      latestProjection = await sendAndWait(
-        page,
-        alias,
-        'Aceito claramente os termos apresentados e quero seguir com a contratação.',
-        latestProjection,
-      );
+      latestProjection = await sendAndWait(page, alias, 'Aceito', latestProjection);
       evidence.clearAcceptance = termsStatus(latestProjection) === 'ACCEPTED'
         && paymentStatus(latestProjection) === 'NOT_STARTED';
 
@@ -547,10 +542,11 @@ function hasServiceComparison(projection: Projection): boolean {
 function hasCatalogExplanation(projection: Projection): boolean {
   const text = normalize(repliesAfterCustomerQuestion(projection, /como funciona|detalhar entregas|o que eu recebo|processo|suporte/i).join('\n'));
   return /consultoria\s+online|online.*consultoria/.test(text)
-    && /manual/.test(text)
+    && /manual\s+do\s+espaco|manual/.test(text)
     && /tour\s+virtual/.test(text)
     && /(?:3|tres)\s+op(?:c|ç)oes?/.test(text)
-    && /(?:2|duas)\s+rodadas?/.test(text);
+    && /(?:2|duas)\s+rodadas?/.test(text)
+    && /suporte/.test(text);
 }
 
 function hasNoCommercialAdvance(projection: Projection): boolean {
@@ -559,13 +555,8 @@ function hasNoCommercialAdvance(projection: Projection): boolean {
     && ownership(projection) === 'URBA';
 }
 
-function hasAllIcpTopics(text: string): boolean {
-  return icpTopics(text).length === 3;
-}
-
-function hasRemainingIcpTopics(text: string): boolean {
-  const topics = icpTopics(text);
-  return topics.length > 0 && topics.length < 3;
+function hasExactlyOneIcpTopic(text: string): boolean {
+  return icpTopics(text).length === 1;
 }
 
 function icpTopics(text: string): string[] {
@@ -575,7 +566,9 @@ function icpTopics(text: string): string[] {
 function hasTopic(text: string, topic: 'pronoun' | 'firstTimeHiring' | 'occupation'): boolean {
   const normalized = normalize(text);
   if (topic === 'pronoun') {
-    return /pronome|tratamento|refir|cham[ae]d|senhor|senhora/.test(normalized);
+    // Keep `prefiro` (a valid refusal/example in the first-time question)
+    // from being mistaken for the pronoun stem `refir`.
+    return /\b(?:pronome|tratamento|refira|referir|chamad[ao]|senhor|senhora)\b/.test(normalized);
   }
   if (topic === 'firstTimeHiring') {
     return /primeir|contrat(ou|ar|a).*vez|ja.*contrat/.test(normalized);

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ActiveTurnLeaseService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ActiveTurnLeaseService.java
@@ -8,6 +8,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -36,10 +37,15 @@ public class ActiveTurnLeaseService {
     }
 
     public ActiveTurnLease acquire(String hermesSessionId, String turnId, String contactId, String sourceMessageId) {
+        return acquire(hermesSessionId, turnId, contactId, sourceMessageId, List.of(sourceMessageId));
+    }
+
+    public ActiveTurnLease acquire(String hermesSessionId, String turnId, String contactId, String sourceMessageId,
+                                   List<String> sourceMessageIds) {
         Instant acquired = clock.instant();
         ActiveTurnLease requested = new ActiveTurnLease(hermesSessionId, turnId, contactId, sourceMessageId,
                 br.com.urbana.connect.domain.reception.model.ActiveTurnLeaseStatus.RUNNING,
-                acquired, acquired.plus(ttl), null, 0, UUID.randomUUID().toString());
+                acquired, acquired.plus(ttl), null, 0, UUID.randomUUID().toString(), sourceMessageIds);
         return gateway.acquire(requested).orElseThrow(() -> new LeaseUnavailableException(
                 "another running turn already owns session " + hermesSessionId));
     }
@@ -111,7 +117,12 @@ public class ActiveTurnLeaseService {
 
     public <T> T withLease(String sessionId, String turnId, String contactId, String sourceMessageId,
                            Supplier<T> action) {
-        ActiveTurnLease lease = acquire(sessionId, turnId, contactId, sourceMessageId);
+        return withLease(sessionId, turnId, contactId, sourceMessageId, List.of(sourceMessageId), action);
+    }
+
+    public <T> T withLease(String sessionId, String turnId, String contactId, String sourceMessageId,
+                           List<String> sourceMessageIds, Supplier<T> action) {
+        ActiveTurnLease lease = acquire(sessionId, turnId, contactId, sourceMessageId, sourceMessageIds);
         AtomicReference<ActiveTurnLease> currentLease = new AtomicReference<>(lease);
         ScheduledExecutorService heartbeatExecutor = newHeartbeatExecutor();
         ScheduledFuture<?> heartbeatTask = scheduleHeartbeat(heartbeatExecutor, currentLease);
@@ -209,6 +220,14 @@ public class ActiveTurnLeaseService {
     public void withLease(String sessionId, String turnId, String contactId, String sourceMessageId,
                           Runnable action) {
         withLease(sessionId, turnId, contactId, sourceMessageId, () -> {
+            action.run();
+            return null;
+        });
+    }
+
+    public void withLease(String sessionId, String turnId, String contactId, String sourceMessageId,
+                          List<String> sourceMessageIds, Runnable action) {
+        withLease(sessionId, turnId, contactId, sourceMessageId, sourceMessageIds, () -> {
             action.run();
             return null;
         });

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/CommercialPolicyService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/CommercialPolicyService.java
@@ -31,6 +31,8 @@ public final class CommercialPolicyService {
     public static final String PREFER_NOT_TO_ANSWER = "PREFER_NOT_TO_ANSWER";
     private static final String PAYMENT_PROOF_PENDING_MESSAGE =
             "Recebi o comprovante. Agora ele aguarda validação humana; aviso assim que o pagamento for confirmado.";
+    private static final String TERMS_REVIEW_VERB =
+            "(?:ler|analisar|revisar|avaliar|verificar|refletir|pensar)";
     private static final List<String> MANDATORY_ICP = CustomerFactType.icpFieldNames();
     private static final List<String> ALLOWED_PAYMENT_METHODS = List.of("PIX", "CARD");
 
@@ -107,6 +109,10 @@ public final class CommercialPolicyService {
             throw new IllegalStateException("service must be selected before terms");
         }
         service(conversation.selectedService());
+        if (conversation.termsStatus() == br.com.urbana.connect.domain.reception.model.TermsStatus.ACCEPTED
+                && conversation.activeTermsConsentId() == null) {
+            return conversation.reopenTermsForAudit(Objects.requireNonNull(now, "now"));
+        }
         if (conversation.termsStatus() != br.com.urbana.connect.domain.reception.model.TermsStatus.NOT_PRESENTED
                 && conversation.termsStatus() != br.com.urbana.connect.domain.reception.model.TermsStatus.DECLINED) {
             return conversation;
@@ -139,7 +145,18 @@ public final class CommercialPolicyService {
         if (normalized.contains("nao") || normalized.contains("recuso") || normalized.contains("discordo")) {
             return false;
         }
-        return normalized.matches(".*(?:\\b(aceito|concordo)\\b.*\\btermos\\b|"
+        if (normalized.matches(".*\\b(?:aceito|concordo)\\b\\s*(?:[,;:]\\s*)?"
+                + "(?:(?:em|com|para)\\s+)?\\b" + TERMS_REVIEW_VERB + "\\b.*")
+                || normalized.matches(".*\\b(?:aceito|concordo)\\b.*"
+                + "\\b(?:vou|irei|pretendo|quero|preciso)\\s+" + TERMS_REVIEW_VERB + "\\b.*")
+                || normalized.matches(".*\\b(?:aceito|concordo)\\b.*"
+                + "\\b(?:talvez|nao\\s+sei)\\b.*")
+                || normalized.matches(".*\\b(?:aceito|concordo)\\b\\s*[,;:.! ]*\\bdepois\\b.*")) {
+            return false;
+        }
+        return normalized.matches("aceito[!,. ]*")
+                || normalized.matches("aceito[!,. ]+.*\\b(?:pix|cartao|credito)\\b.*")
+                || normalized.matches(".*(?:\\b(aceito|concordo)\\b.*\\btermos\\b|"
                 + "\\bestou\\s+de\\s+acordo\\b.*\\btermos\\b).*" );
     }
 
@@ -222,6 +239,10 @@ public final class CommercialPolicyService {
             return new AgentOutput(PAYMENT_PROOF_PENDING_MESSAGE, AgentNextAction.AWAIT_PAYMENT_APPROVAL);
         }
         String normalized = normalizeText(candidate.message());
+        if (conversation.paymentStatus() == PaymentStatus.PREPARED
+                && (!normalized.contains("1 servico para cada ambiente") || !normalized.contains("comprovante"))) {
+            throw new IllegalArgumentException("prepared payment output must include quantity per environment and proof guidance");
+        }
         if (conversation.paymentStatus() != PaymentStatus.CONFIRMED) {
             boolean briefingReleaseClaim = claimsBriefingRelease(normalized)
                     && !briefingIsExplicitlyDeferred(normalized);

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/CommercialPolicyService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/CommercialPolicyService.java
@@ -31,8 +31,8 @@ public final class CommercialPolicyService {
     public static final String PREFER_NOT_TO_ANSWER = "PREFER_NOT_TO_ANSWER";
     private static final String PAYMENT_PROOF_PENDING_MESSAGE =
             "Recebi o comprovante. Agora ele aguarda validação humana; aviso assim que o pagamento for confirmado.";
-    private static final String TERMS_REVIEW_VERB =
-            "(?:ler|analisar|revisar|avaliar|verificar|refletir|pensar)";
+    private static final List<String> TERMS_REVIEW_VERBS =
+            List.of("ler", "analisar", "revisar", "avaliar", "verificar", "refletir", "pensar");
     private static final List<String> MANDATORY_ICP = CustomerFactType.icpFieldNames();
     private static final List<String> ALLOWED_PAYMENT_METHODS = List.of("PIX", "CARD");
 
@@ -145,19 +145,187 @@ public final class CommercialPolicyService {
         if (normalized.contains("nao") || normalized.contains("recuso") || normalized.contains("discordo")) {
             return false;
         }
-        if (normalized.matches(".*\\b(?:aceito|concordo)\\b\\s*(?:[,;:]\\s*)?"
-                + "(?:(?:em|com|para)\\s+)?\\b" + TERMS_REVIEW_VERB + "\\b.*")
-                || normalized.matches(".*\\b(?:aceito|concordo)\\b.*"
-                + "\\b(?:vou|irei|pretendo|quero|preciso)\\s+" + TERMS_REVIEW_VERB + "\\b.*")
-                || normalized.matches(".*\\b(?:aceito|concordo)\\b.*"
-                + "\\b(?:talvez|nao\\s+sei)\\b.*")
-                || normalized.matches(".*\\b(?:aceito|concordo)\\b\\s*[,;:.! ]*\\bdepois\\b.*")) {
+        if (hasImmediateReviewRequest(normalized)
+                || hasDeferredReviewRequest(normalized)
+                || hasUncertainAcceptance(normalized)
+                || hasAcceptanceFollowedBy(normalized, "depois", true)) {
             return false;
         }
-        return normalized.matches("aceito[!,. ]*")
-                || normalized.matches("aceito[!,. ]+.*\\b(?:pix|cartao|credito)\\b.*")
-                || normalized.matches(".*(?:\\b(aceito|concordo)\\b.*\\btermos\\b|"
-                + "\\bestou\\s+de\\s+acordo\\b.*\\btermos\\b).*" );
+        return isBareAcceptance(normalized)
+                || isAcceptanceWithPaymentMethod(normalized)
+                || hasAcceptanceFollowedBy(normalized, "termos", false)
+                || hasAcceptancePhraseFollowedBy(normalized, "estou de acordo", "termos");
+    }
+
+    private static boolean hasImmediateReviewRequest(String normalized) {
+        for (String acceptance : List.of("aceito", "concordo")) {
+            int start = indexOfWord(normalized, acceptance, 0);
+            while (start >= 0) {
+                int cursor = start + acceptance.length();
+                while (cursor < normalized.length() && Character.isWhitespace(normalized.charAt(cursor))) {
+                    cursor++;
+                }
+                if (cursor < normalized.length() && ",:;".indexOf(normalized.charAt(cursor)) >= 0) {
+                    cursor++;
+                    while (cursor < normalized.length() && Character.isWhitespace(normalized.charAt(cursor))) {
+                        cursor++;
+                    }
+                }
+                for (String preposition : List.of("em", "com", "para")) {
+                    int afterPreposition = wordEnd(normalized, cursor, preposition);
+                    if (afterPreposition >= 0 && hasWhitespaceAfter(normalized, afterPreposition)) {
+                        cursor = afterPreposition;
+                        while (cursor < normalized.length() && Character.isWhitespace(normalized.charAt(cursor))) {
+                            cursor++;
+                        }
+                        break;
+                    }
+                }
+                if (containsReviewVerbAt(normalized, cursor)) {
+                    return true;
+                }
+                start = indexOfWord(normalized, acceptance, start + acceptance.length());
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasDeferredReviewRequest(String normalized) {
+        for (String acceptance : List.of("aceito", "concordo")) {
+            int acceptanceIndex = indexOfWord(normalized, acceptance, 0);
+            while (acceptanceIndex >= 0) {
+                for (String modal : List.of("vou", "irei", "pretendo", "quero", "preciso")) {
+                    int modalIndex = indexOfWord(normalized, modal, acceptanceIndex + acceptance.length());
+                    if (modalIndex >= 0 && containsReviewVerbAfter(normalized, modalIndex + modal.length())) {
+                        return true;
+                    }
+                }
+                acceptanceIndex = indexOfWord(normalized, acceptance, acceptanceIndex + acceptance.length());
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasUncertainAcceptance(String normalized) {
+        for (String acceptance : List.of("aceito", "concordo")) {
+            int acceptanceIndex = indexOfWord(normalized, acceptance, 0);
+            if (acceptanceIndex >= 0
+                    && indexOfWord(normalized, "talvez", acceptanceIndex + acceptance.length()) >= 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isBareAcceptance(String normalized) {
+        if (!normalized.startsWith("aceito")) {
+            return false;
+        }
+        String suffix = normalized.substring("aceito".length());
+        return suffix.chars().allMatch(character -> "!,. ".indexOf(character) >= 0);
+    }
+
+    private static boolean isAcceptanceWithPaymentMethod(String normalized) {
+        if (!normalized.startsWith("aceito") || normalized.length() == "aceito".length()) {
+            return false;
+        }
+        char separator = normalized.charAt("aceito".length());
+        if ("!,. ".indexOf(separator) < 0) {
+            return false;
+        }
+        return indexOfAnyWord(normalized, List.of("pix", "cartao", "credito"), "aceito".length()) >= 0;
+    }
+
+    private static boolean hasAcceptanceFollowedBy(String normalized, String target, boolean immediate) {
+        for (String acceptance : List.of("aceito", "concordo")) {
+            int acceptanceIndex = indexOfWord(normalized, acceptance, 0);
+            while (acceptanceIndex >= 0) {
+                int from = acceptanceIndex + acceptance.length();
+                if (immediate) {
+                    while (from < normalized.length() && ",;:.! ".indexOf(normalized.charAt(from)) >= 0) {
+                        from++;
+                    }
+                    if (wordEnd(normalized, from, target) >= 0) {
+                        return true;
+                    }
+                } else if (indexOfWord(normalized, target, from) >= 0) {
+                    return true;
+                }
+                acceptanceIndex = indexOfWord(normalized, acceptance, from);
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasAcceptancePhraseFollowedBy(String normalized, String phrase, String target) {
+        int phraseIndex = indexOfPhrase(normalized, phrase, 0);
+        return phraseIndex >= 0 && indexOfWord(normalized, target, phraseIndex + phrase.length()) >= 0;
+    }
+
+    private static boolean containsReviewVerbAt(String normalized, int start) {
+        for (String verb : TERMS_REVIEW_VERBS) {
+            if (wordEnd(normalized, start, verb) >= 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsReviewVerbAfter(String normalized, int start) {
+        for (String verb : TERMS_REVIEW_VERBS) {
+            int index = indexOfWord(normalized, verb, start);
+            if (index >= 0 && hasWhitespaceBetween(normalized, start, index)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int indexOfAnyWord(String normalized, List<String> values, int fromIndex) {
+        return values.stream()
+                .mapToInt(value -> indexOfWord(normalized, value, fromIndex))
+                .filter(index -> index >= 0)
+                .min()
+                .orElse(-1);
+    }
+
+    private static int indexOfWord(String value, String word, int fromIndex) {
+        int index = value.indexOf(word, fromIndex);
+        while (index >= 0) {
+            if (isWordBoundary(value, index - 1) && isWordBoundary(value, index + word.length())) {
+                return index;
+            }
+            index = value.indexOf(word, index + word.length());
+        }
+        return -1;
+    }
+
+    private static int indexOfPhrase(String value, String phrase, int fromIndex) {
+        int index = value.indexOf(phrase, fromIndex);
+        while (index >= 0) {
+            if (isWordBoundary(value, index - 1)
+                    && isWordBoundary(value, index + phrase.length())) {
+                return index;
+            }
+            index = value.indexOf(phrase, index + phrase.length());
+        }
+        return -1;
+    }
+
+    private static int wordEnd(String value, int start, String word) {
+        return indexOfWord(value, word, start) == start ? start + word.length() : -1;
+    }
+
+    private static boolean hasWhitespaceAfter(String value, int start) {
+        return start < value.length() && Character.isWhitespace(value.charAt(start));
+    }
+
+    private static boolean hasWhitespaceBetween(String value, int start, int end) {
+        return start < end && value.substring(start, end).chars().allMatch(Character::isWhitespace);
+    }
+
+    private static boolean isWordBoundary(String value, int index) {
+        return index < 0 || index >= value.length() || !Character.isLetterOrDigit(value.charAt(index));
     }
 
     public ReceptionConversation preparePayment(ReceptionConversation conversation,

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/CommercialPolicyService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/CommercialPolicyService.java
@@ -31,8 +31,17 @@ public final class CommercialPolicyService {
     public static final String PREFER_NOT_TO_ANSWER = "PREFER_NOT_TO_ANSWER";
     private static final String PAYMENT_PROOF_PENDING_MESSAGE =
             "Recebi o comprovante. Agora ele aguarda validação humana; aviso assim que o pagamento for confirmado.";
+    private static final String ACCEPTANCE_WORD = "aceito";
+    private static final String AGREEMENT_WORD = "concordo";
+    private static final List<String> ACCEPTANCE_WORDS = List.of(ACCEPTANCE_WORD, AGREEMENT_WORD);
     private static final List<String> TERMS_REVIEW_VERBS =
             List.of("ler", "analisar", "revisar", "avaliar", "verificar", "refletir", "pensar");
+    private static final List<String> REVIEW_PREPOSITIONS = List.of("em", "com", "para");
+    private static final List<String> DEFERRED_REVIEW_MODALS =
+            List.of("vou", "irei", "pretendo", "quero", "preciso");
+    private static final String IMMEDIATE_REVIEW_SEPARATORS = ",:;";
+    private static final String ACCEPTANCE_SEPARATORS = "!,. ";
+    private static final String IMMEDIATE_TARGET_SEPARATORS = ",;:.! ";
     private static final List<String> MANDATORY_ICP = CustomerFactType.icpFieldNames();
     private static final List<String> ALLOWED_PAYMENT_METHODS = List.of("PIX", "CARD");
 
@@ -158,43 +167,43 @@ public final class CommercialPolicyService {
     }
 
     private static boolean hasImmediateReviewRequest(String normalized) {
-        for (String acceptance : List.of("aceito", "concordo")) {
-            int start = indexOfWord(normalized, acceptance, 0);
-            while (start >= 0) {
-                int cursor = start + acceptance.length();
-                while (cursor < normalized.length() && Character.isWhitespace(normalized.charAt(cursor))) {
-                    cursor++;
-                }
-                if (cursor < normalized.length() && ",:;".indexOf(normalized.charAt(cursor)) >= 0) {
-                    cursor++;
-                    while (cursor < normalized.length() && Character.isWhitespace(normalized.charAt(cursor))) {
-                        cursor++;
-                    }
-                }
-                for (String preposition : List.of("em", "com", "para")) {
-                    int afterPreposition = wordEnd(normalized, cursor, preposition);
-                    if (afterPreposition >= 0 && hasWhitespaceAfter(normalized, afterPreposition)) {
-                        cursor = afterPreposition;
-                        while (cursor < normalized.length() && Character.isWhitespace(normalized.charAt(cursor))) {
-                            cursor++;
-                        }
-                        break;
-                    }
-                }
-                if (containsReviewVerbAt(normalized, cursor)) {
-                    return true;
-                }
-                start = indexOfWord(normalized, acceptance, start + acceptance.length());
+        return ACCEPTANCE_WORDS.stream()
+                .anyMatch(acceptance -> hasImmediateReviewRequest(normalized, acceptance));
+    }
+
+    private static boolean hasImmediateReviewRequest(String normalized, String acceptance) {
+        int start = indexOfWord(normalized, acceptance, 0);
+        while (start >= 0) {
+            int reviewStart = immediateReviewStart(normalized, start, acceptance);
+            if (containsReviewVerbAt(normalized, reviewStart)) {
+                return true;
             }
+            start = indexOfWord(normalized, acceptance, start + acceptance.length());
         }
         return false;
     }
 
+    private static int immediateReviewStart(String normalized, int acceptanceIndex, String acceptance) {
+        int cursor = skipWhitespace(normalized, acceptanceIndex + acceptance.length());
+        cursor = skipSingleSeparator(normalized, cursor, IMMEDIATE_REVIEW_SEPARATORS);
+        return skipReviewPreposition(normalized, cursor);
+    }
+
+    private static int skipReviewPreposition(String normalized, int start) {
+        for (String preposition : REVIEW_PREPOSITIONS) {
+            int afterPreposition = wordEnd(normalized, start, preposition);
+            if (afterPreposition >= 0 && hasWhitespaceAfter(normalized, afterPreposition)) {
+                return skipWhitespace(normalized, afterPreposition);
+            }
+        }
+        return start;
+    }
+
     private static boolean hasDeferredReviewRequest(String normalized) {
-        for (String acceptance : List.of("aceito", "concordo")) {
+        for (String acceptance : ACCEPTANCE_WORDS) {
             int acceptanceIndex = indexOfWord(normalized, acceptance, 0);
             while (acceptanceIndex >= 0) {
-                for (String modal : List.of("vou", "irei", "pretendo", "quero", "preciso")) {
+                for (String modal : DEFERRED_REVIEW_MODALS) {
                     int modalIndex = indexOfWord(normalized, modal, acceptanceIndex + acceptance.length());
                     if (modalIndex >= 0 && containsReviewVerbAfter(normalized, modalIndex + modal.length())) {
                         return true;
@@ -207,7 +216,7 @@ public final class CommercialPolicyService {
     }
 
     private static boolean hasUncertainAcceptance(String normalized) {
-        for (String acceptance : List.of("aceito", "concordo")) {
+        for (String acceptance : ACCEPTANCE_WORDS) {
             int acceptanceIndex = indexOfWord(normalized, acceptance, 0);
             if (acceptanceIndex >= 0
                     && indexOfWord(normalized, "talvez", acceptanceIndex + acceptance.length()) >= 0) {
@@ -218,43 +227,51 @@ public final class CommercialPolicyService {
     }
 
     private static boolean isBareAcceptance(String normalized) {
-        if (!normalized.startsWith("aceito")) {
+        if (!normalized.startsWith(ACCEPTANCE_WORD)) {
             return false;
         }
-        String suffix = normalized.substring("aceito".length());
-        return suffix.chars().allMatch(character -> "!,. ".indexOf(character) >= 0);
+        String suffix = normalized.substring(ACCEPTANCE_WORD.length());
+        return suffix.chars().allMatch(character -> ACCEPTANCE_SEPARATORS.indexOf(character) >= 0);
     }
 
     private static boolean isAcceptanceWithPaymentMethod(String normalized) {
-        if (!normalized.startsWith("aceito") || normalized.length() == "aceito".length()) {
+        if (!normalized.startsWith(ACCEPTANCE_WORD)
+                || normalized.length() == ACCEPTANCE_WORD.length()) {
             return false;
         }
-        char separator = normalized.charAt("aceito".length());
-        if ("!,. ".indexOf(separator) < 0) {
+        char separator = normalized.charAt(ACCEPTANCE_WORD.length());
+        if (ACCEPTANCE_SEPARATORS.indexOf(separator) < 0) {
             return false;
         }
-        return indexOfAnyWord(normalized, List.of("pix", "cartao", "credito"), "aceito".length()) >= 0;
+        return indexOfAnyWord(normalized, List.of("pix", "cartao", "credito"), ACCEPTANCE_WORD.length()) >= 0;
     }
 
     private static boolean hasAcceptanceFollowedBy(String normalized, String target, boolean immediate) {
-        for (String acceptance : List.of("aceito", "concordo")) {
-            int acceptanceIndex = indexOfWord(normalized, acceptance, 0);
-            while (acceptanceIndex >= 0) {
-                int from = acceptanceIndex + acceptance.length();
-                if (immediate) {
-                    while (from < normalized.length() && ",;:.! ".indexOf(normalized.charAt(from)) >= 0) {
-                        from++;
-                    }
-                    if (wordEnd(normalized, from, target) >= 0) {
-                        return true;
-                    }
-                } else if (indexOfWord(normalized, target, from) >= 0) {
-                    return true;
-                }
-                acceptanceIndex = indexOfWord(normalized, acceptance, from);
+        return ACCEPTANCE_WORDS.stream()
+                .anyMatch(acceptance -> hasAcceptanceFollowedBy(normalized, acceptance, target, immediate));
+    }
+
+    private static boolean hasAcceptanceFollowedBy(String normalized, String acceptance,
+                                                     String target, boolean immediate) {
+        int acceptanceIndex = indexOfWord(normalized, acceptance, 0);
+        while (acceptanceIndex >= 0) {
+            if (targetFollowsAcceptance(normalized, acceptanceIndex, acceptance, target, immediate)) {
+                return true;
             }
+            acceptanceIndex = indexOfWord(normalized, acceptance,
+                    acceptanceIndex + acceptance.length());
         }
         return false;
+    }
+
+    private static boolean targetFollowsAcceptance(String normalized, int acceptanceIndex,
+                                                    String acceptance, String target, boolean immediate) {
+        int from = acceptanceIndex + acceptance.length();
+        if (immediate) {
+            from = skipCharacters(normalized, from, IMMEDIATE_TARGET_SEPARATORS);
+            return wordEnd(normalized, from, target) >= 0;
+        }
+        return indexOfWord(normalized, target, from) >= 0;
     }
 
     private static boolean hasAcceptancePhraseFollowedBy(String normalized, String phrase, String target) {
@@ -318,6 +335,29 @@ public final class CommercialPolicyService {
 
     private static boolean hasWhitespaceAfter(String value, int start) {
         return start < value.length() && Character.isWhitespace(value.charAt(start));
+    }
+
+    private static int skipWhitespace(String value, int start) {
+        int cursor = start;
+        while (cursor < value.length() && Character.isWhitespace(value.charAt(cursor))) {
+            cursor++;
+        }
+        return cursor;
+    }
+
+    private static int skipSingleSeparator(String value, int start, String separators) {
+        if (start < value.length() && separators.indexOf(value.charAt(start)) >= 0) {
+            return skipWhitespace(value, start + 1);
+        }
+        return start;
+    }
+
+    private static int skipCharacters(String value, int start, String characters) {
+        int cursor = start;
+        while (cursor < value.length() && characters.indexOf(value.charAt(cursor)) >= 0) {
+            cursor++;
+        }
+        return cursor;
     }
 
     private static boolean hasWhitespaceBetween(String value, int start, int end) {

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/PocReceptionConfiguration.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/PocReceptionConfiguration.java
@@ -194,7 +194,8 @@ public class PocReceptionConfiguration {
             ActiveTurnLeaseService leases, CommercialPolicyService policy,
             TermsAcceptanceUseCase termsAcceptance, DomainToolInvocationGateway invocations) {
         return new ReceptionTurnReconciliationService(hermes, conversations, transcript, turns,
-                Clock.systemUTC(), leases, policy, termsAcceptance, invocations);
+                Clock.systemUTC(), new ReceptionTurnReconciliationService.Dependencies(
+                        leases, policy, termsAcceptance, invocations));
     }
 
     @Bean

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/PocReceptionConfiguration.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/PocReceptionConfiguration.java
@@ -13,6 +13,7 @@ import br.com.urbana.connect.domain.reception.port.out.CustomerFactGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionConversationGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTranscriptGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTurnGateway;
+import br.com.urbana.connect.domain.reception.port.out.TermsConsentAuditGateway;
 import br.com.urbana.connect.infrastructure.hermes.HttpHermesSessionsGateway;
 import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.MongoActiveTurnLeaseGateway;
 import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.MongoAgentSessionLinkGateway;
@@ -29,6 +30,8 @@ import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.Spring
 import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.SpringDataReceptionConversationRepository;
 import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.SpringDataReceptionMessageRepository;
 import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.SpringDataReceptionTurnRepository;
+import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.SpringDataTermsConsentAuditRepository;
+import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.MongoTermsConsentAuditGateway;
 import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.SpringDataPocPendingEventRepository;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.beans.factory.annotation.Value;
@@ -70,8 +73,11 @@ public class PocReceptionConfiguration {
     public DomainToolService statefulDomainToolService(CommercialPolicyService policy,
                                                        ReceptionConversationGateway conversations,
                                                        CustomerFactGateway facts,
-                                                       ReceptionTranscriptGateway transcript) {
-        return new StatefulDomainToolService(policy, conversations, facts, transcript);
+                                                       ReceptionTranscriptGateway transcript,
+                                                       TermsAcceptanceUseCase termsAcceptance) {
+        StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts, transcript);
+        tools.setTermsAcceptanceUseCase(termsAcceptance);
+        return tools;
     }
 
     @Bean
@@ -91,6 +97,18 @@ public class PocReceptionConfiguration {
     public ReceptionConversationGateway receptionConversationGateway(
             SpringDataReceptionConversationRepository repository, MongoTemplate template) {
         return new MongoReceptionConversationGateway(repository, template);
+    }
+
+    @Bean
+    public TermsConsentAuditGateway termsConsentAuditGateway(
+            SpringDataTermsConsentAuditRepository repository, MongoTemplate template) {
+        return new MongoTermsConsentAuditGateway(repository, template);
+    }
+
+    @Bean
+    public TermsAcceptanceUseCase termsAcceptanceUseCase(TermsConsentAuditGateway audits,
+                                                         ReceptionConversationGateway conversations) {
+        return new TermsAcceptanceUseCase(audits, conversations);
     }
 
     @Bean
@@ -173,9 +191,10 @@ public class PocReceptionConfiguration {
     public ReceptionTurnReconciliationService receptionTurnReconciliationService(
             HermesSessionService hermes, ReceptionConversationGateway conversations,
             ReceptionTranscriptGateway transcript, ReceptionTurnGateway turns,
-            ActiveTurnLeaseService leases) {
+            ActiveTurnLeaseService leases, CommercialPolicyService policy,
+            TermsAcceptanceUseCase termsAcceptance, DomainToolInvocationGateway invocations) {
         return new ReceptionTurnReconciliationService(hermes, conversations, transcript, turns,
-                Clock.systemUTC(), leases);
+                Clock.systemUTC(), leases, policy, termsAcceptance, invocations);
     }
 
     @Bean
@@ -186,10 +205,13 @@ public class PocReceptionConfiguration {
             ReceptionTurnCoordinator coordinator, ActiveTurnLeaseService leases,
             DomainToolInvocationGateway invocations, ReceptionMetrics metrics,
             ReturningCustomerService returningCustomers, NonProspectPolicy nonProspectPolicy,
+            TermsAcceptanceUseCase termsAcceptance,
             @Value("${hermes.poc.delay-threshold:5s}") String delayThreshold) {
-        return new ReceptionOrchestrator(hermes, conversations, facts, transcript, turns,
+        ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(hermes, conversations, facts, transcript, turns,
                 policy, coordinator, leases, invocations, Clock.systemUTC(), metrics, returningCustomers,
                 nonProspectPolicy, DurationStyle.detectAndParse(delayThreshold));
+        orchestrator.setTermsAcceptanceUseCase(termsAcceptance);
+        return orchestrator;
     }
 
     @Bean

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionOrchestrator.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionOrchestrator.java
@@ -16,6 +16,10 @@ import br.com.urbana.connect.domain.reception.model.ReceptionTurn;
 import br.com.urbana.connect.domain.reception.model.ReceptionTurnStatus;
 import br.com.urbana.connect.domain.reception.model.ReceptionEventIds;
 import br.com.urbana.connect.domain.reception.model.ResumeStatus;
+import br.com.urbana.connect.domain.reception.model.TermsConsentAudit;
+import br.com.urbana.connect.domain.reception.model.TermsConsentStatus;
+import br.com.urbana.connect.domain.reception.model.TermsStatus;
+import br.com.urbana.connect.domain.reception.model.DomainToolName;
 import br.com.urbana.connect.domain.reception.port.out.CustomerFactGateway;
 import br.com.urbana.connect.domain.reception.port.out.DomainToolInvocationGateway;
 import br.com.urbana.connect.domain.reception.port.out.HermesResumeGateway;
@@ -67,7 +71,7 @@ public final class ReceptionOrchestrator {
     private static final String SAFE_PAYMENT_PREPARATION_MESSAGE =
             "Para continuar, escolha uma forma de pagamento: PIX ou cartão de crédito.";
     private static final String SAFE_PAYMENT_PROOF_MESSAGE =
-            "O pagamento está preparado. Realize-o pelo link e envie o comprovante por aqui.";
+            "O pagamento está preparado. No link da POC, que é uma simulação, considere 1 serviço para cada ambiente contratado. Depois do pagamento, envie o comprovante por aqui.";
     private static final String SAFE_PAYMENT_PROOF_HANDOFF_MESSAGE =
             "Recebi o comprovante. Vou encaminhar sua conversa para a arquiteta, que fará a validação do pagamento por aqui.";
     private static final String SAFE_COMMERCIAL_RECOVERY_MESSAGE =
@@ -92,6 +96,7 @@ public final class ReceptionOrchestrator {
     private final ReceptionMetrics metrics;
     private final NonProspectPolicy nonProspectPolicy;
     private final Duration delayThreshold;
+    private TermsAcceptanceUseCase termsAcceptance;
     private final Map<String, NonProspectPolicy.State> nonProspectStates = new ConcurrentHashMap<>();
     private final Map<String, LongAdder> hermesChatCallsByContact = new ConcurrentHashMap<>();
 
@@ -191,6 +196,11 @@ public final class ReceptionOrchestrator {
             throw new IllegalArgumentException("delay threshold must be positive");
         }
         this.delayThreshold = delayThreshold;
+    }
+
+    /** Optional additive wiring preserves existing test constructors. */
+    public void setTermsAcceptanceUseCase(TermsAcceptanceUseCase termsAcceptance) {
+        this.termsAcceptance = termsAcceptance;
     }
 
     public ReceptionOrchestrator(HermesSessionService hermes,
@@ -526,7 +536,9 @@ public final class ReceptionOrchestrator {
                         value.put("sourceMessageId", message.sourceMessageId());
                         return value;
                     }).toList();
-            byte[] canonical = RESUME_JSON.writeValueAsBytes(projection);
+            // Hermes canonical JSON keeps supplementary Unicode characters as
+            // UTF-8 rather than Jackson's escaped UTF-16 surrogate pairs.
+            byte[] canonical = RESUME_JSON.writeValueAsString(projection).getBytes(StandardCharsets.UTF_8);
             return "sha256:" + HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(canonical));
         } catch (Exception failure) {
             throw new IllegalStateException("resume checksum unavailable", failure);
@@ -766,6 +778,7 @@ public final class ReceptionOrchestrator {
                 return runTurn(events, conversation, activeTurn);
             }
             return leases.withLease(resolution.sessionId(), activeTurn.id(), first.contactId(), last.eventId(),
+                    events.stream().map(InboundConversationEvent::eventId).toList(),
                     () -> runTurn(events, conversation, activeTurn));
         } catch (RuntimeException exception) {
             recordLeaseBlockIfApplicable(exception, activeTurn);
@@ -819,9 +832,15 @@ public final class ReceptionOrchestrator {
         }
         Optional<InboundConversationEvent> acceptance = events.stream()
                 .filter(event -> policy.isExplicitTermsAcceptance(event.conversationalText())).findFirst();
-        if (initial.termsStatus() == br.com.urbana.connect.domain.reception.model.TermsStatus.PRESENTED
-                && acceptance.isPresent()) {
-            beforeChat = conversations.save(policy.acceptTerms(initial, acceptance.get().occurredAt()));
+        if (beforeChat.termsStatus() == TermsStatus.PRESENTED && acceptance.isPresent()
+                && termsAcceptance != null && beforeChat.activeTermsConsentId() != null) {
+            InboundConversationEvent accepted = acceptance.get();
+            ReceptionMessage acceptanceMessage = transcript.findByEventId(accepted.eventId()).orElseThrow();
+            ReceptionConversation acceptedConversation = termsAcceptance.recordAcceptance(beforeChat,
+                    accepted.eventId(), acceptanceMessage.id(), acceptanceMessage.text(),
+                    accepted.occurredAt(), policy);
+            beforeChat = termsAcceptance.persistsConversation()
+                    ? acceptedConversation : conversations.save(acceptedConversation);
         }
         Optional<InboundConversationEvent> proof = events.stream()
                 .filter(InboundConversationEvent::isPaymentProof).findFirst();
@@ -853,10 +872,10 @@ public final class ReceptionOrchestrator {
         HermesSessionsGateway.HermesChatResult chat = chatWithDelayTracking(first.contactId(),
                 new HermesSessionsGateway.HermesChatRequest(input, images, null, null, null), turn);
         ReceptionConversation canonical = conversations.findByContactId(first.contactId()).orElse(beforeChat);
-        if (canonical.termsStatus() == br.com.urbana.connect.domain.reception.model.TermsStatus.PRESENTED
-                && acceptance.isPresent()) {
-            canonical = conversations.save(policy.acceptTerms(canonical, acceptance.get().occurredAt()));
-        }
+        // An inbound message cannot accept terms that Hermes has only just
+        // prepared in this same turn.  Only the pre-chat checkpoint above may
+        // consume an acceptance, and only for terms already visible to the
+        // person before this inbound event.
         List<br.com.urbana.connect.domain.reception.model.DomainToolInvocation> ledger = invocations == null
                 ? List.of() : invocations.findByTurnId(turn.id());
         // The handoff tool may have changed the authoritative conversation
@@ -891,7 +910,15 @@ public final class ReceptionOrchestrator {
         }
         String customerMessage = ensureInitialPresentation(canonical, output.message());
         output = new AgentOutput(customerMessage, output.nextAction());
-        appendOutbound(canonical, last.eventId() + ":outbound", turn.correlationId(), customerMessage);
+        if (hasNewerInboundThan(canonical, last)) {
+            ReceptionTurn stale = turn.failSafeToRetry("STALE_INBOUND_BEFORE_PUBLICATION", clock.instant());
+            turns.save(stale);
+            metrics.recordTurn(stale, ledger);
+            return new TurnReceipt(last.eventId(), turn.correlationId(), TurnStatus.FAILED_SAFE_TO_RETRY,
+                    null, "STALE_INBOUND_BEFORE_PUBLICATION");
+        }
+        ReceptionMessage outbound = appendOutbound(canonical, last.eventId() + ":outbound", turn.correlationId(), customerMessage);
+        canonical = recordTermsPresentationIfNeeded(canonical, ledger, turn, outbound);
         ReceptionTurn completed = turn.complete(chat.usage(), clock.instant(), output);
         turns.save(completed);
         metrics.recordTurn(completed, ledger);
@@ -1124,13 +1151,50 @@ public final class ReceptionOrchestrator {
                 || normalized.contains("unavailable");
     }
 
-    private void appendOutbound(ReceptionConversation conversation, String eventId,
+    private ReceptionMessage appendOutbound(ReceptionConversation conversation, String eventId,
                                 String correlationId, String text) {
         ReceptionMessage message = new ReceptionMessage(UUID.randomUUID().toString(),
                 ReceptionEventIds.outbound(eventId, correlationId), correlationId,
                 conversation.id(), conversation.contactId(), ReceptionMessageDirection.OUTBOUND,
                 ReceptionMessageSender.URBA, ReceptionMessageType.TEXT, text, null, null, clock.instant());
         transcript.appendIfAbsent(message);
+        return transcript.findByEventId(message.eventId()).orElse(message);
+    }
+
+    private ReceptionConversation recordTermsPresentationIfNeeded(ReceptionConversation conversation,
+                                                                   List<br.com.urbana.connect.domain.reception.model.DomainToolInvocation> ledger,
+                                                                   ReceptionTurn turn, ReceptionMessage outbound) {
+        if (termsAcceptance == null || conversation.termsStatus() != TermsStatus.PRESENTED
+                || conversation.activeTermsConsentId() != null || conversation.contractingUnitId() == null
+                || conversation.environmentLabel() == null || conversation.environmentSourceMessageId() == null) {
+            return conversation;
+        }
+        Optional<br.com.urbana.connect.domain.reception.model.DomainToolInvocation> invocation = ledger.stream()
+                .filter(value -> value.toolName() == DomainToolName.PREPARE_TERMS)
+                .filter(value -> value.status() == br.com.urbana.connect.domain.reception.model.DomainToolInvocationStatus.SUCCEEDED)
+                .reduce((first, last) -> last);
+        if (invocation.isEmpty()) return conversation;
+        Object payload = invocation.get().resultPayload();
+        String resource = payload instanceof Map<?, ?> map && map.get("url") != null ? map.get("url").toString() : null;
+        if (resource == null || resource.isBlank()
+                || outbound.text() == null || !outbound.text().contains(resource)) return conversation;
+        String presentationId = "terms:" + conversation.id() + ":" + conversation.contractingUnitId()
+                + ":" + invocation.get().id();
+        TermsConsentAudit audit = new TermsConsentAudit(presentationId, conversation.id(), conversation.contactId(),
+                turn.id(), conversation.contractingUnitId(), conversation.environmentLabel(),
+                conversation.environmentSourceMessageId(), conversation.selectedService(), resource, null,
+                invocation.get().id(), outbound.id(), outbound.createdAt(), null, null, null, null, outbound.createdAt(),
+                TermsConsentStatus.PRESENTED, conversation.version(), null);
+        termsAcceptance.recordPresentation(audit);
+        return conversations.save(conversation.activateTermsConsent(presentationId, outbound.createdAt()));
+    }
+
+    /** Prevents a delayed turn from replying after a newer inbound was persisted. */
+    private boolean hasNewerInboundThan(ReceptionConversation conversation, InboundConversationEvent processed) {
+        return transcript.findByConversationId(conversation.id()).stream()
+                .filter(message -> message.direction() == ReceptionMessageDirection.INBOUND)
+                .anyMatch(message -> !message.eventId().equals(processed.eventId())
+                        && message.createdAt().isAfter(processed.occurredAt()));
     }
 
     /**

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationService.java
@@ -1,7 +1,11 @@
 package br.com.urbana.connect.application.reception;
 
 import br.com.urbana.connect.application.reception.tools.StatefulDomainToolService;
+import br.com.urbana.connect.domain.reception.model.AgentNextAction;
 import br.com.urbana.connect.domain.reception.model.AgentOutput;
+import br.com.urbana.connect.domain.reception.model.DomainToolInvocation;
+import br.com.urbana.connect.domain.reception.model.DomainToolInvocationStatus;
+import br.com.urbana.connect.domain.reception.model.DomainToolName;
 import br.com.urbana.connect.domain.reception.model.ReceptionConversation;
 import br.com.urbana.connect.domain.reception.model.ReceptionEventIds;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessage;
@@ -11,6 +15,10 @@ import br.com.urbana.connect.domain.reception.model.ReceptionMessageType;
 import br.com.urbana.connect.domain.reception.model.ReceptionTurn;
 import br.com.urbana.connect.domain.reception.model.ReceptionTurnStatus;
 import br.com.urbana.connect.domain.reception.model.ReceptionMode;
+import br.com.urbana.connect.domain.reception.model.TermsConsentAudit;
+import br.com.urbana.connect.domain.reception.model.TermsConsentStatus;
+import br.com.urbana.connect.domain.reception.model.TermsStatus;
+import br.com.urbana.connect.domain.reception.port.out.DomainToolInvocationGateway;
 import br.com.urbana.connect.domain.reception.port.out.HermesSessionsGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionConversationGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTranscriptGateway;
@@ -20,9 +28,11 @@ import br.com.urbana.connect.infrastructure.hermes.HermesAgentOutputParser;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.Map;
 
 /** Completes an uncertain turn only when Hermes exposes a changed stable cursor. */
 public final class ReceptionTurnReconciliationService {
@@ -32,6 +42,9 @@ public final class ReceptionTurnReconciliationService {
     private final ReceptionTurnGateway turns;
     private final Clock clock;
     private final ActiveTurnLeaseService leases;
+    private final CommercialPolicyService policy;
+    private final TermsAcceptanceUseCase termsAcceptance;
+    private final DomainToolInvocationGateway invocations;
     private final HermesAgentOutputParser parser = new HermesAgentOutputParser();
 
     public ReceptionTurnReconciliationService(HermesSessionService hermes,
@@ -39,7 +52,7 @@ public final class ReceptionTurnReconciliationService {
                                               ReceptionTranscriptGateway transcript,
                                               ReceptionTurnGateway turns,
                                               Clock clock) {
-        this(hermes, conversations, transcript, turns, clock, null);
+        this(hermes, conversations, transcript, turns, clock, null, null, null, null);
     }
 
     public ReceptionTurnReconciliationService(HermesSessionService hermes,
@@ -48,12 +61,27 @@ public final class ReceptionTurnReconciliationService {
                                               ReceptionTurnGateway turns,
                                               Clock clock,
                                               ActiveTurnLeaseService leases) {
+        this(hermes, conversations, transcript, turns, clock, leases, null, null, null);
+    }
+
+    public ReceptionTurnReconciliationService(HermesSessionService hermes,
+                                              ReceptionConversationGateway conversations,
+                                              ReceptionTranscriptGateway transcript,
+                                              ReceptionTurnGateway turns,
+                                              Clock clock,
+                                              ActiveTurnLeaseService leases,
+                                              CommercialPolicyService policy,
+                                              TermsAcceptanceUseCase termsAcceptance,
+                                              DomainToolInvocationGateway invocations) {
         this.hermes = Objects.requireNonNull(hermes, "hermes");
         this.conversations = Objects.requireNonNull(conversations, "conversations");
         this.transcript = Objects.requireNonNull(transcript, "transcript");
         this.turns = Objects.requireNonNull(turns, "turns");
         this.clock = clock == null ? Clock.systemUTC() : clock;
         this.leases = leases;
+        this.policy = policy;
+        this.termsAcceptance = termsAcceptance;
+        this.invocations = invocations;
     }
 
     public Optional<String> reconcile(String turnOrEventId) {
@@ -112,17 +140,123 @@ public final class ReceptionTurnReconciliationService {
             }
             return Optional.of(StatefulDomainToolService.HUMAN_HANDOFF_ACK);
         }
+        boolean newerInbound = transcript.findByConversationId(conversation.id()).stream()
+                .filter(message -> message.direction() == ReceptionMessageDirection.INBOUND)
+                .anyMatch(message -> turn.startedAt() != null && message.createdAt().isAfter(turn.startedAt())
+                        && !turn.inboundMessageIds().contains(message.id()));
+        if (newerInbound) {
+            turns.save(turn.failSafeToRetry("STALE_INBOUND_BEFORE_RECONCILIATION", clock.instant()));
+            if (leases != null) leases.releaseForReconciliation(turn.hermesSessionId(), turn.id());
+            return Optional.empty();
+        }
+        AgentOutput safeOutput = reconcileOutput(output, conversation);
+        String customerMessage = ensureInitialPresentation(conversation, safeOutput.message());
+        safeOutput = new AgentOutput(customerMessage, safeOutput.nextAction(), safeOutput.handoffReason());
+        if (hasNewerInbound(conversation, turn)) {
+            turns.save(turn.failSafeToRetry("STALE_INBOUND_BEFORE_RECONCILIATION", clock.instant()));
+            if (leases != null) leases.releaseForReconciliation(turn.hermesSessionId(), turn.id());
+            return Optional.empty();
+        }
         String eventId = ReceptionEventIds.outbound(turn.id(), turn.correlationId());
         ReceptionMessage outbound = new ReceptionMessage(UUID.randomUUID().toString(), eventId,
                 turn.correlationId(), conversation.id(), turn.contactId(), ReceptionMessageDirection.OUTBOUND,
-                ReceptionMessageSender.URBA, ReceptionMessageType.TEXT, output.message(), null, null, clock.instant());
+                ReceptionMessageSender.URBA, ReceptionMessageType.TEXT, customerMessage, null, null, clock.instant());
         transcript.appendIfAbsent(outbound);
-        ReceptionTurn completed = turn.complete(turn.usage(), clock.instant(), output);
+        ReceptionMessage persistedOutbound = transcript.findByEventId(eventId).orElse(outbound);
+        conversation = recordTermsPresentationIfNeeded(conversation, turn, persistedOutbound);
+        // A second fence closes the common publication race where an inbound
+        // is persisted while the outbound append is in flight. The transcript
+        // append is idempotent; the turn is deliberately left retryable so the
+        // successor turn becomes the conversational owner.
+        if (hasNewerInbound(conversation, turn)) {
+            turns.save(turn.failSafeToRetry("STALE_INBOUND_DURING_RECONCILIATION_PUBLICATION", clock.instant()));
+            if (leases != null) leases.releaseForReconciliation(turn.hermesSessionId(), turn.id());
+            return Optional.empty();
+        }
+        ReceptionTurn completed = turn.complete(turn.usage(), clock.instant(), safeOutput);
         turns.save(completed);
         if (leases != null) {
             leases.releaseForReconciliation(turn.hermesSessionId(), turn.id());
         }
-        return Optional.of(output.message());
+        return Optional.of(customerMessage);
+    }
+
+    private AgentOutput reconcileOutput(AgentOutput candidate, ReceptionConversation conversation) {
+        if (policy == null) return candidate;
+        try {
+            return policy.reconcileOutput(candidate, conversation);
+        } catch (IllegalArgumentException rejected) {
+            return safeOutputAfterRejection(conversation);
+        }
+    }
+
+    private AgentOutput safeOutputAfterRejection(ReceptionConversation conversation) {
+        return switch (conversation.paymentStatus()) {
+            case PROOF_RECEIVED -> new AgentOutput(
+                    "Recebi o comprovante. Agora ele aguarda validação humana; aviso assim que o pagamento for confirmado.",
+                    AgentNextAction.AWAIT_PAYMENT_APPROVAL);
+            case PREPARED -> new AgentOutput(
+                    "O pagamento está preparado. Esta etapa da POC é uma simulação: considere 1 serviço para "
+                            + "cada ambiente contratado e envie o comprovante por aqui.",
+                    AgentNextAction.AWAIT_PAYMENT_PROOF);
+            case NOT_STARTED, REJECTED -> new AgentOutput(
+                    conversation.paymentStatus() == br.com.urbana.connect.domain.reception.model.PaymentStatus.NOT_STARTED
+                            ? "Para continuar, escolha uma forma de pagamento: PIX ou cartão de crédito."
+                            : "Não consigo confirmar essa etapa com segurança. Posso te orientar sobre o próximo passo?",
+                    AgentNextAction.AWAIT_CUSTOMER);
+            case CONFIRMED -> new AgentOutput(
+                    "Não consigo confirmar essa etapa com segurança. Posso te orientar sobre o próximo passo?",
+                    AgentNextAction.AWAIT_CUSTOMER);
+        };
+    }
+
+    private String ensureInitialPresentation(ReceptionConversation conversation, String text) {
+        boolean hasOutbound = transcript.findByConversationId(conversation.id()).stream()
+                .anyMatch(message -> message.direction() == ReceptionMessageDirection.OUTBOUND);
+        if (hasOutbound || identifiesUrbaAndUrbana(text)) return text;
+        return "Olá! Sou a Urba, assistente virtual da Urbana do Brasil. " + text;
+    }
+
+    private static boolean identifiesUrbaAndUrbana(String text) {
+        if (text == null) return false;
+        String normalized = text.toLowerCase(Locale.ROOT);
+        return normalized.contains("urba") && normalized.contains("urbana do brasil");
+    }
+
+    private boolean hasNewerInbound(ReceptionConversation conversation, ReceptionTurn turn) {
+        return transcript.findByConversationId(conversation.id()).stream()
+                .filter(message -> message.direction() == ReceptionMessageDirection.INBOUND)
+                .anyMatch(message -> turn.startedAt() != null && message.createdAt().isAfter(turn.startedAt())
+                        && !turn.inboundMessageIds().contains(message.id()));
+    }
+
+    private ReceptionConversation recordTermsPresentationIfNeeded(ReceptionConversation conversation,
+                                                                   ReceptionTurn turn,
+                                                                   ReceptionMessage outbound) {
+        if (termsAcceptance == null || invocations == null || conversation.termsStatus() != TermsStatus.PRESENTED
+                || conversation.activeTermsConsentId() != null || conversation.contractingUnitId() == null
+                || conversation.environmentLabel() == null || conversation.environmentSourceMessageId() == null) {
+            return conversation;
+        }
+        Optional<DomainToolInvocation> invocation = invocations.findByTurnId(turn.id()).stream()
+                .filter(value -> value.toolName() == DomainToolName.PREPARE_TERMS)
+                .filter(value -> value.status() == DomainToolInvocationStatus.SUCCEEDED)
+                .reduce((first, last) -> last);
+        if (invocation.isEmpty()) return conversation;
+        Object payload = invocation.get().resultPayload();
+        String resource = payload instanceof Map<?, ?> map && map.get("url") != null
+                ? map.get("url").toString() : null;
+        if (resource == null || resource.isBlank() || outbound.text() == null
+                || !outbound.text().contains(resource)) return conversation;
+        String presentationId = "terms:" + conversation.id() + ":" + conversation.contractingUnitId()
+                + ":" + invocation.get().id();
+        TermsConsentAudit audit = new TermsConsentAudit(presentationId, conversation.id(), conversation.contactId(),
+                turn.id(), conversation.contractingUnitId(), conversation.environmentLabel(),
+                conversation.environmentSourceMessageId(), conversation.selectedService(), resource, null,
+                invocation.get().id(), outbound.id(), outbound.createdAt(), null, null, null, null, outbound.createdAt(),
+                TermsConsentStatus.PRESENTED, conversation.version(), null);
+        termsAcceptance.recordPresentation(audit);
+        return conversations.save(conversation.activateTermsConsent(presentationId, outbound.createdAt()));
     }
 
     private AgentOutput parseSafely(String content) {

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationService.java
@@ -52,7 +52,7 @@ public final class ReceptionTurnReconciliationService {
                                               ReceptionTranscriptGateway transcript,
                                               ReceptionTurnGateway turns,
                                               Clock clock) {
-        this(hermes, conversations, transcript, turns, clock, null, null, null, null);
+        this(hermes, conversations, transcript, turns, clock, new Dependencies(null, null, null, null));
     }
 
     public ReceptionTurnReconciliationService(HermesSessionService hermes,
@@ -61,7 +61,7 @@ public final class ReceptionTurnReconciliationService {
                                               ReceptionTurnGateway turns,
                                               Clock clock,
                                               ActiveTurnLeaseService leases) {
-        this(hermes, conversations, transcript, turns, clock, leases, null, null, null);
+        this(hermes, conversations, transcript, turns, clock, new Dependencies(leases, null, null, null));
     }
 
     public ReceptionTurnReconciliationService(HermesSessionService hermes,
@@ -69,19 +69,23 @@ public final class ReceptionTurnReconciliationService {
                                               ReceptionTranscriptGateway transcript,
                                               ReceptionTurnGateway turns,
                                               Clock clock,
-                                              ActiveTurnLeaseService leases,
-                                              CommercialPolicyService policy,
-                                              TermsAcceptanceUseCase termsAcceptance,
-                                              DomainToolInvocationGateway invocations) {
+                                              Dependencies dependencies) {
         this.hermes = Objects.requireNonNull(hermes, "hermes");
         this.conversations = Objects.requireNonNull(conversations, "conversations");
         this.transcript = Objects.requireNonNull(transcript, "transcript");
         this.turns = Objects.requireNonNull(turns, "turns");
         this.clock = clock == null ? Clock.systemUTC() : clock;
-        this.leases = leases;
-        this.policy = policy;
-        this.termsAcceptance = termsAcceptance;
-        this.invocations = invocations;
+        Dependencies configured = Objects.requireNonNull(dependencies, "dependencies");
+        this.leases = configured.leases();
+        this.policy = configured.policy();
+        this.termsAcceptance = configured.termsAcceptance();
+        this.invocations = configured.invocations();
+    }
+
+    public record Dependencies(ActiveTurnLeaseService leases,
+                               CommercialPolicyService policy,
+                               TermsAcceptanceUseCase termsAcceptance,
+                               DomainToolInvocationGateway invocations) {
     }
 
     public Optional<String> reconcile(String turnOrEventId) {

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/TermsAcceptanceUseCase.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/TermsAcceptanceUseCase.java
@@ -1,0 +1,107 @@
+package br.com.urbana.connect.application.reception;
+
+import br.com.urbana.connect.domain.reception.model.TermsConsentAudit;
+import br.com.urbana.connect.domain.reception.model.TermsConsentStatus;
+import br.com.urbana.connect.domain.reception.model.ReceptionConversation;
+import br.com.urbana.connect.domain.reception.model.TermsStatus;
+import br.com.urbana.connect.domain.reception.port.out.ReceptionConversationGateway;
+import br.com.urbana.connect.domain.reception.port.out.TermsConsentAuditGateway;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/** Application boundary that prevents an acceptance without durable presentation evidence. */
+public class TermsAcceptanceUseCase {
+    private final TermsConsentAuditGateway audits;
+    private final ReceptionConversationGateway conversations;
+
+    /** Compatibility constructor for isolated domain tests and legacy callers. */
+    public TermsAcceptanceUseCase(TermsConsentAuditGateway audits) {
+        this(audits, null);
+    }
+
+    public TermsAcceptanceUseCase(TermsConsentAuditGateway audits,
+                                  ReceptionConversationGateway conversations) {
+        this.audits = Objects.requireNonNull(audits);
+        this.conversations = conversations;
+    }
+
+    public TermsConsentAudit recordAcceptance(String presentationId, String eventId, String messageId,
+                                              String exactText, long conversationVersion, Instant now) {
+        require(presentationId, "presentationId");
+        require(eventId, "eventId");
+        require(messageId, "messageId");
+        require(exactText, "exactText");
+        if (conversationVersion < 0) {
+            throw new IllegalArgumentException("conversationVersion must be non-negative");
+        }
+        Objects.requireNonNull(now, "now");
+        return audits.acceptIfPresented(presentationId, eventId, messageId, exactText, conversationVersion, now);
+    }
+
+    public TermsConsentAudit recordPresentation(TermsConsentAudit presentation) {
+        if (presentation.status() != br.com.urbana.connect.domain.reception.model.TermsConsentStatus.PRESENTED) {
+            throw new IllegalArgumentException("only a presented audit can be recorded as presentation evidence");
+        }
+        return audits.savePresentationIfAbsent(presentation);
+    }
+
+    /**
+     * Applies the commercial transition only after the CAS-backed evidence was
+     * accepted. Legacy conversations without an active presentation are
+     * intentionally rejected so terms are presented again instead of inferred.
+     */
+    @Transactional
+    public ReceptionConversation recordAcceptance(ReceptionConversation conversation, String eventId,
+                                                  String messageId, String exactText, Instant now,
+                                                  CommercialPolicyService policy) {
+        Objects.requireNonNull(conversation, "conversation");
+        if (conversation.termsStatus() != TermsStatus.PRESENTED || conversation.activeTermsConsentId() == null) {
+            throw new IllegalStateException("terms must be presented with durable evidence before acceptance");
+        }
+        TermsConsentAudit presented = audits.findByPresentationId(conversation.activeTermsConsentId())
+                .orElseThrow(() -> new IllegalStateException("terms presentation evidence is missing"));
+        if ((presented.status() != TermsConsentStatus.PRESENTED
+                && presented.status() != TermsConsentStatus.ACCEPTED)
+                || !conversation.id().equals(presented.conversationId())
+                || !Objects.equals(conversation.contractingUnitId(), presented.contractingUnitId())
+                || !Objects.equals(conversation.selectedService(), presented.serviceType())) {
+            throw new IllegalStateException("terms presentation evidence does not match the current contracting unit");
+        }
+        if (presented.status() == TermsConsentStatus.PRESENTED) {
+            recordAcceptance(presented.presentationId(), eventId, messageId, exactText,
+                    conversation.version(), now);
+        }
+        ReceptionConversation accepted = policy.acceptTerms(conversation, exactText, now);
+        return conversations == null ? accepted : conversations.save(accepted);
+    }
+
+    /** True when the production adapter owns the conversation write in the transaction. */
+    public boolean persistsConversation() {
+        return conversations != null;
+    }
+
+    /** Fails closed when a conversation points at missing or incomplete evidence. */
+    public TermsConsentAudit requireAcceptedEvidence(ReceptionConversation conversation) {
+        Objects.requireNonNull(conversation, "conversation");
+        if (conversation.activeTermsConsentId() == null) {
+            throw new IllegalStateException("durable terms presentation evidence is missing");
+        }
+        TermsConsentAudit audit = audits.findByPresentationId(conversation.activeTermsConsentId())
+                .orElseThrow(() -> new IllegalStateException("durable terms presentation evidence is missing"));
+        if (audit.status() != TermsConsentStatus.ACCEPTED
+                || !conversation.id().equals(audit.conversationId())
+                || !Objects.equals(conversation.contractingUnitId(), audit.contractingUnitId())
+                || !Objects.equals(conversation.selectedService(), audit.serviceType())) {
+            throw new IllegalStateException("durable terms acceptance evidence does not match the current contracting unit");
+        }
+        return audit;
+    }
+
+    private static void require(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+    }
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolService.java
@@ -42,6 +42,8 @@ import java.util.regex.Pattern;
  */
 public final class StatefulDomainToolService implements DomainToolService {
     private static final String NOT_INFORMED = "NÃO INFORMADO";
+    private static final String ENVIRONMENT = "ENVIRONMENT";
+    private static final String CUSTOMER_MESSAGE = "customerMessage";
     public static final String HUMAN_HANDOFF_ACK =
             "Vou encaminhar sua conversa para a arquiteta, que continuará com você por aqui.";
     private final CommercialPolicyService policy;
@@ -258,7 +260,7 @@ public final class StatefulDomainToolService implements DomainToolService {
             // but it is not a real contracting environment. Keeping it
             // tentative prevents the sentinel from creating a commercial
             // unit or unlocking terms.
-            confidence = "ENVIRONMENT".equals(type)
+            confidence = ENVIRONMENT.equals(type)
                     ? FactConfidence.TENTATIVE
                     : FactConfidence.CONFIRMED;
         } else if (requestedConfidence == FactConfidence.CONFIRMED
@@ -277,7 +279,7 @@ public final class StatefulDomainToolService implements DomainToolService {
             ReceptionConversation conversation = conversation(contactId);
             conversations.save(policy.selectService(conversation, value, now));
         }
-        if ("ENVIRONMENT".equals(type) && saved.confidence() == FactConfidence.CONFIRMED
+        if (ENVIRONMENT.equals(type) && saved.confidence() == FactConfidence.CONFIRMED
                 && !isNotInformedValue(saved.value())) {
             ReceptionConversation conversation = conversation(contactId);
             String unitId = contractingUnitId(conversation.id(), sourceMessageId, value);
@@ -369,21 +371,21 @@ public final class StatefulDomainToolService implements DomainToolService {
             return Map.of("status", "PREPARED", "serviceType", conversation.selectedService(),
                     "instruction", policy.paymentUrl(conversation.selectedService()),
                     "nextAction", "AWAIT_PAYMENT_PROOF",
-                    "customerMessage", "Pagamento preparado. No link da POC, que é uma simulação, considere 1 serviço para cada ambiente contratado. Depois do pagamento, envie o comprovante por aqui.");
+                    CUSTOMER_MESSAGE, "Pagamento preparado. No link da POC, que é uma simulação, considere 1 serviço para cada ambiente contratado. Depois do pagamento, envie o comprovante por aqui.");
         }
         return switch (conversation.paymentStatus()) {
             case PREPARED -> Map.of("status", "ALREADY_PREPARED", "serviceType", conversation.selectedService(),
                     "nextAction", "AWAIT_PAYMENT_PROOF",
-                    "customerMessage", "O pagamento já foi preparado. Aguardo o comprovante por aqui.");
+                    CUSTOMER_MESSAGE, "O pagamento já foi preparado. Aguardo o comprovante por aqui.");
             case PROOF_RECEIVED -> Map.of("status", "PROOF_RECEIVED", "serviceType", conversation.selectedService(),
                     "nextAction", "AWAIT_PAYMENT_APPROVAL",
-                    "customerMessage", "O comprovante já foi recebido e aguarda validação humana.");
+                    CUSTOMER_MESSAGE, "O comprovante já foi recebido e aguarda validação humana.");
             case CONFIRMED -> Map.of("status", "CONFIRMED", "serviceType", conversation.selectedService(),
                     "nextAction", "NONE",
-                    "customerMessage", "O pagamento já foi confirmado pela arquiteta.");
+                    CUSTOMER_MESSAGE, "O pagamento já foi confirmado pela arquiteta.");
             case NOT_STARTED, REJECTED -> Map.of("status", conversation.paymentStatus().name(),
                     "serviceType", conversation.selectedService(), "nextAction", "NONE",
-                    "customerMessage", "Preciso confirmar essa etapa antes de continuar.");
+                    CUSTOMER_MESSAGE, "Preciso confirmar essa etapa antes de continuar.");
         };
     }
 
@@ -483,10 +485,6 @@ public final class StatefulDomainToolService implements DomainToolService {
         return supported == null ? context.sourceMessageId() : supported;
     }
 
-    private String sourceText(ToolExecutionContext context) {
-        return sourceText(context.sourceMessageId());
-    }
-
     private String sourceText(String eventId) {
         if (transcript == null) {
             return "";
@@ -497,7 +495,7 @@ public final class StatefulDomainToolService implements DomainToolService {
 
     private static boolean explicitlySupports(String type, String value, String source) {
         if (isNotInformedValue(value)) {
-            return !"ENVIRONMENT".equals(type);
+            return !ENVIRONMENT.equals(type);
         }
         if (source == null || source.isBlank()) return false;
         String normalizedSource = normalizeEvidence(source);
@@ -532,7 +530,7 @@ public final class StatefulDomainToolService implements DomainToolService {
         return switch (type) {
             case "PRONOUN_PREFERENCE" -> normalizedSource.contains(normalizedValue);
             case "OCCUPATION", "NEED" -> normalizedSource.contains(normalizedValue);
-            case "ENVIRONMENT" -> containsWholePhrase(normalizedSource, normalizedValue);
+            case ENVIRONMENT -> containsWholePhrase(normalizedSource, normalizedValue);
             case "SELECTED_SERVICE" -> normalizedSource.contains(normalizedValue);
             default -> false;
         };
@@ -570,7 +568,7 @@ public final class StatefulDomainToolService implements DomainToolService {
             case "FIRST_TIME_HIRING" -> canonicalFirstTimeHiring(value);
             case "SELECTED_SERVICE" -> canonicalService(value);
             case "NEED" -> value.trim();
-            case "ENVIRONMENT" -> isNotInformedValue(value) ? NOT_INFORMED : value.trim();
+            case ENVIRONMENT -> isNotInformedValue(value) ? NOT_INFORMED : value.trim();
             default -> value.trim();
         };
     }
@@ -670,7 +668,7 @@ public final class StatefulDomainToolService implements DomainToolService {
             case "SELECTED SERVICE", "SERVICE", "SERVICO", "SELECTED SERVICO" ->
                     "SELECTED_SERVICE";
             case "NEED", "NECESSIDADE", "PROJECT NEED" -> "NEED";
-            case "ENVIRONMENT", "AMBIENTE" -> "ENVIRONMENT";
+            case ENVIRONMENT, "AMBIENTE" -> ENVIRONMENT;
             default -> normalized.replace(' ', '_');
         };
     }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolService.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolService.java
@@ -1,6 +1,7 @@
 package br.com.urbana.connect.application.reception.tools;
 
 import br.com.urbana.connect.application.reception.CommercialPolicyService;
+import br.com.urbana.connect.application.reception.TermsAcceptanceUseCase;
 import br.com.urbana.connect.domain.reception.model.CustomerFact;
 import br.com.urbana.connect.domain.reception.model.CustomerFactType;
 import br.com.urbana.connect.domain.reception.model.FactConfidence;
@@ -23,6 +24,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.text.Normalizer;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -30,6 +33,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 /**
  * The six allowlisted tools mutate only authoritative Urbana state. Hermes
@@ -46,6 +50,7 @@ public final class StatefulDomainToolService implements DomainToolService {
     private final ReceptionTranscriptGateway transcript;
     private IcpObservationEventGateway icpObservations;
     private HumanHandoffNotificationGateway handoffNotifications;
+    private TermsAcceptanceUseCase termsAcceptance;
 
     public StatefulDomainToolService(CommercialPolicyService policy,
                                      ReceptionConversationGateway conversations,
@@ -90,6 +95,11 @@ public final class StatefulDomainToolService implements DomainToolService {
     @Autowired(required = false)
     void setHumanHandoffNotificationGateway(HumanHandoffNotificationGateway handoffNotifications) {
         this.handoffNotifications = handoffNotifications;
+    }
+
+    @Autowired(required = false)
+    public void setTermsAcceptanceUseCase(TermsAcceptanceUseCase termsAcceptance) {
+        this.termsAcceptance = termsAcceptance;
     }
 
     @Override
@@ -141,17 +151,26 @@ public final class StatefulDomainToolService implements DomainToolService {
                 if (isServiceSelectionRejection(rejection)) {
                     yield serviceSelectionRejection();
                 }
-                if (conversation.termsStatus() != br.com.urbana.connect.domain.reception.model.TermsStatus.ACCEPTED
-                        && isTermsRejection(rejection)) {
+                if (isTermsRejection(rejection) && (conversation.termsStatus()
+                        != br.com.urbana.connect.domain.reception.model.TermsStatus.ACCEPTED
+                        || conversation.activeTermsConsentId() == null
+                        || rejection.getMessage().toLowerCase(Locale.ROOT).contains("durable terms"))) {
                     yield termsRejection();
                 }
                 yield new DomainToolInvocationUseCase.DomainRejectionException(
                         "BUSINESS_RULE_REJECTED", "ASK_FOR_CLARIFICATION", List.of(),
                         "Preciso confirmar uma informação antes de continuar.");
             }
-            case PREPARE_TERMS -> new DomainToolInvocationUseCase.DomainRejectionException(
-                    "SERVICE_NOT_CONFIRMED", "CONFIRM_SERVICE", List.of("serviceType"),
-                    "Preciso confirmar o serviço escolhido antes de apresentar os termos.");
+            case PREPARE_TERMS -> {
+                if (rejection.getMessage() != null && rejection.getMessage().contains("environment")) {
+                    yield new DomainToolInvocationUseCase.DomainRejectionException(
+                            "ENVIRONMENT_NOT_CONFIRMED", "ASK_FOR_ENVIRONMENT", List.of("environment"),
+                            "Para preparar os termos, preciso confirmar qual ambiente você deseja contratar.");
+                }
+                yield new DomainToolInvocationUseCase.DomainRejectionException(
+                        "SERVICE_NOT_CONFIRMED", "CONFIRM_SERVICE", List.of("serviceType"),
+                        "Preciso confirmar o serviço escolhido antes de apresentar os termos.");
+            }
             case UPDATE_CUSTOMER_FACT -> new DomainToolInvocationUseCase.DomainRejectionException(
                     "CUSTOMER_INFORMATION_INVALID", "ASK_FOR_CLARIFICATION", List.of(),
                     "Preciso confirmar essa informação antes de continuar.");
@@ -232,9 +251,16 @@ public final class StatefulDomainToolService implements DomainToolService {
         FactConfidence requestedConfidence = confidence(args);
         FactConfidence confidence = requestedConfidence;
         Instant now = context.now();
-        String sourceText = sourceText(context);
+        String sourceMessageId = sourceMessageIdFor(type, value, context);
+        String sourceText = sourceText(sourceMessageId);
         if (isNotInformedValue(value)) {
-            confidence = FactConfidence.CONFIRMED;
+            // A refusal is a valid terminal answer for optional ICP fields,
+            // but it is not a real contracting environment. Keeping it
+            // tentative prevents the sentinel from creating a commercial
+            // unit or unlocking terms.
+            confidence = "ENVIRONMENT".equals(type)
+                    ? FactConfidence.TENTATIVE
+                    : FactConfidence.CONFIRMED;
         } else if (requestedConfidence == FactConfidence.CONFIRMED
                 && !explicitlySupports(type, value, sourceText)) {
             // A model cannot turn an unsupported claim into a confirmed fact.
@@ -243,13 +269,19 @@ public final class StatefulDomainToolService implements DomainToolService {
         }
         List<CustomerFact> current = facts.findCurrentByContactId(contactId, now);
         CustomerFact newFact = new CustomerFact(contactId, type, value, confidence,
-                context.sourceMessageId(), now);
+                sourceMessageId, now);
         current.stream().filter(f -> type.equalsIgnoreCase(f.type()) && f.supersededBy() == null)
                 .forEach(previous -> facts.save(previous.supersede(newFact.id(), now)));
         CustomerFact saved = facts.save(newFact);
         if ("SELECTED_SERVICE".equals(type)) {
             ReceptionConversation conversation = conversation(contactId);
             conversations.save(policy.selectService(conversation, value, now));
+        }
+        if ("ENVIRONMENT".equals(type) && saved.confidence() == FactConfidence.CONFIRMED
+                && !isNotInformedValue(saved.value())) {
+            ReceptionConversation conversation = conversation(contactId);
+            String unitId = contractingUnitId(conversation.id(), sourceMessageId, value);
+            conversations.save(conversation.bindContractingUnit(unitId, value, sourceMessageId, now));
         }
         return Map.of("status", "RECORDED", "factType", saved.type(), "value", saved.value(),
                 "confidence", saved.confidence().name());
@@ -280,6 +312,10 @@ public final class StatefulDomainToolService implements DomainToolService {
                                               ToolExecutionContext context) {
         Instant now = context.now();
         ReceptionConversation conversation = conversation(contactId);
+        if (conversation.contractingUnitId() == null || conversation.environmentLabel() == null
+                || conversation.environmentSourceMessageId() == null) {
+            throw new IllegalStateException("environment must be explicitly bound before terms");
+        }
         String requested = stringArg(args, "serviceType");
         String canonicalRequested = policy.service(requested).serviceType();
         if (conversation.selectedService() == null) {
@@ -311,13 +347,14 @@ public final class StatefulDomainToolService implements DomainToolService {
                 || !conversation.selectedService().equalsIgnoreCase(canonicalServiceType)) {
             throw new IllegalStateException("service does not match the selected catalog item");
         }
-        if (conversation.termsStatus() == br.com.urbana.connect.domain.reception.model.TermsStatus.PRESENTED) {
-            String source = sourceText(context);
-            if (!policy.isExplicitTermsAcceptance(source)) {
-                throw new IllegalStateException("payment requires explicit terms acceptance in the bound inbound message");
-            }
-            conversation = conversations.save(policy.acceptTerms(conversation, now));
+        if (conversation.termsStatus() != br.com.urbana.connect.domain.reception.model.TermsStatus.ACCEPTED
+                || conversation.activeTermsConsentId() == null) {
+            throw new IllegalStateException("payment requires accepted terms with durable consent evidence");
         }
+        if (termsAcceptance == null) {
+            throw new IllegalStateException("durable terms acceptance evidence is unavailable");
+        }
+        termsAcceptance.requireAcceptedEvidence(conversation);
         ReceptionConversation prepared = policy.preparePayment(conversation, facts.findByContactId(contactId),
                 stringArg(args, "method"), now);
         if (prepared != conversation) {
@@ -332,7 +369,7 @@ public final class StatefulDomainToolService implements DomainToolService {
             return Map.of("status", "PREPARED", "serviceType", conversation.selectedService(),
                     "instruction", policy.paymentUrl(conversation.selectedService()),
                     "nextAction", "AWAIT_PAYMENT_PROOF",
-                    "customerMessage", "Pagamento preparado. Realize o pagamento pelo link e envie o comprovante por aqui.");
+                    "customerMessage", "Pagamento preparado. No link da POC, que é uma simulação, considere 1 serviço para cada ambiente contratado. Depois do pagamento, envie o comprovante por aqui.");
         }
         return switch (conversation.paymentStatus()) {
             case PREPARED -> Map.of("status", "ALREADY_PREPARED", "serviceType", conversation.selectedService(),
@@ -435,17 +472,32 @@ public final class StatefulDomainToolService implements DomainToolService {
         return value == null ? FactConfidence.CONFIRMED : FactConfidence.valueOf(value.toString().toUpperCase(Locale.ROOT));
     }
 
+    private String sourceMessageIdFor(String type, String value, ToolExecutionContext context) {
+        if (transcript == null) {
+            return context.sourceMessageId();
+        }
+        String supported = context.sourceMessageIds().stream()
+                .filter(eventId -> explicitlySupports(type, value, sourceText(eventId)))
+                .reduce((first, last) -> last)
+                .orElse(null);
+        return supported == null ? context.sourceMessageId() : supported;
+    }
+
     private String sourceText(ToolExecutionContext context) {
+        return sourceText(context.sourceMessageId());
+    }
+
+    private String sourceText(String eventId) {
         if (transcript == null) {
             return "";
         }
-        return transcript.findByEventId(context.sourceMessageId()).map(message ->
+        return transcript.findByEventId(eventId).map(message ->
                 message.text() == null ? "" : message.text()).orElse("");
     }
 
     private static boolean explicitlySupports(String type, String value, String source) {
         if (isNotInformedValue(value)) {
-            return true;
+            return !"ENVIRONMENT".equals(type);
         }
         if (source == null || source.isBlank()) return false;
         String normalizedSource = normalizeEvidence(source);
@@ -480,9 +532,26 @@ public final class StatefulDomainToolService implements DomainToolService {
         return switch (type) {
             case "PRONOUN_PREFERENCE" -> normalizedSource.contains(normalizedValue);
             case "OCCUPATION", "NEED" -> normalizedSource.contains(normalizedValue);
+            case "ENVIRONMENT" -> containsWholePhrase(normalizedSource, normalizedValue);
             case "SELECTED_SERVICE" -> normalizedSource.contains(normalizedValue);
             default -> false;
         };
+    }
+
+    private static boolean containsWholePhrase(String normalizedSource, String normalizedValue) {
+        if (normalizedValue == null || normalizedValue.isBlank()) {
+            return false;
+        }
+        String sourceWords = normalizedSource.replaceAll("[^\\p{L}\\p{N}]+", " ").trim()
+                .replaceAll("\\s+", " ");
+        String valueWords = normalizedValue.replaceAll("[^\\p{L}\\p{N}]+", " ").trim()
+                .replaceAll("\\s+", " ");
+        if (valueWords.isBlank()) {
+            return false;
+        }
+        Pattern phrase = Pattern.compile("(?<![\\p{L}\\p{N}])" + Pattern.quote(valueWords)
+                + "(?![\\p{L}\\p{N}])");
+        return phrase.matcher(sourceWords).find();
     }
 
     private static boolean containsNegation(String normalizedSource) {
@@ -501,6 +570,7 @@ public final class StatefulDomainToolService implements DomainToolService {
             case "FIRST_TIME_HIRING" -> canonicalFirstTimeHiring(value);
             case "SELECTED_SERVICE" -> canonicalService(value);
             case "NEED" -> value.trim();
+            case "ENVIRONMENT" -> isNotInformedValue(value) ? NOT_INFORMED : value.trim();
             default -> value.trim();
         };
     }
@@ -560,6 +630,17 @@ public final class StatefulDomainToolService implements DomainToolService {
                 .replaceAll("\\s+", "_");
     }
 
+    private static String contractingUnitId(String conversationId, String sourceMessageId, String label) {
+        try {
+            String canonicalLabel = normalizeEvidence(label);
+            byte[] hash = MessageDigest.getInstance("SHA-256").digest(
+                    (conversationId + ":" + sourceMessageId + ":" + canonicalLabel).getBytes(StandardCharsets.UTF_8));
+            return "unit_" + HexFormat.of().formatHex(hash, 0, 16);
+        } catch (java.security.NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is unavailable", impossible);
+        }
+    }
+
     private static String stringArg(Map<String, Object> args, String key) {
         Object value = args.get(key);
         if (value == null || value.toString().isBlank()) {
@@ -589,6 +670,7 @@ public final class StatefulDomainToolService implements DomainToolService {
             case "SELECTED SERVICE", "SERVICE", "SERVICO", "SELECTED SERVICO" ->
                     "SELECTED_SERVICE";
             case "NEED", "NECESSIDADE", "PROJECT NEED" -> "NEED";
+            case "ENVIRONMENT", "AMBIENTE" -> "ENVIRONMENT";
             default -> normalized.replace(' ', '_');
         };
     }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/ToolExecutionContext.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/tools/ToolExecutionContext.java
@@ -3,6 +3,7 @@ package br.com.urbana.connect.application.reception.tools;
 import br.com.urbana.connect.domain.reception.model.ActiveTurnLease;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 
 /** Backend-resolved provenance for a domain tool invocation. */
@@ -14,5 +15,10 @@ public record ToolExecutionContext(ActiveTurnLease lease, Instant now) {
 
     public String sourceMessageId() {
         return lease.sourceMessageId();
+    }
+
+    /** All inbound event ids released in this turn, in chronological order. */
+    public List<String> sourceMessageIds() {
+        return lease.sourceMessageIds();
     }
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/ActiveTurnLease.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/ActiveTurnLease.java
@@ -1,6 +1,7 @@
 package br.com.urbana.connect.domain.reception.model;
 
 import java.time.Instant;
+import java.util.List;
 
 public record ActiveTurnLease(
         String hermesSessionId,
@@ -12,12 +13,21 @@ public record ActiveTurnLease(
         Instant expiresAt,
         Instant revokedAt,
         long version,
-        String claimToken) {
+        String claimToken,
+        List<String> sourceMessageIds) {
     public ActiveTurnLease(String hermesSessionId, String turnId, String contactId, String sourceMessageId,
                            ActiveTurnLeaseStatus status, Instant acquiredAt, Instant expiresAt,
                            Instant revokedAt, long version) {
         this(hermesSessionId, turnId, contactId, sourceMessageId, status, acquiredAt, expiresAt,
-                revokedAt, version, turnId + ":" + version);
+                revokedAt, version, turnId + ":" + version, List.of(sourceMessageId));
+    }
+
+    /** Compatibility constructor for persisted leases created before batched provenance. */
+    public ActiveTurnLease(String hermesSessionId, String turnId, String contactId, String sourceMessageId,
+                           ActiveTurnLeaseStatus status, Instant acquiredAt, Instant expiresAt,
+                           Instant revokedAt, long version, String claimToken) {
+        this(hermesSessionId, turnId, contactId, sourceMessageId, status, acquiredAt, expiresAt,
+                revokedAt, version, claimToken, List.of(sourceMessageId));
     }
 
     public ActiveTurnLease {
@@ -36,6 +46,11 @@ public record ActiveTurnLease(
         }
         claimToken = claimToken == null || claimToken.isBlank()
                 ? turnId + ":" + version : claimToken;
+        if (sourceMessageIds == null || sourceMessageIds.isEmpty()
+                || sourceMessageIds.stream().anyMatch(value -> value == null || value.isBlank())) {
+            throw new IllegalArgumentException("sourceMessageIds must contain at least one non-blank event id");
+        }
+        sourceMessageIds = List.copyOf(sourceMessageIds);
     }
 
     public boolean isActiveAt(Instant now) {
@@ -52,7 +67,8 @@ public record ActiveTurnLease(
             return this;
         }
         return new ActiveTurnLease(hermesSessionId, turnId, contactId, sourceMessageId,
-                ActiveTurnLeaseStatus.REVOKED, acquiredAt, expiresAt, now, version + 1, claimToken);
+                ActiveTurnLeaseStatus.REVOKED, acquiredAt, expiresAt, now, version + 1, claimToken,
+                sourceMessageIds);
     }
 
     public ActiveTurnLease expire(Instant now) {
@@ -60,7 +76,8 @@ public record ActiveTurnLease(
             return this;
         }
         return new ActiveTurnLease(hermesSessionId, turnId, contactId, sourceMessageId,
-                ActiveTurnLeaseStatus.EXPIRED, acquiredAt, expiresAt, null, version + 1, claimToken);
+                ActiveTurnLeaseStatus.EXPIRED, acquiredAt, expiresAt, null, version + 1, claimToken,
+                sourceMessageIds);
     }
 
     public ActiveTurnLease reconcile(Instant now) {
@@ -68,7 +85,8 @@ public record ActiveTurnLease(
             return this;
         }
         return new ActiveTurnLease(hermesSessionId, turnId, contactId, sourceMessageId,
-                ActiveTurnLeaseStatus.RECONCILING, acquiredAt, expiresAt, null, version + 1, claimToken);
+                ActiveTurnLeaseStatus.RECONCILING, acquiredAt, expiresAt, null, version + 1, claimToken,
+                sourceMessageIds);
     }
 
     public ActiveTurnLease heartbeat(Instant now, java.time.Duration ttl) {
@@ -79,7 +97,8 @@ public record ActiveTurnLease(
             return this;
         }
         return new ActiveTurnLease(hermesSessionId, turnId, contactId, sourceMessageId,
-                status, acquiredAt, now.plus(ttl), revokedAt, version + 1, claimToken);
+                status, acquiredAt, now.plus(ttl), revokedAt, version + 1, claimToken,
+                sourceMessageIds);
     }
 
     private static void require(String value, String name) {

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/CustomerFactType.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/CustomerFactType.java
@@ -8,7 +8,9 @@ public enum CustomerFactType {
     FIRST_TIME_HIRING,
     OCCUPATION,
     NEED,
-    SELECTED_SERVICE;
+    SELECTED_SERVICE,
+    /** Explicit environment binding; operational metadata, never an ICP field. */
+    ENVIRONMENT;
 
     private static final List<String> ICP_FIELD_NAMES = List.of(
             PRONOUN_PREFERENCE.name(), FIRST_TIME_HIRING.name(), OCCUPATION.name());

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/ReceptionConversation.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/ReceptionConversation.java
@@ -24,7 +24,26 @@ public record ReceptionConversation(
         int resumeBoundarySequence,
         String resumeDecisionAction,
         String resumeDecisionMessage,
-        String resumeFailureCode) {
+        String resumeFailureCode,
+        String contractingUnitId,
+        String environmentLabel,
+        String environmentSourceMessageId,
+        String activeTermsConsentId) {
+
+    /** Compatibility constructor for persisted conversations created before unit binding. */
+    public ReceptionConversation(String id, String contactId, ReceptionMode mode,
+                                 CommercialStage commercialStage, String selectedService,
+                                 TermsStatus termsStatus, PaymentStatus paymentStatus,
+                                 String handoffReason, Instant createdAt, Instant updatedAt,
+                                 long version, ResumeStatus resumeStatus, String resumeId,
+                                 String resumeIdempotencyKey, String resumeChecksum,
+                                 int resumeBoundarySequence, String resumeDecisionAction,
+                                 String resumeDecisionMessage, String resumeFailureCode) {
+        this(id, contactId, mode, commercialStage, selectedService, termsStatus, paymentStatus,
+                handoffReason, createdAt, updatedAt, version, resumeStatus, resumeId,
+                resumeIdempotencyKey, resumeChecksum, resumeBoundarySequence, resumeDecisionAction,
+                resumeDecisionMessage, resumeFailureCode, null, null, null, null);
+    }
 
     public ReceptionConversation(String id, String contactId, ReceptionMode mode,
                                  CommercialStage commercialStage, String selectedService,
@@ -87,6 +106,24 @@ public record ReceptionConversation(
                 handoffReason, now);
     }
 
+    public ReceptionConversation bindContractingUnit(String unitId, String label, String sourceMessageId, Instant now) {
+        require(unitId, "contractingUnitId"); require(label, "environmentLabel"); require(sourceMessageId, "environmentSourceMessageId");
+        if (Objects.equals(contractingUnitId, unitId)) return this;
+        return new ReceptionConversation(id, contactId, mode, CommercialStage.DISCOVERY, null,
+                TermsStatus.NOT_PRESENTED, PaymentStatus.NOT_STARTED, handoffReason, createdAt, now, version + 1,
+                resumeStatus, resumeId, resumeIdempotencyKey, resumeChecksum, resumeBoundarySequence,
+                resumeDecisionAction, resumeDecisionMessage, resumeFailureCode, unitId, label, sourceMessageId, null);
+    }
+
+    public ReceptionConversation activateTermsConsent(String consentId, Instant now) {
+        require(consentId, "activeTermsConsentId");
+        return new ReceptionConversation(id, contactId, mode, commercialStage, selectedService, termsStatus,
+                paymentStatus, handoffReason, createdAt, now, version + 1, resumeStatus, resumeId,
+                resumeIdempotencyKey, resumeChecksum, resumeBoundarySequence, resumeDecisionAction,
+                resumeDecisionMessage, resumeFailureCode, contractingUnitId, environmentLabel,
+                environmentSourceMessageId, consentId);
+    }
+
     public ReceptionConversation presentTerms(Instant now) {
         if (selectedService == null) {
             throw new IllegalStateException("service must be selected before terms");
@@ -96,6 +133,29 @@ public record ReceptionConversation(
         }
         return copy(mode, CommercialStage.TERMS, selectedService, TermsStatus.PRESENTED,
                 paymentStatus, handoffReason, now);
+    }
+
+    /**
+     * Reopens a legacy accepted conversation whose presentation evidence was
+     * never recorded. Payment is reset so an old inferred acceptance can never
+     * authorize a new charge without a fresh, auditable presentation.
+     */
+    public ReceptionConversation reopenTermsForAudit(Instant now) {
+        if (termsStatus != TermsStatus.ACCEPTED || activeTermsConsentId != null) {
+            throw new IllegalStateException("only an unaudited accepted conversation can reopen terms");
+        }
+        if (selectedService == null) {
+            throw new IllegalStateException("service must be selected before terms");
+        }
+        if (mode != ReceptionMode.AI) {
+            throw new IllegalStateException("human conversation cannot reopen terms");
+        }
+        return new ReceptionConversation(id, contactId, mode, CommercialStage.TERMS, selectedService,
+                TermsStatus.PRESENTED, PaymentStatus.NOT_STARTED, handoffReason, createdAt,
+                Objects.requireNonNull(now, "now"), version + 1, resumeStatus, resumeId,
+                resumeIdempotencyKey, resumeChecksum, resumeBoundarySequence, resumeDecisionAction,
+                resumeDecisionMessage, resumeFailureCode, contractingUnitId, environmentLabel,
+                environmentSourceMessageId, null);
     }
 
     public ReceptionConversation acceptTerms(Instant now) {
@@ -222,7 +282,8 @@ public record ReceptionConversation(
         return new ReceptionConversation(id, contactId, nextMode, nextStage, nextService,
                 nextTerms, nextPayment, nextReason, createdAt, now, version + 1,
                 nextResumeStatus, nextResumeId, nextResumeKey, nextChecksum, nextBoundary,
-                nextAction, nextMessage, nextFailure);
+                nextAction, nextMessage, nextFailure, contractingUnitId, environmentLabel,
+                environmentSourceMessageId, Objects.equals(nextService, selectedService) ? activeTermsConsentId : null);
     }
 
     private static String require(String value, String field) {

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/TermsConsentAudit.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/TermsConsentAudit.java
@@ -23,9 +23,9 @@ public record TermsConsentAudit(
         require(environmentSourceMessageId, "environmentSourceMessageId"); require(serviceType, "serviceType");
         require(termsResource, "termsResource"); require(prepareTermsInvocationId, "prepareTermsInvocationId");
         require(termsOutboundMessageId, "termsOutboundMessageId");
-        presentedAt = Objects.requireNonNull(presentedAt, "presentedAt");
-        recordedAt = Objects.requireNonNull(recordedAt, "recordedAt");
-        status = Objects.requireNonNull(status, "status");
+        Objects.requireNonNull(presentedAt, "presentedAt");
+        Objects.requireNonNull(recordedAt, "recordedAt");
+        Objects.requireNonNull(status, "status");
         if (conversationVersionAtPresentation < 0) throw new IllegalArgumentException("presentation version must be non-negative");
         if (status == TermsConsentStatus.PRESENTED && (acceptanceMessageId != null || acceptanceEventId != null
                 || acceptanceTextExact != null || acceptedAt != null || conversationVersionAtAcceptance != null)) {
@@ -34,7 +34,7 @@ public record TermsConsentAudit(
         if (status == TermsConsentStatus.ACCEPTED) {
             require(acceptanceMessageId, "acceptanceMessageId"); require(acceptanceEventId, "acceptanceEventId");
             require(acceptanceTextExact, "acceptanceTextExact");
-            acceptedAt = Objects.requireNonNull(acceptedAt, "acceptedAt");
+            Objects.requireNonNull(acceptedAt, "acceptedAt");
             if (conversationVersionAtAcceptance == null || conversationVersionAtAcceptance < 0) {
                 throw new IllegalArgumentException("acceptance version must be non-negative");
             }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/TermsConsentAudit.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/TermsConsentAudit.java
@@ -1,0 +1,66 @@
+package br.com.urbana.connect.domain.reception.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Durable evidence for one resource presented to one contracting unit.  The
+ * first accepted inbound event wins; later events cannot rewrite its text.
+ */
+public record TermsConsentAudit(
+        String presentationId, String conversationId, String contactId, String turnId,
+        String contractingUnitId, String environmentLabelSnapshot, String environmentSourceMessageId,
+        String serviceType, String termsResource, String termsVersion, String prepareTermsInvocationId,
+        String termsOutboundMessageId, Instant presentedAt, String acceptanceMessageId,
+        String acceptanceEventId, String acceptanceTextExact, Instant acceptedAt, Instant recordedAt,
+        TermsConsentStatus status, long conversationVersionAtPresentation,
+        Long conversationVersionAtAcceptance) {
+
+    public TermsConsentAudit {
+        require(presentationId, "presentationId"); require(conversationId, "conversationId");
+        require(contactId, "contactId"); require(turnId, "turnId"); require(contractingUnitId, "contractingUnitId");
+        require(environmentLabelSnapshot, "environmentLabelSnapshot");
+        require(environmentSourceMessageId, "environmentSourceMessageId"); require(serviceType, "serviceType");
+        require(termsResource, "termsResource"); require(prepareTermsInvocationId, "prepareTermsInvocationId");
+        require(termsOutboundMessageId, "termsOutboundMessageId");
+        presentedAt = Objects.requireNonNull(presentedAt, "presentedAt");
+        recordedAt = Objects.requireNonNull(recordedAt, "recordedAt");
+        status = Objects.requireNonNull(status, "status");
+        if (conversationVersionAtPresentation < 0) throw new IllegalArgumentException("presentation version must be non-negative");
+        if (status == TermsConsentStatus.PRESENTED && (acceptanceMessageId != null || acceptanceEventId != null
+                || acceptanceTextExact != null || acceptedAt != null || conversationVersionAtAcceptance != null)) {
+            throw new IllegalArgumentException("presented audit cannot contain acceptance evidence");
+        }
+        if (status == TermsConsentStatus.ACCEPTED) {
+            require(acceptanceMessageId, "acceptanceMessageId"); require(acceptanceEventId, "acceptanceEventId");
+            require(acceptanceTextExact, "acceptanceTextExact");
+            acceptedAt = Objects.requireNonNull(acceptedAt, "acceptedAt");
+            if (conversationVersionAtAcceptance == null || conversationVersionAtAcceptance < 0) {
+                throw new IllegalArgumentException("acceptance version must be non-negative");
+            }
+        }
+    }
+
+    public TermsConsentAudit accept(String messageId, String eventId, String exactText,
+                                    Instant now, long conversationVersion) {
+        if (status == TermsConsentStatus.ACCEPTED) return this;
+        require(messageId, "acceptanceMessageId");
+        require(eventId, "acceptanceEventId");
+        require(exactText, "acceptanceTextExact");
+        Objects.requireNonNull(now, "acceptedAt");
+        if (now.isBefore(presentedAt)) {
+            throw new IllegalStateException("terms acceptance cannot precede presentation");
+        }
+        if (conversationVersion < 0) {
+            throw new IllegalArgumentException("acceptance version must be non-negative");
+        }
+        return new TermsConsentAudit(presentationId, conversationId, contactId, turnId, contractingUnitId,
+                environmentLabelSnapshot, environmentSourceMessageId, serviceType, termsResource, termsVersion,
+                prepareTermsInvocationId, termsOutboundMessageId, presentedAt, messageId, eventId, exactText,
+                now, now, TermsConsentStatus.ACCEPTED, conversationVersionAtPresentation, conversationVersion);
+    }
+
+    private static void require(String value, String field) {
+        if (value == null || value.isBlank()) throw new IllegalArgumentException(field + " must not be blank");
+    }
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/TermsConsentStatus.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/TermsConsentStatus.java
@@ -1,0 +1,7 @@
+package br.com.urbana.connect.domain.reception.model;
+
+/** Immutable lifecycle for the evidence attached to one terms presentation. */
+public enum TermsConsentStatus {
+    PRESENTED,
+    ACCEPTED
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/port/out/TermsConsentAuditGateway.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/port/out/TermsConsentAuditGateway.java
@@ -1,0 +1,14 @@
+package br.com.urbana.connect.domain.reception.port.out;
+
+import br.com.urbana.connect.domain.reception.model.TermsConsentAudit;
+
+import java.util.Optional;
+
+public interface TermsConsentAuditGateway {
+    Optional<TermsConsentAudit> findByPresentationId(String presentationId);
+    Optional<TermsConsentAudit> findPresented(String conversationId, String contractingUnitId);
+    TermsConsentAudit savePresentationIfAbsent(TermsConsentAudit audit);
+    TermsConsentAudit acceptIfPresented(String presentationId, String acceptanceEventId,
+                                        String acceptanceMessageId, String acceptanceTextExact,
+                                        long conversationVersion, java.time.Instant acceptedAt);
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItem.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItem.java
@@ -24,10 +24,10 @@ public record ServiceCatalogItem(
         boolean available) {
 
     private static final List<String> COMMON_DELIVERABLES = List.of(
-            "Manual PDF",
+            "Manual do Espaço em PDF",
             "Tour Virtual",
             "3 opções de solução",
-            "2 rodadas consolidadas");
+            "2 rodadas de alterações ou ajustes");
 
     private static final List<String> COMMON_PROCESS = List.of(
             "briefing",
@@ -41,7 +41,7 @@ public record ServiceCatalogItem(
             "7 dias úteis a partir do início da produção",
             "pausa do prazo enquanto o cliente estiver pendente de feedback ou aprovação",
             "aprovação final explícita",
-            "entrega por e-mail do Manual PDF e do Tour Virtual",
+            "entrega por e-mail do Manual do Espaço em PDF e do Tour Virtual",
             "suporte de 3 meses pelo WhatsApp");
 
     private static final List<String> COMMON_RESPONSIBILITIES = List.of(
@@ -147,7 +147,7 @@ public record ServiceCatalogItem(
                         ServiceType.DECOR_REFORMA,
                         "Decor Reforma",
                         "🧱",
-                        "Solução para reforma interna; demandas técnicas específicas dependem de avaliação da arquiteta.",
+                        "Consultoria online para reforma de ambiente interno. Atende até 20 m² por ambiente contratado; mudanças técnicas dependem de avaliação da arquiteta e cada ambiente recebe sua própria solução.",
                         new BigDecimal("450.00"),
                         AreaRule.UP_TO_20_SQM_PER_ENVIRONMENT,
                         "decor-reforma"));
@@ -178,9 +178,20 @@ public record ServiceCatalogItem(
                 COMMON_DELIVERABLES,
                 COMMON_PROCESS,
                 COMMON_RESPONSIBILITIES,
-                COMMON_EXCLUSIONS,
-                "Suporte de 3 meses após a entrega para dúvidas sobre o Manual e cores, sem visita ou gestão de obra.",
+                exclusionsFor(type),
+                "Suporte de 3 meses após a entrega pelo WhatsApp para dúvidas sobre o Manual e cores, sem visita e sem gestão de obra.",
                 true);
+    }
+
+    private static List<String> exclusionsFor(ServiceType type) {
+        if (type == ServiceType.DECOR_REFORMA) {
+            return List.of(
+                    "A Urbana presta consultoria online e não executa a obra.",
+                    "A Urbana não compra materiais nem contrata profissionais.",
+                    "Demandas estruturais, elétricas, hidráulicas, de gás, ART/RRT, projeto legal ou aprovações dependem de avaliação da arquiteta.",
+                    "O suporte não inclui visita, gestão de obra ou garantia do resultado.");
+        }
+        return COMMON_EXCLUSIONS;
     }
 
     private static List<String> immutableCopy(List<String> values) {

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/ActiveTurnLeaseDocument.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/ActiveTurnLeaseDocument.java
@@ -8,6 +8,7 @@ import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
+import java.util.List;
 
 @Data
 @Document(collection = "reception_active_turn_leases")
@@ -21,6 +22,7 @@ public class ActiveTurnLeaseDocument {
     @Indexed
     private String contactId;
     private String sourceMessageId;
+    private List<String> sourceMessageIds;
     private ActiveTurnLeaseStatus status;
     private Instant acquiredAt;
     // Keep EXPIRED/REVOKED tombstones. TTL deletion would allow a late

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoActiveTurnLeaseGateway.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoActiveTurnLeaseGateway.java
@@ -264,6 +264,7 @@ public class MongoActiveTurnLeaseGateway implements ActiveTurnLeaseGateway {
                 .set("turnId", lease.turnId())
                 .set("contactId", lease.contactId())
                 .set("sourceMessageId", lease.sourceMessageId())
+                .set("sourceMessageIds", lease.sourceMessageIds())
                 .set("status", lease.status())
                 .set("acquiredAt", lease.acquiredAt())
                 .set("expiresAt", lease.expiresAt())
@@ -285,6 +286,7 @@ public class MongoActiveTurnLeaseGateway implements ActiveTurnLeaseGateway {
         document.setTurnId(lease.turnId());
         document.setContactId(lease.contactId());
         document.setSourceMessageId(lease.sourceMessageId());
+        document.setSourceMessageIds(lease.sourceMessageIds());
         document.setStatus(lease.status());
         document.setAcquiredAt(lease.acquiredAt());
         document.setExpiresAt(lease.expiresAt());
@@ -297,7 +299,9 @@ public class MongoActiveTurnLeaseGateway implements ActiveTurnLeaseGateway {
     private ActiveTurnLease toDomain(ActiveTurnLeaseDocument document) {
         return new ActiveTurnLease(document.getHermesSessionId(), document.getTurnId(), document.getContactId(),
                 document.getSourceMessageId(), document.getStatus(), document.getAcquiredAt(),
-                document.getExpiresAt(), document.getRevokedAt(), document.getVersion(), document.getClaimToken());
+                document.getExpiresAt(), document.getRevokedAt(), document.getVersion(), document.getClaimToken(),
+                document.getSourceMessageIds() == null || document.getSourceMessageIds().isEmpty()
+                        ? java.util.List.of(document.getSourceMessageId()) : document.getSourceMessageIds());
     }
 
     private static void require(String value, String field) {

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoReceptionConversationGateway.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoReceptionConversationGateway.java
@@ -65,7 +65,11 @@ public class MongoReceptionConversationGateway implements ReceptionConversationG
                 .set("resumeBoundarySequence", conversation.resumeBoundarySequence())
                 .set("resumeDecisionAction", conversation.resumeDecisionAction())
                 .set("resumeDecisionMessage", conversation.resumeDecisionMessage())
-                .set("resumeFailureCode", conversation.resumeFailureCode());
+                .set("resumeFailureCode", conversation.resumeFailureCode())
+                .set("contractingUnitId", conversation.contractingUnitId())
+                .set("environmentLabel", conversation.environmentLabel())
+                .set("environmentSourceMessageId", conversation.environmentSourceMessageId())
+                .set("activeTermsConsentId", conversation.activeTermsConsentId());
         ReceptionConversationDocument updated = template.findAndModify(query, update,
                 FindAndModifyOptions.options().returnNew(true), ReceptionConversationDocument.class);
         if (updated == null) {
@@ -87,6 +91,8 @@ public class MongoReceptionConversationGateway implements ReceptionConversationG
         d.setResumeDecisionAction(value.resumeDecisionAction());
         d.setResumeDecisionMessage(value.resumeDecisionMessage());
         d.setResumeFailureCode(value.resumeFailureCode());
+        d.setContractingUnitId(value.contractingUnitId()); d.setEnvironmentLabel(value.environmentLabel());
+        d.setEnvironmentSourceMessageId(value.environmentSourceMessageId()); d.setActiveTermsConsentId(value.activeTermsConsentId());
         return d;
     }
 
@@ -96,6 +102,7 @@ public class MongoReceptionConversationGateway implements ReceptionConversationG
                 d.getCreatedAt(), d.getUpdatedAt(), d.getVersion(),
                 d.getResumeStatus(), d.getResumeId(), d.getResumeIdempotencyKey(), d.getResumeChecksum(),
                 d.getResumeBoundarySequence(), d.getResumeDecisionAction(), d.getResumeDecisionMessage(),
-                d.getResumeFailureCode());
+                d.getResumeFailureCode(), d.getContractingUnitId(), d.getEnvironmentLabel(),
+                d.getEnvironmentSourceMessageId(), d.getActiveTermsConsentId());
     }
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoTermsConsentAuditGateway.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoTermsConsentAuditGateway.java
@@ -1,0 +1,77 @@
+package br.com.urbana.connect.infrastructure.persistence.mongodb.reception;
+
+import br.com.urbana.connect.domain.reception.model.TermsConsentAudit;
+import br.com.urbana.connect.domain.reception.model.TermsConsentStatus;
+import br.com.urbana.connect.domain.reception.port.out.TermsConsentAuditGateway;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.mongodb.core.FindAndModifyOptions;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public final class MongoTermsConsentAuditGateway implements TermsConsentAuditGateway {
+    private final SpringDataTermsConsentAuditRepository repository;
+    private final MongoTemplate template;
+
+    public MongoTermsConsentAuditGateway(SpringDataTermsConsentAuditRepository repository, MongoTemplate template) {
+        this.repository = repository; this.template = template;
+    }
+    public Optional<TermsConsentAudit> findByPresentationId(String id) { return repository.findById(id).map(this::toDomain); }
+    public Optional<TermsConsentAudit> findPresented(String conversationId, String unitId) {
+        return repository.findFirstByConversationIdAndContractingUnitIdAndStatusOrderByPresentedAtDesc(
+                conversationId, unitId, TermsConsentStatus.PRESENTED).map(this::toDomain);
+    }
+    public TermsConsentAudit savePresentationIfAbsent(TermsConsentAudit audit) {
+        if (audit == null || audit.status() != TermsConsentStatus.PRESENTED) {
+            throw new IllegalArgumentException("only a presented audit can be persisted");
+        }
+        Optional<TermsConsentAuditDocument> existing = repository.findById(audit.presentationId());
+        if (existing.isPresent()) {
+            return toDomain(existing.orElseThrow());
+        }
+        try { return toDomain(repository.insert(toDocument(audit))); }
+        catch (DuplicateKeyException duplicate) { return findByPresentationId(audit.presentationId()).orElseThrow(() -> duplicate); }
+    }
+    public TermsConsentAudit acceptIfPresented(String id, String eventId, String messageId, String text,
+                                                long version, Instant now) {
+        require(id, "presentationId");
+        require(eventId, "acceptanceEventId");
+        require(messageId, "acceptanceMessageId");
+        require(text, "acceptanceTextExact");
+        if (version < 0) throw new IllegalArgumentException("conversationVersion must be non-negative");
+        if (now == null) throw new IllegalArgumentException("acceptedAt must not be null");
+        Query query = Query.query(new Criteria().andOperator(Criteria.where("_id").is(id),
+                Criteria.where("status").is(TermsConsentStatus.PRESENTED),
+                Criteria.where("presentedAt").lte(now)));
+        Update update = new Update().set("status", TermsConsentStatus.ACCEPTED)
+                .set("acceptanceEventId", eventId).set("acceptanceMessageId", messageId)
+                .set("acceptanceTextExact", text).set("acceptedAt", now).set("recordedAt", now)
+                .set("conversationVersionAtAcceptance", version);
+        TermsConsentAuditDocument changed = template.findAndModify(query, update,
+                FindAndModifyOptions.options().returnNew(true), TermsConsentAuditDocument.class);
+        if (changed != null) return toDomain(changed);
+        TermsConsentAudit existing = findByPresentationId(id)
+                .orElseThrow(() -> new IllegalStateException("terms presentation evidence is missing"));
+        if (existing.status() != TermsConsentStatus.ACCEPTED) throw new IllegalStateException("terms acceptance was not recorded");
+        return existing;
+    }
+    private TermsConsentAuditDocument toDocument(TermsConsentAudit a) {
+        TermsConsentAuditDocument d = new TermsConsentAuditDocument(); d.setPresentationId(a.presentationId());
+        d.setConversationId(a.conversationId()); d.setContactId(a.contactId()); d.setTurnId(a.turnId()); d.setContractingUnitId(a.contractingUnitId());
+        d.setEnvironmentLabelSnapshot(a.environmentLabelSnapshot()); d.setEnvironmentSourceMessageId(a.environmentSourceMessageId());
+        d.setServiceType(a.serviceType()); d.setTermsResource(a.termsResource()); d.setTermsVersion(a.termsVersion());
+        d.setPrepareTermsInvocationId(a.prepareTermsInvocationId()); d.setTermsOutboundMessageId(a.termsOutboundMessageId());
+        d.setPresentedAt(a.presentedAt()); d.setAcceptanceMessageId(a.acceptanceMessageId()); d.setAcceptanceEventId(a.acceptanceEventId());
+        d.setAcceptanceTextExact(a.acceptanceTextExact()); d.setAcceptedAt(a.acceptedAt()); d.setRecordedAt(a.recordedAt()); d.setStatus(a.status());
+        d.setConversationVersionAtPresentation(a.conversationVersionAtPresentation()); d.setConversationVersionAtAcceptance(a.conversationVersionAtAcceptance()); return d;
+    }
+    private TermsConsentAudit toDomain(TermsConsentAuditDocument d) { return new TermsConsentAudit(d.getPresentationId(), d.getConversationId(), d.getContactId(), d.getTurnId(), d.getContractingUnitId(), d.getEnvironmentLabelSnapshot(), d.getEnvironmentSourceMessageId(), d.getServiceType(), d.getTermsResource(), d.getTermsVersion(), d.getPrepareTermsInvocationId(), d.getTermsOutboundMessageId(), d.getPresentedAt(), d.getAcceptanceMessageId(), d.getAcceptanceEventId(), d.getAcceptanceTextExact(), d.getAcceptedAt(), d.getRecordedAt(), d.getStatus(), d.getConversationVersionAtPresentation(), d.getConversationVersionAtAcceptance()); }
+
+    private static void require(String value, String field) {
+        if (value == null || value.isBlank()) throw new IllegalArgumentException(field + " must not be blank");
+    }
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/ReceptionConversationDocument.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/ReceptionConversationDocument.java
@@ -36,4 +36,8 @@ public class ReceptionConversationDocument {
     private String resumeDecisionAction;
     private String resumeDecisionMessage;
     private String resumeFailureCode;
+    private String contractingUnitId;
+    private String environmentLabel;
+    private String environmentSourceMessageId;
+    private String activeTermsConsentId;
 }

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/SpringDataTermsConsentAuditRepository.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/SpringDataTermsConsentAuditRepository.java
@@ -1,0 +1,11 @@
+package br.com.urbana.connect.infrastructure.persistence.mongodb.reception;
+
+import br.com.urbana.connect.domain.reception.model.TermsConsentStatus;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface SpringDataTermsConsentAuditRepository extends MongoRepository<TermsConsentAuditDocument, String> {
+    Optional<TermsConsentAuditDocument> findFirstByConversationIdAndContractingUnitIdAndStatusOrderByPresentedAtDesc(
+            String conversationId, String contractingUnitId, TermsConsentStatus status);
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/TermsConsentAuditDocument.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/TermsConsentAuditDocument.java
@@ -1,0 +1,29 @@
+package br.com.urbana.connect.infrastructure.persistence.mongodb.reception;
+
+import br.com.urbana.connect.domain.reception.model.TermsConsentStatus;
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Data
+@Document(collection = "reception_terms_consent_audits")
+@CompoundIndex(name = "conversation_unit_status", def = "{'conversationId': 1, 'contractingUnitId': 1, 'status': 1}")
+public class TermsConsentAuditDocument {
+    @Id private String presentationId;
+    @Indexed private String conversationId;
+    private String contactId; private String turnId; private String contractingUnitId;
+    private String environmentLabelSnapshot; private String environmentSourceMessageId;
+    private String serviceType; private String termsResource; private String termsVersion;
+    @Indexed(unique = true, sparse = true)
+    private String prepareTermsInvocationId;
+    private String termsOutboundMessageId;
+    private Instant presentedAt; private String acceptanceMessageId;
+    @Indexed(unique = true, sparse = true) private String acceptanceEventId;
+    private String acceptanceTextExact; private Instant acceptedAt; private Instant recordedAt;
+    private TermsConsentStatus status; private long conversationVersionAtPresentation;
+    private Long conversationVersionAtAcceptance;
+}

--- a/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/TermsConsentAuditDocument.java
+++ b/apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/TermsConsentAuditDocument.java
@@ -13,17 +13,29 @@ import java.time.Instant;
 @Document(collection = "reception_terms_consent_audits")
 @CompoundIndex(name = "conversation_unit_status", def = "{'conversationId': 1, 'contractingUnitId': 1, 'status': 1}")
 public class TermsConsentAuditDocument {
-    @Id private String presentationId;
-    @Indexed private String conversationId;
-    private String contactId; private String turnId; private String contractingUnitId;
-    private String environmentLabelSnapshot; private String environmentSourceMessageId;
-    private String serviceType; private String termsResource; private String termsVersion;
+    @Id
+    private String presentationId;
+    @Indexed
+    private String conversationId;
+    private String contactId;
+    private String turnId;
+    private String contractingUnitId;
+    private String environmentLabelSnapshot;
+    private String environmentSourceMessageId;
+    private String serviceType;
+    private String termsResource;
+    private String termsVersion;
     @Indexed(unique = true, sparse = true)
     private String prepareTermsInvocationId;
     private String termsOutboundMessageId;
-    private Instant presentedAt; private String acceptanceMessageId;
-    @Indexed(unique = true, sparse = true) private String acceptanceEventId;
-    private String acceptanceTextExact; private Instant acceptedAt; private Instant recordedAt;
-    private TermsConsentStatus status; private long conversationVersionAtPresentation;
+    private Instant presentedAt;
+    private String acceptanceMessageId;
+    @Indexed(unique = true, sparse = true)
+    private String acceptanceEventId;
+    private String acceptanceTextExact;
+    private Instant acceptedAt;
+    private Instant recordedAt;
+    private TermsConsentStatus status;
+    private long conversationVersionAtPresentation;
     private Long conversationVersionAtAcceptance;
 }

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ActiveTurnLeaseServiceTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ActiveTurnLeaseServiceTest.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Optional;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
@@ -48,6 +49,19 @@ class ActiveTurnLeaseServiceTest {
                 .isEqualTo(ActiveTurnLeaseStatus.RUNNING);
         assertThatThrownBy(() -> service.requireActive("session-1", "other", "contact-1", "message-1"))
                 .isInstanceOf(ActiveTurnLeaseService.LeaseRejectedException.class);
+    }
+
+    @Test
+    void preservesAllInboundEventIdsForBatchedToolProvenance() {
+        FakeLeaseGateway gateway = new FakeLeaseGateway();
+        ActiveTurnLeaseService service = new ActiveTurnLeaseService(gateway,
+                Clock.fixed(now, ZoneOffset.UTC), Duration.ofSeconds(30));
+
+        ActiveTurnLease lease = service.acquire("session-1", "turn-1", "contact-1", "event-2",
+                List.of("event-1", "event-2"));
+
+        assertThat(lease.sourceMessageId()).isEqualTo("event-2");
+        assertThat(lease.sourceMessageIds()).containsExactly("event-1", "event-2");
     }
 
     @Test

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/CommercialPolicyServiceTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/CommercialPolicyServiceTest.java
@@ -22,6 +22,20 @@ class CommercialPolicyServiceTest {
     private static final Instant NOW = Instant.parse("2026-08-05T12:00:00Z");
 
     @Test
+    void rejectsPreparedPaymentOutputWithoutQuantityAndProofCopyButAllowsTheRequiredGuidance() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        ReceptionConversation prepared = new ReceptionConversation("conversation-1", "contact-1",
+                ReceptionMode.AI, CommercialStage.PAYMENT, "DECOR", TermsStatus.ACCEPTED,
+                PaymentStatus.PREPARED, null, NOW, NOW, 1);
+        assertThatThrownBy(() -> policy.reconcileOutput(new AgentOutput(
+                "Acesse o link de pagamento.", AgentNextAction.AWAIT_PAYMENT_PROOF), prepared))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("quantity");
+        assertThat(policy.reconcileOutput(new AgentOutput(
+                "No link da POC, considere 1 serviço para cada ambiente contratado. Depois, envie o comprovante por aqui.",
+                AgentNextAction.AWAIT_PAYMENT_PROOF), prepared).message()).contains("1 serviço");
+    }
+
+    @Test
     void allowsTermsAndPaymentWithoutOptionalIcpAndKeepsHumanApprovalBeforeBriefing() {
         CommercialPolicyService policy = new CommercialPolicyService();
         ReceptionConversation conversation = ReceptionConversation.start("contact-1", NOW);
@@ -60,6 +74,20 @@ class CommercialPolicyServiceTest {
         conversation = policy.approvePaymentProof(conversation, NOW);
         assertThat(conversation.paymentStatus()).isEqualTo(PaymentStatus.CONFIRMED);
         assertThat(policy.briefingFor(conversation)).containsIgnoringCase("briefing").contains("DECOR_INTERIORES");
+    }
+
+    @Test
+    void reopensLegacyAcceptedConversationWithoutConsentEvidence() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        ReceptionConversation legacy = policy.acceptTerms(policy.presentTerms(
+                policy.selectService(ReceptionConversation.start("contact-1", NOW), "DECOR", NOW),
+                List.of(), NOW), NOW);
+        ReceptionConversation presentedAgain = policy.presentTerms(legacy, List.of(), NOW.plusSeconds(1));
+
+        assertThat(presentedAgain.termsStatus()).isEqualTo(TermsStatus.PRESENTED);
+        assertThat(presentedAgain.activeTermsConsentId()).isNull();
+        assertThat(presentedAgain.paymentStatus()).isEqualTo(PaymentStatus.NOT_STARTED);
+        assertThat(presentedAgain.commercialStage()).isEqualTo(CommercialStage.TERMS);
     }
 
     @Test
@@ -129,7 +157,7 @@ class CommercialPolicyServiceTest {
 
         policy.services().forEach(service -> {
             assertThat(service.deliverables())
-                    .containsExactly("Manual PDF", "Tour Virtual", "3 opções de solução", "2 rodadas consolidadas");
+                    .containsExactly("Manual do Espaço em PDF", "Tour Virtual", "3 opções de solução", "2 rodadas de alterações ou ajustes");
             assertThat(service.process()).anyMatch(value -> value.equals("briefing"));
             assertThat(service.process()).anyMatch(value -> value.equals("medidas, fotos e vídeos"));
             assertThat(service.process()).anyMatch(value -> value.contains("Google Meet"));
@@ -261,13 +289,36 @@ class CommercialPolicyServiceTest {
     }
 
     @Test
-    void acceptsClearTermsWithNaturalQualifiersButNotBareAcceptance() {
+    void acceptsClearTermsIncludingBareAcceptanceOnlyWhenTheConversationAlreadyPresentedTerms() {
         CommercialPolicyService policy = new CommercialPolicyService();
 
-        assertThat(policy.isExplicitTermsAcceptance(
-                "Aceito claramente os termos apresentados e quero seguir com a contratação.")).isTrue();
-        assertThat(policy.isExplicitTermsAcceptance("Aceito")).isFalse();
-        assertThat(policy.isExplicitTermsAcceptance("Não aceito os termos.")).isFalse();
+        List.of(
+                new AcceptanceCase("Aceito claramente os termos apresentados e quero seguir com a contratação.", true),
+                new AcceptanceCase(" Aceito! ", true),
+                new AcceptanceCase("ACEITO, quero pagar no cartão", true),
+                new AcceptanceCase("aceito os termos", true),
+                new AcceptanceCase("Não aceito os termos.", false),
+                new AcceptanceCase("talvez", false),
+                new AcceptanceCase("Aceito depois", false),
+                new AcceptanceCase("Aceito, mas vou pensar", false),
+                new AcceptanceCase("Aceito ler os termos", false),
+                new AcceptanceCase("Aceito analisar os termos", false),
+                new AcceptanceCase("Aceito revisar os termos", false),
+                new AcceptanceCase("Aceito avaliar os termos", false),
+                new AcceptanceCase("Aceito verificar os termos", false),
+                new AcceptanceCase("Aceito refletir sobre os termos", false),
+                new AcceptanceCase("Concordo com ler os termos", false),
+                new AcceptanceCase("Aceito os termos, vou ler", false),
+                new AcceptanceCase("Aceito os termos, mas vou analisar", false),
+                new AcceptanceCase("Aceito os termos, mas pretendo revisar", false),
+                new AcceptanceCase("Aceito os termos, vou ler depois", false),
+                new AcceptanceCase("Aceito pensar", false))
+                .forEach(testCase -> assertThat(policy.isExplicitTermsAcceptance(testCase.text()))
+                        .as("acceptance text: %s", testCase.text())
+                        .isEqualTo(testCase.expected()));
+    }
+
+    private record AcceptanceCase(String text, boolean expected) {
     }
 
     @Test
@@ -307,7 +358,7 @@ class CommercialPolicyServiceTest {
                 ReceptionMode.AI, CommercialStage.PAYMENT, "DECOR", TermsStatus.ACCEPTED,
                 PaymentStatus.PREPARED, null, NOW, NOW, 1);
         AgentOutput candidate = new AgentOutput(
-                "O pagamento via PIX está preparado. Após realizar o pagamento, envie o comprovante. "
+                "O pagamento via PIX está preparado. Considere 1 serviço para cada ambiente contratado. Após realizar o pagamento, envie o comprovante. "
                         + "O comprovante não confirma a aprovação.", AgentNextAction.AWAIT_PAYMENT_PROOF);
 
         assertThat(policy.reconcileOutput(candidate, conversation)).isEqualTo(candidate);
@@ -320,7 +371,7 @@ class CommercialPolicyServiceTest {
                 ReceptionMode.AI, CommercialStage.PAYMENT, "DECOR", TermsStatus.ACCEPTED,
                 PaymentStatus.PREPARED, null, NOW, NOW, 1);
         AgentOutput candidate = new AgentOutput(
-                "O pagamento via PIX foi preparado. Envie o comprovante; ele será analisado e aprovado "
+                "O pagamento via PIX foi preparado. Considere 1 serviço para cada ambiente contratado. Envie o comprovante; ele será analisado e aprovado "
                         + "exclusivamente pela equipe humana.", AgentNextAction.AWAIT_PAYMENT_PROOF);
 
         assertThat(policy.reconcileOutput(candidate, conversation)).isEqualTo(candidate);
@@ -333,7 +384,7 @@ class CommercialPolicyServiceTest {
                 ReceptionMode.AI, CommercialStage.PAYMENT, "DECOR", TermsStatus.ACCEPTED,
                 PaymentStatus.PREPARED, null, NOW, NOW, 1);
         AgentOutput candidate = new AgentOutput(
-                "O pagamento via PIX foi preparado: https://fixtures.urbana.local/payment/decor. "
+                "O pagamento via PIX foi preparado: https://fixtures.urbana.local/payment/decor. Considere 1 serviço para cada ambiente contratado. "
                         + "Após realizar o pagamento, envie o comprovante; ele será submetido à aprovação humana.",
                 AgentNextAction.AWAIT_PAYMENT_PROOF);
 
@@ -363,7 +414,7 @@ class CommercialPolicyServiceTest {
                 ReceptionMode.AI, CommercialStage.PAYMENT, "DECOR", TermsStatus.ACCEPTED,
                 PaymentStatus.PREPARED, null, NOW, NOW, 1);
         AgentOutput candidate = new AgentOutput(
-                "Certo. O pagamento via Pix está preparado em https://fixtures.urbana.local/payment/decor. "
+                "Certo. O pagamento via Pix está preparado em https://fixtures.urbana.local/payment/decor. Considere 1 serviço para cada ambiente contratado. "
                         + "Após pagar, envie o comprovante; a aprovação será feita exclusivamente pela equipe da Urbana.",
                 AgentNextAction.AWAIT_PAYMENT_PROOF);
 
@@ -377,7 +428,7 @@ class CommercialPolicyServiceTest {
                 ReceptionMode.AI, CommercialStage.PAYMENT, "DECOR", TermsStatus.ACCEPTED,
                 PaymentStatus.PREPARED, null, NOW, NOW, 1);
         AgentOutput candidate = new AgentOutput(
-                "O pagamento via PIX foi preparado. Após realizar o pagamento, envie o comprovante. "
+                "O pagamento via PIX foi preparado. Considere 1 serviço para cada ambiente contratado. Após realizar o pagamento, envie o comprovante. "
                         + "A confirmação depende de aprovação humana.", AgentNextAction.AWAIT_PAYMENT_PROOF);
 
         assertThat(policy.reconcileOutput(candidate, conversation)).isEqualTo(candidate);

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/CommercialPolicyServiceTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/CommercialPolicyServiceTest.java
@@ -27,8 +27,9 @@ class CommercialPolicyServiceTest {
         ReceptionConversation prepared = new ReceptionConversation("conversation-1", "contact-1",
                 ReceptionMode.AI, CommercialStage.PAYMENT, "DECOR", TermsStatus.ACCEPTED,
                 PaymentStatus.PREPARED, null, NOW, NOW, 1);
-        assertThatThrownBy(() -> policy.reconcileOutput(new AgentOutput(
-                "Acesse o link de pagamento.", AgentNextAction.AWAIT_PAYMENT_PROOF), prepared))
+        AgentOutput missingGuidance = new AgentOutput(
+                "Acesse o link de pagamento.", AgentNextAction.AWAIT_PAYMENT_PROOF);
+        assertThatThrownBy(() -> policy.reconcileOutput(missingGuidance, prepared))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("quantity");
         assertThat(policy.reconcileOutput(new AgentOutput(
                 "No link da POC, considere 1 serviço para cada ambiente contratado. Depois, envie o comprovante por aqui.",
@@ -209,11 +210,12 @@ class CommercialPolicyServiceTest {
         AgentOutput requestedBriefing = new AgentOutput("aqui está o briefing", AgentNextAction.AWAIT_CUSTOMER);
         assertThatThrownBy(() -> policy.reconcileOutput(requestedBriefing, conversation))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> policy.reconcileOutput(new AgentOutput(
-                "Segue o briefing DECOR: fixture local.", AgentNextAction.AWAIT_CUSTOMER), conversation))
+        AgentOutput briefingWithFixture = new AgentOutput(
+                "Segue o briefing DECOR: fixture local.", AgentNextAction.AWAIT_CUSTOMER);
+        assertThatThrownBy(() -> policy.reconcileOutput(briefingWithFixture, conversation))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> policy.reconcileOutput(new AgentOutput(
-                "Pagamento confirmado.", AgentNextAction.NONE), conversation))
+        AgentOutput confirmedPayment = new AgentOutput("Pagamento confirmado.", AgentNextAction.NONE);
+        assertThatThrownBy(() -> policy.reconcileOutput(confirmedPayment, conversation))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -234,8 +236,9 @@ class CommercialPolicyServiceTest {
                 ReceptionMode.AI, CommercialStage.PAYMENT, "DECOR", TermsStatus.ACCEPTED,
                 PaymentStatus.NOT_STARTED, null, NOW, NOW, 1);
 
-        assertThatThrownBy(() -> policy.reconcileOutput(new AgentOutput(
-                "Vou aguardar a confirmação do pagamento.", AgentNextAction.AWAIT_PAYMENT_APPROVAL), conversation))
+        AgentOutput approvalBeforeProof = new AgentOutput(
+                "Vou aguardar a confirmação do pagamento.", AgentNextAction.AWAIT_PAYMENT_APPROVAL);
+        assertThatThrownBy(() -> policy.reconcileOutput(approvalBeforeProof, conversation))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("proof");
     }
@@ -268,12 +271,14 @@ class CommercialPolicyServiceTest {
         CommercialPolicyService policy = new CommercialPolicyService();
         ReceptionConversation conversation = ReceptionConversation.start("contact-1", NOW);
 
-        assertThatThrownBy(() -> policy.reconcileOutput(new AgentOutput(
+        AgentOutput paymentLink = new AgentOutput(
                 "Para pagar, acesse https://fixtures.urbana.local/payment/decor.",
-                AgentNextAction.AWAIT_CUSTOMER), conversation))
+                AgentNextAction.AWAIT_CUSTOMER);
+        assertThatThrownBy(() -> policy.reconcileOutput(paymentLink, conversation))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> policy.reconcileOutput(new AgentOutput(
-                "Seu briefing está pronto para preencher.", AgentNextAction.AWAIT_CUSTOMER), conversation))
+        AgentOutput readyBriefing = new AgentOutput(
+                "Seu briefing está pronto para preencher.", AgentNextAction.AWAIT_CUSTOMER);
+        assertThatThrownBy(() -> policy.reconcileOutput(readyBriefing, conversation))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/PocReceptionConfigurationTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/PocReceptionConfigurationTest.java
@@ -20,6 +20,7 @@ import br.com.urbana.connect.interfaces.rest.poc.DomainToolController;
 import br.com.urbana.connect.interfaces.rest.poc.ConversationSimulatorController;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -67,44 +68,53 @@ class PocReceptionConfigurationTest {
                         "hermes.sessions.internal-tool-token=test-token",
                         "hermes.sessions.internal-tool-principal=hermes-urbana-domain")
                 .run(context -> {
-                    assertThat(context).hasSingleBean(DomainToolController.class);
-                    assertThat(context).hasSingleBean(ConversationSimulatorController.class);
-                    assertThat(context).hasSingleBean(HermesSessionService.class);
-                    assertThat(context).hasSingleBean(ReceptionOrchestrator.class);
-                    assertThat(context).hasSingleBean(HermesWebhookMessageHandler.class);
-                    assertThat(context).hasSingleBean(NonProspectPolicy.class);
-                    assertThat(context).hasSingleBean(MessageBatcher.class);
-                    assertThat(context).hasSingleBean(MediaNormalizationService.class);
-                    assertThat(context).hasSingleBean(PocReceptionIngress.class);
-                    assertThat(context).hasSingleBean(PocPendingEventGateway.class);
-                    assertThat(context).hasSingleBean(ReceptionTurnReconciliationService.class);
-                    assertThat(context).hasSingleBean(PocReceptionWorker.class);
-                    assertThat(context).hasSingleBean(DomainToolService.class);
-                    assertThat(context).hasSingleBean(TermsAcceptanceUseCase.class);
-                    assertThat(context).hasSingleBean(
-                            br.com.urbana.connect.domain.reception.port.out.TermsConsentAuditGateway.class);
-                    assertThat(context.getBean(DomainToolService.class)).isInstanceOf(StatefulDomainToolService.class);
-                    assertThat(context).hasSingleBean(ActiveTurnLeaseService.class);
-                    assertThat(ReflectionTestUtils.getField(context.getBean(ReceptionOrchestrator.class), "delayThreshold"))
-                            .isEqualTo(Duration.ofMillis(75));
-                    assertThat(ReflectionTestUtils.getField(context.getBean(ActiveTurnLeaseService.class), "ttl"))
-                            .isEqualTo(Duration.ofSeconds(240));
-                    assertThat(ReflectionTestUtils.getField(context.getBean(PocReceptionWorker.class), "claimTtl"))
-                            .isEqualTo(Duration.ofSeconds(240));
-                    assertThat(context).hasSingleBean(ActiveTurnLeaseGateway.class);
-                    assertThat(context).hasSingleBean(AgentSessionLinkGateway.class);
-                    assertThat(ReflectionTestUtils.getField(context.getBean(ActiveTurnLeaseGateway.class), "template"))
-                            .isSameAs(mongoTemplate);
-                    assertThat(ReflectionTestUtils.getField(context.getBean(AgentSessionLinkGateway.class), "template"))
-                            .isSameAs(mongoTemplate);
-                    assertThat(ReflectionTestUtils.getField(context.getBean(PocPendingEventGateway.class), "template"))
-                            .isSameAs(mongoTemplate);
-                    PocReceptionIngress ingress = context.getBean(PocReceptionIngress.class);
-                    assertThat(ReflectionTestUtils.getField(ingress, "pendingEvents"))
-                            .isSameAs(context.getBean(PocPendingEventGateway.class));
-                    assertThat(ReflectionTestUtils.getField(ingress, "worker"))
-                            .isSameAs(context.getBean(PocReceptionWorker.class));
+                    assertCoreBeans(context);
+                    assertTimingAndGatewayWiring(context, mongoTemplate);
                 });
+    }
+
+    private static void assertCoreBeans(AssertableApplicationContext context) {
+        assertThat(context).hasSingleBean(DomainToolController.class);
+        assertThat(context).hasSingleBean(ConversationSimulatorController.class);
+        assertThat(context).hasSingleBean(HermesSessionService.class);
+        assertThat(context).hasSingleBean(ReceptionOrchestrator.class);
+        assertThat(context).hasSingleBean(HermesWebhookMessageHandler.class);
+        assertThat(context).hasSingleBean(NonProspectPolicy.class);
+        assertThat(context).hasSingleBean(MessageBatcher.class);
+        assertThat(context).hasSingleBean(MediaNormalizationService.class);
+        assertThat(context).hasSingleBean(PocReceptionIngress.class);
+        assertThat(context).hasSingleBean(PocPendingEventGateway.class);
+        assertThat(context).hasSingleBean(ReceptionTurnReconciliationService.class);
+        assertThat(context).hasSingleBean(PocReceptionWorker.class);
+        assertThat(context).hasSingleBean(DomainToolService.class);
+        assertThat(context).hasSingleBean(TermsAcceptanceUseCase.class);
+        assertThat(context).hasSingleBean(
+                br.com.urbana.connect.domain.reception.port.out.TermsConsentAuditGateway.class);
+        assertThat(context.getBean(DomainToolService.class)).isInstanceOf(StatefulDomainToolService.class);
+    }
+
+    private static void assertTimingAndGatewayWiring(AssertableApplicationContext context,
+                                                     MongoTemplate mongoTemplate) {
+        assertThat(context).hasSingleBean(ActiveTurnLeaseService.class);
+        assertThat(ReflectionTestUtils.getField(context.getBean(ReceptionOrchestrator.class), "delayThreshold"))
+                .isEqualTo(Duration.ofMillis(75));
+        assertThat(ReflectionTestUtils.getField(context.getBean(ActiveTurnLeaseService.class), "ttl"))
+                .isEqualTo(Duration.ofSeconds(240));
+        assertThat(ReflectionTestUtils.getField(context.getBean(PocReceptionWorker.class), "claimTtl"))
+                .isEqualTo(Duration.ofSeconds(240));
+        assertThat(context).hasSingleBean(ActiveTurnLeaseGateway.class);
+        assertThat(context).hasSingleBean(AgentSessionLinkGateway.class);
+        assertThat(ReflectionTestUtils.getField(context.getBean(ActiveTurnLeaseGateway.class), "template"))
+                .isSameAs(mongoTemplate);
+        assertThat(ReflectionTestUtils.getField(context.getBean(AgentSessionLinkGateway.class), "template"))
+                .isSameAs(mongoTemplate);
+        assertThat(ReflectionTestUtils.getField(context.getBean(PocPendingEventGateway.class), "template"))
+                .isSameAs(mongoTemplate);
+        PocReceptionIngress ingress = context.getBean(PocReceptionIngress.class);
+        assertThat(ReflectionTestUtils.getField(ingress, "pendingEvents"))
+                .isSameAs(context.getBean(PocPendingEventGateway.class));
+        assertThat(ReflectionTestUtils.getField(ingress, "worker"))
+                .isSameAs(context.getBean(PocReceptionWorker.class));
     }
 
     @TestConfiguration(proxyBeanMethods = false)

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/PocReceptionConfigurationTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/PocReceptionConfigurationTest.java
@@ -15,6 +15,7 @@ import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.Spring
 import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.SpringDataAgentSessionLinkRepository;
 import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.SpringDataDomainToolInvocationRepository;
 import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.SpringDataPocPendingEventRepository;
+import br.com.urbana.connect.infrastructure.persistence.mongodb.reception.SpringDataTermsConsentAuditRepository;
 import br.com.urbana.connect.interfaces.rest.poc.DomainToolController;
 import br.com.urbana.connect.interfaces.rest.poc.ConversationSimulatorController;
 import org.junit.jupiter.api.Test;
@@ -45,6 +46,7 @@ class PocReceptionConfigurationTest {
         SpringDataReceptionMessageRepository messageRepository = mock(SpringDataReceptionMessageRepository.class);
         SpringDataReceptionTurnRepository turnRepository = mock(SpringDataReceptionTurnRepository.class);
         SpringDataPocPendingEventRepository pendingEventRepository = mock(SpringDataPocPendingEventRepository.class);
+        SpringDataTermsConsentAuditRepository termsConsentAuditRepository = mock(SpringDataTermsConsentAuditRepository.class);
         new ApplicationContextRunner()
                 .withUserConfiguration(PocReceptionConfiguration.class, ControllerConfiguration.class)
                 .withBean(SpringDataActiveTurnLeaseRepository.class, () -> leaseRepository)
@@ -55,6 +57,7 @@ class PocReceptionConfigurationTest {
                 .withBean(SpringDataReceptionMessageRepository.class, () -> messageRepository)
                 .withBean(SpringDataReceptionTurnRepository.class, () -> turnRepository)
                 .withBean(SpringDataPocPendingEventRepository.class, () -> pendingEventRepository)
+                .withBean(SpringDataTermsConsentAuditRepository.class, () -> termsConsentAuditRepository)
                 .withBean(MongoTemplate.class, () -> mongoTemplate)
                 .withBean(WhatsAppMessageGateway.class, () -> mock(WhatsAppMessageGateway.class))
                 .withBean(RestClient.Builder.class, RestClient::builder)
@@ -77,6 +80,9 @@ class PocReceptionConfigurationTest {
                     assertThat(context).hasSingleBean(ReceptionTurnReconciliationService.class);
                     assertThat(context).hasSingleBean(PocReceptionWorker.class);
                     assertThat(context).hasSingleBean(DomainToolService.class);
+                    assertThat(context).hasSingleBean(TermsAcceptanceUseCase.class);
+                    assertThat(context).hasSingleBean(
+                            br.com.urbana.connect.domain.reception.port.out.TermsConsentAuditGateway.class);
                     assertThat(context.getBean(DomainToolService.class)).isInstanceOf(StatefulDomainToolService.class);
                     assertThat(context).hasSingleBean(ActiveTurnLeaseService.class);
                     assertThat(ReflectionTestUtils.getField(context.getBean(ReceptionOrchestrator.class), "delayThreshold"))

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionOrchestratorTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionOrchestratorTest.java
@@ -1190,7 +1190,8 @@ class ReceptionOrchestratorTest {
                 "oi", NOW);
         InboundConversationEvent second = new InboundConversationEvent("batch-b", "poc:bia", ReceptionMessageType.TEXT,
                 "oi", NOW);
-        assertThatThrownBy(() -> orchestrator.processBatch(List.of(first, second)))
+        List<InboundConversationEvent> differentContacts = List.of(first, second);
+        assertThatThrownBy(() -> orchestrator.processBatch(differentContacts))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("multiple contacts");
     }
 

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionOrchestratorTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionOrchestratorTest.java
@@ -32,6 +32,7 @@ import br.com.urbana.connect.domain.reception.port.out.ReceptionTurnGateway;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessageDirection;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -57,6 +58,17 @@ import static org.mockito.Mockito.when;
 
 class ReceptionOrchestratorTest {
     private static final Instant NOW = Instant.parse("2026-08-05T12:00:00Z");
+
+    @Test
+    void resumeChecksumUsesUtf8ForSupplementaryUnicodeInsteadOfEscapedSurrogates() throws Exception {
+        Method checksum = ReceptionOrchestrator.class.getDeclaredMethod("resumeChecksum", List.class);
+        checksum.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        String actual = (String) checksum.invoke(null, List.of(
+                new HermesResumeGateway.ContextMessage(1, "m-1", "CONTACT", "user", "🦕")));
+
+        assertThat(actual).isEqualTo("sha256:109629377e6112df724faa31ac7d0a57771f88fc18ef448ba8da4da6b610436d");
+    }
 
     @Test
     void persistsInboundBeforeDispatchAndAddsIdentityOnlyToTheFirstHermesResponse() {
@@ -168,7 +180,7 @@ class ReceptionOrchestratorTest {
     }
 
     @Test
-    void appliesAcceptanceAfterHermesPresentsTermsDuringTheSameTurn() {
+    void doesNotApplyAcceptanceWhenHermesPresentsTermsDuringTheSameTurn() {
         MemoryConversation conversations = new MemoryConversation();
         conversations.value = ReceptionConversation.start("conversation-1", "poc:ana", NOW);
         MemoryTranscript transcript = new MemoryTranscript();
@@ -189,7 +201,7 @@ class ReceptionOrchestratorTest {
                 "Aceito os termos", NOW));
 
         assertThat(receipt.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.COMPLETED);
-        assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.ACCEPTED);
+        assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.PRESENTED);
     }
 
     @Test

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionOrchestratorTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionOrchestratorTest.java
@@ -18,6 +18,8 @@ import br.com.urbana.connect.domain.reception.model.ReceptionMode;
 import br.com.urbana.connect.domain.reception.model.ResumeStatus;
 import br.com.urbana.connect.domain.reception.model.ReceptionEventIds;
 import br.com.urbana.connect.domain.reception.model.TermsStatus;
+import br.com.urbana.connect.domain.reception.model.TermsConsentAudit;
+import br.com.urbana.connect.domain.reception.model.TermsConsentStatus;
 import br.com.urbana.connect.domain.reception.model.CommercialStage;
 import br.com.urbana.connect.domain.reception.port.out.AgentSessionLinkGateway;
 import br.com.urbana.connect.domain.reception.port.out.ActiveTurnLeaseGateway;
@@ -29,6 +31,7 @@ import br.com.urbana.connect.domain.reception.port.out.HermesResumeGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionConversationGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTranscriptGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTurnGateway;
+import br.com.urbana.connect.domain.reception.port.out.TermsConsentAuditGateway;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessageDirection;
 import org.junit.jupiter.api.Test;
 
@@ -1048,6 +1051,149 @@ class ReceptionOrchestratorTest {
                 .extracting(ReceptionTurn::retryAllowed).isEqualTo(true);
     }
 
+    @Test
+    void acceptsAnExplicitInboundOnlyAfterDurableTermsPresentationEvidence() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        MemoryConversation conversations = new MemoryConversation();
+        ReceptionConversation presented = policy.presentTerms(
+                policy.selectService(ReceptionConversation.start("conversation-1", "poc:ana", NOW), "DECOR", NOW),
+                List.of(), NOW);
+        presented = presented.bindContractingUnit("unit-1", "sala", "environment-event", NOW);
+        presented = policy.presentTerms(policy.selectService(presented, "DECOR", NOW), List.of(), NOW);
+        presented = presented.activateTermsConsent("presentation-1", NOW);
+        conversations.value = presented;
+        MemoryAudits audits = new MemoryAudits();
+        audits.savePresentationIfAbsent(new TermsConsentAudit("presentation-1", presented.id(), presented.contactId(),
+                "turn-presentation", presented.contractingUnitId(), presented.environmentLabel(),
+                presented.environmentSourceMessageId(), presented.selectedService(), policy.termsUrl("DECOR"), "v1",
+                "invocation-1", "terms-outbound", NOW, null, null, null, null, NOW,
+                TermsConsentStatus.PRESENTED, presented.version(), null));
+        MemoryTranscript transcript = new MemoryTranscript();
+        MemoryTurns turns = new MemoryTurns();
+        ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(
+                new HermesSessionService(new FakeSessions("Obrigada!"), new MemoryLinks()), conversations,
+                new MemoryFacts(), transcript, turns, policy, new ReceptionTurnCoordinator(),
+                Clock.fixed(NOW, ZoneOffset.UTC));
+        orchestrator.setTermsAcceptanceUseCase(new TermsAcceptanceUseCase(audits, conversations));
+
+        ReceptionOrchestrator.TurnReceipt receipt = orchestrator.process(new InboundConversationEvent(
+                "acceptance-event", "poc:ana", ReceptionMessageType.TEXT, "Aceito os termos", NOW.plusSeconds(1)));
+
+        assertThat(receipt.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.COMPLETED);
+        assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.ACCEPTED);
+        assertThat(audits.findByPresentationId("presentation-1")).hasValueSatisfying(audit -> {
+            assertThat(audit.status()).isEqualTo(TermsConsentStatus.ACCEPTED);
+            assertThat(audit.acceptanceEventId()).isEqualTo("acceptance-event");
+            assertThat(audit.acceptanceTextExact()).isEqualTo("Aceito os termos");
+        });
+    }
+
+    @Test
+    void recordsTermsPresentationOnlyWhenSuccessfulInvocationResourceAppearsInPublishedText() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        MemoryAudits audits = new MemoryAudits();
+        MemoryInvocations invocations = new MemoryInvocations();
+        DomainToolInvocation invocation = new DomainToolInvocation("invocation-1", "key-1", "any-turn", "session-1",
+                "poc:ana", DomainToolName.PREPARE_TERMS, "hash", DomainToolInvocationStatus.SUCCEEDED, "OK",
+                Map.of("url", policy.termsUrl("DECOR")), NOW, NOW.plusSeconds(1));
+        invocations.values.add(invocation);
+        MemoryConversation conversations = new MemoryConversation();
+        ReceptionConversation presented = ReceptionConversation.start("conversation-1", "poc:ana", NOW)
+                .bindContractingUnit("unit-1", "sala", "environment-event", NOW)
+                .selectService("DECOR_INTERIORES", NOW)
+                .presentTerms(NOW.plusSeconds(1));
+        conversations.value = presented;
+        MemoryTranscript transcript = new MemoryTranscript();
+        ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(
+                new HermesSessionService(new FakeSessions("Confira os termos: " + policy.termsUrl("DECOR")),
+                        new MemoryLinks()), conversations, new MemoryFacts(), transcript, new MemoryTurns(), policy,
+                new ReceptionTurnCoordinator(), null, invocations, Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC));
+        orchestrator.setTermsAcceptanceUseCase(new TermsAcceptanceUseCase(audits, conversations));
+
+        ReceptionOrchestrator.TurnReceipt receipt = orchestrator.process(new InboundConversationEvent(
+                "terms-event", "poc:ana", ReceptionMessageType.TEXT, "Quero ver os termos", NOW.plusSeconds(2)));
+
+        assertThat(receipt.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.COMPLETED);
+        assertThat(conversations.value.activeTermsConsentId()).isNotBlank();
+        assertThat(audits.findByPresentationId(conversations.value.activeTermsConsentId()))
+                .hasValueSatisfying(value -> assertThat(value.status()).isEqualTo(TermsConsentStatus.PRESENTED));
+    }
+
+    @Test
+    void keepsTermsUnactivatedWhenInvocationIsMissingOrResourceIsNotVisible() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        for (List<DomainToolInvocation> ledger : List.of(List.<DomainToolInvocation>of(), List.of(new DomainToolInvocation(
+                "invocation-failed", "key-failed", "any-turn", "session-1", "poc:ana",
+                DomainToolName.PREPARE_TERMS, "hash", DomainToolInvocationStatus.FAILED, "FAILED", Map.of(
+                        "url", policy.termsUrl("DECOR")), NOW, NOW.plusSeconds(1))), List.of(new DomainToolInvocation(
+                "invocation-no-url", "key-no-url", "any-turn", "session-1", "poc:ana",
+                DomainToolName.PREPARE_TERMS, "hash", DomainToolInvocationStatus.SUCCEEDED, "OK", Map.of(), NOW,
+                NOW.plusSeconds(1))))) {
+            MemoryConversation conversations = new MemoryConversation();
+            conversations.value = ReceptionConversation.start("conversation-1", "poc:ana", NOW)
+                    .bindContractingUnit("unit-1", "sala", "environment-event", NOW)
+                    .selectService("DECOR_INTERIORES", NOW)
+                    .presentTerms(NOW.plusSeconds(1));
+            MemoryAudits audits = new MemoryAudits();
+            MemoryInvocations invocations = new MemoryInvocations();
+            invocations.values.addAll(ledger);
+            String response = "Confira os termos, mas sem o endereço";
+            MemoryTranscript transcript = new MemoryTranscript();
+            ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(
+                    new HermesSessionService(new FakeSessions(response), new MemoryLinks()), conversations,
+                    new MemoryFacts(), transcript, new MemoryTurns(), policy, new ReceptionTurnCoordinator(), null,
+                    invocations, Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC));
+            orchestrator.setTermsAcceptanceUseCase(new TermsAcceptanceUseCase(audits, conversations));
+
+            orchestrator.process(new InboundConversationEvent("terms-noop-" + ledger.size(), "poc:ana",
+                    ReceptionMessageType.TEXT, "termos", NOW.plusSeconds(2)));
+
+            assertThat(conversations.value.activeTermsConsentId()).isNull();
+            assertThat(audits.values).isEmpty();
+        }
+    }
+
+    @Test
+    void fencesAnObsoleteInboundWhenANewerMessageArrivesBeforePublication() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryTranscript transcript = new MemoryTranscript();
+        MemoryTurns turns = new MemoryTurns();
+        FakeSessions sessions = new FakeSessions("Resposta tardia");
+        sessions.beforeResponse = () -> transcript.messages.add(new ReceptionMessage("newer-message", "newer-event",
+                "newer-correlation", "conversation-1", "poc:ana", ReceptionMessageDirection.INBOUND,
+                ReceptionMessageSender.CONTACT, ReceptionMessageType.TEXT, "mensagem nova", null, null,
+                NOW.plusSeconds(2)));
+        ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(
+                new HermesSessionService(sessions, new MemoryLinks()), conversations, new MemoryFacts(), transcript,
+                turns, new CommercialPolicyService(), new ReceptionTurnCoordinator(), Clock.fixed(NOW, ZoneOffset.UTC));
+
+        ReceptionOrchestrator.TurnReceipt receipt = orchestrator.process(new InboundConversationEvent(
+                "old-event", "poc:ana", ReceptionMessageType.TEXT, "oi", NOW));
+
+        assertThat(receipt.status()).isEqualTo(ReceptionOrchestrator.TurnStatus.FAILED_SAFE_TO_RETRY);
+        assertThat(receipt.error()).isEqualTo("STALE_INBOUND_BEFORE_PUBLICATION");
+        assertThat(transcript.messages).filteredOn(message -> message.direction() == ReceptionMessageDirection.OUTBOUND)
+                .isEmpty();
+        assertThat(turns.values.values()).singleElement().extracting(ReceptionTurn::failureCode)
+                .isEqualTo("STALE_INBOUND_BEFORE_PUBLICATION");
+    }
+
+    @Test
+    void validatesBatchPresenceAndContactOwnershipBeforePersistingAnything() {
+        ReceptionOrchestrator orchestrator = new ReceptionOrchestrator(
+                new HermesSessionService(new FakeSessions("unused"), new MemoryLinks()), new MemoryConversation(),
+                new MemoryFacts(), new MemoryTranscript(), new MemoryTurns(), new CommercialPolicyService(),
+                new ReceptionTurnCoordinator(), Clock.fixed(NOW, ZoneOffset.UTC));
+        assertThatThrownBy(() -> orchestrator.processBatch(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> orchestrator.processBatch(List.of())).isInstanceOf(IllegalArgumentException.class);
+        InboundConversationEvent first = new InboundConversationEvent("batch-a", "poc:ana", ReceptionMessageType.TEXT,
+                "oi", NOW);
+        InboundConversationEvent second = new InboundConversationEvent("batch-b", "poc:bia", ReceptionMessageType.TEXT,
+                "oi", NOW);
+        assertThatThrownBy(() -> orchestrator.processBatch(List.of(first, second)))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("multiple contacts");
+    }
+
     private static boolean awaitStatus(MemoryTurns turns, ReceptionTurnStatus expected, long timeoutMillis)
             throws InterruptedException {
         long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
@@ -1182,6 +1328,51 @@ class ReceptionOrchestratorTest {
         }
         @Override public CustomerFact save(CustomerFact fact) { saveCalls++; return fact; }
     }
+
+    private static final class MemoryAudits implements TermsConsentAuditGateway {
+        final Map<String, TermsConsentAudit> values = new HashMap<>();
+
+        @Override public Optional<TermsConsentAudit> findByPresentationId(String presentationId) {
+            return Optional.ofNullable(values.get(presentationId));
+        }
+
+        @Override public Optional<TermsConsentAudit> findPresented(String conversationId, String unitId) {
+            return values.values().stream().filter(value -> value.conversationId().equals(conversationId)
+                    && value.contractingUnitId().equals(unitId)
+                    && value.status() == TermsConsentStatus.PRESENTED).findFirst();
+        }
+
+        @Override public TermsConsentAudit savePresentationIfAbsent(TermsConsentAudit audit) {
+            return values.computeIfAbsent(audit.presentationId(), ignored -> audit);
+        }
+
+        @Override public TermsConsentAudit acceptIfPresented(String presentationId, String eventId,
+                                                              String messageId, String text, long version, Instant at) {
+            TermsConsentAudit current = values.get(presentationId);
+            if (current == null) throw new IllegalStateException("missing presentation");
+            TermsConsentAudit accepted = current.accept(messageId, eventId, text, at, version);
+            values.put(presentationId, accepted);
+            return accepted;
+        }
+    }
+
+    private static final class MemoryInvocations implements DomainToolInvocationGateway {
+        final List<DomainToolInvocation> values = new ArrayList<>();
+
+        @Override public Optional<DomainToolInvocation> findByIdempotencyKey(String key) {
+            return values.stream().filter(value -> value.idempotencyKey().equals(key)).findFirst();
+        }
+
+        @Override public DomainToolInvocation save(DomainToolInvocation invocation) {
+            values.add(invocation);
+            return invocation;
+        }
+
+        @Override public List<DomainToolInvocation> findByTurnId(String turnId) {
+            return List.copyOf(values);
+        }
+    }
+
     private static final class MemoryTranscript implements ReceptionTranscriptGateway {
         final List<ReceptionMessage> messages = new ArrayList<>();
         Runnable beforeAppend = () -> { };

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationTest.java
@@ -83,7 +83,7 @@ class ReceptionTurnReconciliationTest {
         assertThat(service.reconcile("turn-1")).isEmpty();
         assertThat(transcript.messages).filteredOn(message -> message.direction() == ReceptionMessageDirection.OUTBOUND)
                 .singleElement().extracting(ReceptionMessage::text)
-                .satisfies(value -> assertThat(value.toString()).contains("resposta tardia"));
+                .satisfies(value -> assertThat(value).contains("resposta tardia"));
         assertThat(turns.value.status().name()).isEqualTo("COMPLETED");
     }
 
@@ -217,8 +217,9 @@ class ReceptionTurnReconciliationTest {
         MemoryInvocations invocations = new MemoryInvocations(invocation);
         ReceptionTurnReconciliationService service = new ReceptionTurnReconciliationService(
                 new HermesSessionService(new TermsSessions(termsUrl), new EmptyLinks()), conversations, transcript,
-                turns, Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC), null, policy,
-                new TermsAcceptanceUseCase(audits, conversations), invocations);
+                turns, Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC),
+                new ReceptionTurnReconciliationService.Dependencies(null, policy,
+                        new TermsAcceptanceUseCase(audits, conversations), invocations));
 
         assertThat(service.reconcile("turn-terms")).hasValueSatisfying(value ->
                 assertThat(value).contains(termsUrl));
@@ -260,14 +261,15 @@ class ReceptionTurnReconciliationTest {
         };
         ReceptionTurnReconciliationService service = new ReceptionTurnReconciliationService(
                 new HermesSessionService(sessions, new EmptyLinks()), conversations, transcript, turns,
-                Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC), null, new CommercialPolicyService(), null, null);
+                Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC),
+                new ReceptionTurnReconciliationService.Dependencies(null, new CommercialPolicyService(), null, null));
 
         assertThat(service.reconcile("turn-payment")).hasValueSatisfying(value -> assertThat(value)
                 .contains("simulação", "1 serviço para cada ambiente contratado", "comprovante")
                 .doesNotContain("Pague agora", "http"));
         assertThat(transcript.messages).filteredOn(message -> message.direction() == ReceptionMessageDirection.OUTBOUND)
                 .singleElement().extracting(ReceptionMessage::text)
-                .satisfies(value -> assertThat(value.toString())
+                .satisfies(value -> assertThat(value)
                         .contains("simulação", "1 serviço para cada ambiente contratado", "comprovante"));
     }
 
@@ -340,7 +342,9 @@ class ReceptionTurnReconciliationTest {
                             : "{\"message\":\"Pagamento confirmado\",\"nextAction\":\"AWAIT_PAYMENT_APPROVAL\"}")));
             ReceptionTurnReconciliationService service = new ReceptionTurnReconciliationService(
                     new HermesSessionService(sessions, new EmptyLinks()), conversations, transcript, turns,
-                    Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC), null, new CommercialPolicyService(), null, null);
+                    Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC),
+                    new ReceptionTurnReconciliationService.Dependencies(null,
+                            new CommercialPolicyService(), null, null));
 
             assertThat(service.reconcile(turn.id())).isPresent();
             assertThat(turns.value.status()).isEqualTo(ReceptionTurnStatus.COMPLETED);

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationTest.java
@@ -3,11 +3,20 @@ package br.com.urbana.connect.application.reception;
 import br.com.urbana.connect.domain.reception.model.AgentUsage;
 import br.com.urbana.connect.domain.reception.model.ActiveTurnLease;
 import br.com.urbana.connect.domain.reception.model.ReceptionConversation;
+import br.com.urbana.connect.domain.reception.model.CommercialStage;
+import br.com.urbana.connect.domain.reception.model.PaymentStatus;
+import br.com.urbana.connect.domain.reception.model.ReceptionMode;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessage;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessageDirection;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessageSender;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessageType;
 import br.com.urbana.connect.domain.reception.model.ReceptionTurn;
+import br.com.urbana.connect.domain.reception.model.TermsConsentAudit;
+import br.com.urbana.connect.domain.reception.model.TermsConsentStatus;
+import br.com.urbana.connect.domain.reception.model.TermsStatus;
+import br.com.urbana.connect.domain.reception.model.DomainToolInvocation;
+import br.com.urbana.connect.domain.reception.model.DomainToolInvocationStatus;
+import br.com.urbana.connect.domain.reception.model.DomainToolName;
 import br.com.urbana.connect.domain.reception.port.out.AgentSessionLinkGateway;
 import br.com.urbana.connect.domain.reception.port.out.ActiveTurnLeaseGateway;
 import br.com.urbana.connect.domain.reception.port.out.CustomerFactGateway;
@@ -16,13 +25,17 @@ import br.com.urbana.connect.domain.reception.port.out.HermesSessionsGateway.Her
 import br.com.urbana.connect.domain.reception.port.out.ReceptionConversationGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTranscriptGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTurnGateway;
+import br.com.urbana.connect.domain.reception.port.out.DomainToolInvocationGateway;
+import br.com.urbana.connect.domain.reception.port.out.TermsConsentAuditGateway;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,10 +76,12 @@ class ReceptionTurnReconciliationTest {
                 new HermesSessionService(sessions, new EmptyLinks()), conversations, transcript, turns,
                 Clock.fixed(NOW.plusSeconds(3), ZoneOffset.UTC));
 
-        assertThat(service.reconcile("turn-1")).contains("resposta tardia");
+        assertThat(service.reconcile("turn-1")).hasValueSatisfying(value ->
+                assertThat(value).contains("resposta tardia"));
         assertThat(service.reconcile("turn-1")).isEmpty();
         assertThat(transcript.messages).filteredOn(message -> message.direction() == ReceptionMessageDirection.OUTBOUND)
-                .singleElement().extracting(ReceptionMessage::text).isEqualTo("resposta tardia");
+                .singleElement().extracting(ReceptionMessage::text)
+                .satisfies(value -> assertThat(value.toString()).contains("resposta tardia"));
         assertThat(turns.value.status().name()).isEqualTo("COMPLETED");
     }
 
@@ -126,7 +141,8 @@ class ReceptionTurnReconciliationTest {
                 new HermesSessionService(sessions, new EmptyLinks()), conversations, transcript, turns,
                 Clock.fixed(NOW.plusSeconds(1), ZoneOffset.UTC), leases);
 
-        assertThat(service.reconcile("turn-3")).contains("resposta tardia");
+        assertThat(service.reconcile("turn-3")).hasValueSatisfying(value ->
+                assertThat(value).contains("resposta tardia"));
         verify(gateway).revoke(eq("session-1"), eq("turn-3"), any(Instant.class));
         assertThat(transcript.messages).filteredOn(message ->
                 message.direction() == ReceptionMessageDirection.OUTBOUND).hasSize(1);
@@ -173,6 +189,100 @@ class ReceptionTurnReconciliationTest {
                 .isEqualTo("Vou encaminhar sua conversa para a arquiteta, que continuará com você por aqui.");
     }
 
+    @Test
+    void reconciledTermsTextIsPublishedOnlyWithDurablePresentationEvidence() {
+        MemoryTurns turns = new MemoryTurns();
+        ReceptionTurn turn = ReceptionTurn.queued("turn-terms", "corr-terms", "poc:ana", "session-1",
+                List.of("message-terms"), NOW, "cursor-1|1")
+                .start(NOW).reconcile("HERMES_TIMEOUT_AFTER_DISPATCH", NOW.plusSeconds(1));
+        turns.save(turn);
+        MemoryConversation conversations = new MemoryConversation();
+        ReceptionConversation presented = ReceptionConversation.start("conversation-terms", "poc:ana", NOW)
+                .bindContractingUnit("unit-1", "sala", "message-environment", NOW)
+                .selectService("DECOR_INTERIORES", NOW)
+                .presentTerms(NOW);
+        conversations.value = presented;
+        MemoryTranscript transcript = new MemoryTranscript();
+        transcript.messages.add(new ReceptionMessage("message-terms", "event-terms", "corr-terms",
+                "conversation-terms", "poc:ana", ReceptionMessageDirection.INBOUND,
+                ReceptionMessageSender.CONTACT, ReceptionMessageType.TEXT, "aguardo os termos", null, null, NOW));
+        CommercialPolicyService policy = new CommercialPolicyService();
+        String termsUrl = policy.termsUrl("DECOR_INTERIORES");
+        MemoryAudits audits = new MemoryAudits();
+        DomainToolInvocation invocation = new DomainToolInvocation("invocation-terms", "key-terms", "turn-terms",
+                "session-1", "poc:ana", DomainToolName.PREPARE_TERMS, "hash", DomainToolInvocationStatus.SUCCEEDED,
+                "OK", Map.of("status", "PRESENTED", "url", termsUrl), NOW, NOW.plusSeconds(1));
+        MemoryInvocations invocations = new MemoryInvocations(invocation);
+        ReceptionTurnReconciliationService service = new ReceptionTurnReconciliationService(
+                new HermesSessionService(new TermsSessions(termsUrl), new EmptyLinks()), conversations, transcript,
+                turns, Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC), null, policy,
+                new TermsAcceptanceUseCase(audits, conversations), invocations);
+
+        assertThat(service.reconcile("turn-terms")).hasValueSatisfying(value ->
+                assertThat(value).contains(termsUrl));
+        assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.PRESENTED);
+        assertThat(conversations.value.activeTermsConsentId()).isNotBlank();
+        assertThat(audits.findByPresentationId(conversations.value.activeTermsConsentId()))
+                .hasValueSatisfying(audit -> assertThat(audit.status()).isEqualTo(TermsConsentStatus.PRESENTED));
+    }
+
+    @Test
+    void invalidPreparedPaymentOutputFallsBackToPocQuantityAndProofGuidance() {
+        MemoryTurns turns = new MemoryTurns();
+        ReceptionTurn turn = ReceptionTurn.queued("turn-payment", "corr-payment", "poc:ana", "session-1",
+                        List.of("message-payment"), NOW, "cursor-1|1")
+                .start(NOW)
+                .reconcile("HERMES_TIMEOUT_AFTER_DISPATCH", NOW.plusSeconds(1));
+        turns.save(turn);
+        MemoryConversation conversations = new MemoryConversation();
+        conversations.value = new ReceptionConversation("conversation-payment", "poc:ana", ReceptionMode.AI,
+                CommercialStage.PAYMENT, "DECOR_INTERIORES", TermsStatus.ACCEPTED, PaymentStatus.PREPARED,
+                null, NOW, NOW, 1);
+        MemoryTranscript transcript = new MemoryTranscript();
+        transcript.messages.add(new ReceptionMessage("message-payment", "event-payment", "corr-payment",
+                "conversation-payment", "poc:ana", ReceptionMessageDirection.INBOUND,
+                ReceptionMessageSender.CONTACT, ReceptionMessageType.TEXT, "Como faço o pagamento?",
+                null, null, NOW));
+        HermesSessionsGateway sessions = new HermesSessionsGateway() {
+            @Override public String createSession(String contactId) { return "session-1"; }
+            @Override public HermesChatResult chat(String sessionId, HermesChatRequest request) {
+                throw new AssertionError("must not dispatch");
+            }
+            @Override public List<HermesHistoryMessage> history(String sessionId) { return List.of(); }
+            @Override public HermesHistorySnapshot historySnapshot(String sessionId) {
+                return new HermesHistorySnapshot("cursor-2", List.of(
+                        new HermesHistoryMessage("user", "Como faço o pagamento?"),
+                        new HermesHistoryMessage("assistant",
+                                "{\"message\":\"Pague agora.\",\"nextAction\":\"AWAIT_PAYMENT_PROOF\"}")));
+            }
+        };
+        ReceptionTurnReconciliationService service = new ReceptionTurnReconciliationService(
+                new HermesSessionService(sessions, new EmptyLinks()), conversations, transcript, turns,
+                Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC), null, new CommercialPolicyService(), null, null);
+
+        assertThat(service.reconcile("turn-payment")).hasValueSatisfying(value -> assertThat(value)
+                .contains("simulação", "1 serviço para cada ambiente contratado", "comprovante")
+                .doesNotContain("Pague agora", "http"));
+        assertThat(transcript.messages).filteredOn(message -> message.direction() == ReceptionMessageDirection.OUTBOUND)
+                .singleElement().extracting(ReceptionMessage::text)
+                .satisfies(value -> assertThat(value.toString())
+                        .contains("simulação", "1 serviço para cada ambiente contratado", "comprovante"));
+    }
+
+    private static final class TermsSessions implements HermesSessionsGateway {
+        private final String termsUrl;
+        private TermsSessions(String termsUrl) { this.termsUrl = termsUrl; }
+        @Override public String createSession(String contactId) { return "session-1"; }
+        @Override public HermesChatResult chat(String sessionId, HermesChatRequest request) { throw new AssertionError(); }
+        @Override public List<HermesHistoryMessage> history(String sessionId) { return List.of(); }
+        @Override public HermesHistorySnapshot historySnapshot(String sessionId) {
+            return new HermesHistorySnapshot("cursor-2", List.of(
+                    new HermesHistoryMessage("user", "aguardo os termos"),
+                    new HermesHistoryMessage("assistant", "{\"message\":\"Confira os termos: "
+                            + termsUrl + "\",\"nextAction\":\"AWAIT_CUSTOMER\"}")));
+        }
+    }
+
     private static final class EmptyLinks implements AgentSessionLinkGateway {
         @Override public Optional<br.com.urbana.connect.domain.reception.model.AgentSessionLink> findActiveByContactId(String contactId) { return Optional.empty(); }
         @Override public Optional<br.com.urbana.connect.domain.reception.model.AgentSessionLink> findBySessionId(String sessionId) { return Optional.empty(); }
@@ -202,5 +312,39 @@ class ReceptionTurnReconciliationTest {
         @Override public ReceptionTurn save(ReceptionTurn turn) { return value = turn; }
         @Override public Optional<ReceptionTurn> findById(String turnId) { return Optional.ofNullable(value); }
         @Override public Optional<ReceptionTurn> findByInboundMessageId(String messageId) { return Optional.ofNullable(value); }
+    }
+
+    private static final class MemoryAudits implements TermsConsentAuditGateway {
+        private final Map<String, TermsConsentAudit> values = new HashMap<>();
+        @Override public Optional<TermsConsentAudit> findByPresentationId(String id) {
+            return Optional.ofNullable(values.get(id));
+        }
+        @Override public Optional<TermsConsentAudit> findPresented(String conversationId, String unitId) {
+            return values.values().stream().filter(value -> value.conversationId().equals(conversationId)
+                    && value.contractingUnitId().equals(unitId)
+                    && value.status() == TermsConsentStatus.PRESENTED).findFirst();
+        }
+        @Override public TermsConsentAudit savePresentationIfAbsent(TermsConsentAudit audit) {
+            return values.computeIfAbsent(audit.presentationId(), ignored -> audit);
+        }
+        @Override public TermsConsentAudit acceptIfPresented(String id, String eventId, String messageId,
+                                                             String text, long version, Instant at) {
+            TermsConsentAudit current = findByPresentationId(id).orElseThrow();
+            TermsConsentAudit accepted = current.accept(messageId, eventId, text, at, version);
+            values.put(id, accepted);
+            return accepted;
+        }
+    }
+
+    private static final class MemoryInvocations implements DomainToolInvocationGateway {
+        private final DomainToolInvocation invocation;
+        private MemoryInvocations(DomainToolInvocation invocation) { this.invocation = invocation; }
+        @Override public Optional<DomainToolInvocation> findByIdempotencyKey(String key) {
+            return invocation.idempotencyKey().equals(key) ? Optional.of(invocation) : Optional.empty();
+        }
+        @Override public DomainToolInvocation save(DomainToolInvocation value) { return value; }
+        @Override public List<DomainToolInvocation> findByTurnId(String turnId) {
+            return invocation.turnId().equals(turnId) ? List.of(invocation) : List.of();
+        }
     }
 }

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationTest.java
@@ -1,5 +1,6 @@
 package br.com.urbana.connect.application.reception;
 
+import br.com.urbana.connect.application.reception.tools.StatefulDomainToolService;
 import br.com.urbana.connect.domain.reception.model.AgentUsage;
 import br.com.urbana.connect.domain.reception.model.ActiveTurnLease;
 import br.com.urbana.connect.domain.reception.model.ReceptionConversation;
@@ -11,6 +12,7 @@ import br.com.urbana.connect.domain.reception.model.ReceptionMessageDirection;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessageSender;
 import br.com.urbana.connect.domain.reception.model.ReceptionMessageType;
 import br.com.urbana.connect.domain.reception.model.ReceptionTurn;
+import br.com.urbana.connect.domain.reception.model.ReceptionTurnStatus;
 import br.com.urbana.connect.domain.reception.model.TermsConsentAudit;
 import br.com.urbana.connect.domain.reception.model.TermsConsentStatus;
 import br.com.urbana.connect.domain.reception.model.TermsStatus;
@@ -269,6 +271,239 @@ class ReceptionTurnReconciliationTest {
                         .contains("simulação", "1 serviço para cada ambiente contratado", "comprovante"));
     }
 
+    @Test
+    void ignoresUnknownOrAlreadyResolvedTurnReferencesAndMalformedCheckpoints() {
+        MemoryTurns turns = new MemoryTurns();
+        ReceptionTurn completed = ReceptionTurn.queued("turn-done", "corr-done", "poc:ana", "session-1",
+                List.of("message-done"), NOW, "cursor-1|1").start(NOW).complete(AgentUsage.empty(), NOW.plusSeconds(1),
+                new br.com.urbana.connect.domain.reception.model.AgentOutput("ok",
+                        br.com.urbana.connect.domain.reception.model.AgentNextAction.AWAIT_CUSTOMER));
+        turns.save(completed);
+        ReceptionTurn malformed = ReceptionTurn.queued("turn-malformed", "corr-malformed", "poc:ana", "session-1",
+                List.of("message-malformed"), NOW, "not-a-checkpoint").start(NOW)
+                .reconcile("HERMES_TIMEOUT_AFTER_DISPATCH", NOW.plusSeconds(1));
+        turns.save(malformed);
+        MemoryTranscript transcript = new MemoryTranscript();
+        transcript.messages.add(new ReceptionMessage("message-event", "event-malformed", "corr-malformed",
+                "conversation-1", "poc:ana", ReceptionMessageDirection.INBOUND, ReceptionMessageSender.CONTACT,
+                ReceptionMessageType.TEXT, "oi", null, null, NOW));
+
+        ReceptionTurnReconciliationService service = new ReceptionTurnReconciliationService(
+                new HermesSessionService(new EmptyLinksSessions(), new EmptyLinks()), new MemoryConversation(),
+                transcript, turns, Clock.fixed(NOW, ZoneOffset.UTC));
+
+        assertThat(service.reconcile("missing")).isEmpty();
+        assertThat(service.reconcile("turn-done")).isEmpty();
+        assertThat(service.reconcile("event-malformed")).isEmpty();
+        assertThat(service.reconcile("turn-malformed")).isEmpty();
+    }
+
+    @Test
+    void leavesReconcilingTurnWhenCursorIsUnchangedTooShortOrOutputIsInvalid() {
+        MemoryTurns turns = new MemoryTurns();
+        ReceptionTurn turn = ReceptionTurn.queued("turn-nochange", "corr-nochange", "poc:ana", "session-1",
+                List.of("message-1"), NOW, "cursor-1|1").start(NOW).reconcile("timeout", NOW.plusSeconds(1));
+        turns.save(turn);
+        MemoryConversation conversations = new MemoryConversation();
+        conversations.value = ReceptionConversation.start("conversation-1", "poc:ana", NOW);
+        MemoryTranscript transcript = new MemoryTranscript();
+        transcript.messages.add(inbound("message-1", "conversation-1", "Oi", NOW));
+        SnapshotSessions sessions = new SnapshotSessions("cursor-1", List.of(inboundHistory(), assistant("não json")));
+        ReceptionTurnReconciliationService service = new ReceptionTurnReconciliationService(
+                new HermesSessionService(sessions, new EmptyLinks()), conversations, transcript, turns,
+                Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC));
+
+        assertThat(service.reconcile("turn-nochange")).isEmpty();
+        sessions.cursor = "cursor-2";
+        sessions.messages = List.of(inboundHistory());
+        assertThat(service.reconcile("turn-nochange")).isEmpty();
+        sessions.messages = List.of(inboundHistory(), assistant(""));
+        assertThat(service.reconcile("turn-nochange")).isEmpty();
+        assertThat(turns.value.status()).isEqualTo(ReceptionTurnStatus.RECONCILING);
+    }
+
+    @Test
+    void appliesEveryPaymentFallbackWithoutConfirmingOrReleasingBriefing() {
+        for (PaymentStatus paymentStatus : PaymentStatus.values()) {
+            MemoryTurns turns = new MemoryTurns();
+            ReceptionTurn turn = ReceptionTurn.queued("turn-" + paymentStatus, "corr-" + paymentStatus,
+                    "poc:ana", "session-1", List.of("message-" + paymentStatus), NOW, "cursor-1|1")
+                    .start(NOW).reconcile("timeout", NOW.plusSeconds(1));
+            turns.save(turn);
+            MemoryConversation conversations = new MemoryConversation();
+            conversations.value = paymentConversation(paymentStatus);
+            MemoryTranscript transcript = new MemoryTranscript();
+            transcript.messages.add(inbound("message-" + paymentStatus, "conversation-1", "Como faço?", NOW));
+            SnapshotSessions sessions = new SnapshotSessions("cursor-2", List.of(inboundHistory(),
+                    assistant(paymentStatus == PaymentStatus.PROOF_RECEIVED
+                            ? "{\"message\":\"aguarde\",\"nextAction\":\"AWAIT_PAYMENT_PROOF\"}"
+                            : "{\"message\":\"Pagamento confirmado\",\"nextAction\":\"AWAIT_PAYMENT_APPROVAL\"}")));
+            ReceptionTurnReconciliationService service = new ReceptionTurnReconciliationService(
+                    new HermesSessionService(sessions, new EmptyLinks()), conversations, transcript, turns,
+                    Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC), null, new CommercialPolicyService(), null, null);
+
+            assertThat(service.reconcile(turn.id())).isPresent();
+            assertThat(turns.value.status()).isEqualTo(ReceptionTurnStatus.COMPLETED);
+            String message = transcript.messages.stream().filter(value ->
+                    value.direction() == ReceptionMessageDirection.OUTBOUND).findFirst().orElseThrow().text();
+            switch (paymentStatus) {
+                case PROOF_RECEIVED -> assertThat(message).contains("aguarda validação humana");
+                case PREPARED -> assertThat(message).contains("1 serviço para cada ambiente");
+                case NOT_STARTED -> assertThat(message).contains("escolha uma forma de pagamento");
+                case REJECTED -> assertThat(message).containsIgnoringCase("não consigo confirmar");
+                case CONFIRMED -> assertThat(message).contains("Pagamento confirmado");
+            }
+        }
+    }
+
+    @Test
+    void fencesNewInboundBeforeAndDuringReconciliationPublication() {
+        for (boolean duringPublication : List.of(false, true)) {
+            MemoryTurns turns = new MemoryTurns();
+            ReceptionTurn turn = ReceptionTurn.queued("turn-fence-" + duringPublication,
+                    "corr-fence-" + duringPublication, "poc:ana", "session-1",
+                    List.of("message-fence"), NOW, "cursor-1|1").start(NOW)
+                    .reconcile("timeout", NOW.plusSeconds(1));
+            turns.save(turn);
+            MemoryConversation conversations = new MemoryConversation();
+            conversations.value = ReceptionConversation.start("conversation-1", "poc:ana", NOW);
+            MemoryTranscript transcript = new MemoryTranscript();
+            transcript.messages.add(inbound("message-fence", "conversation-1", "Oi", NOW));
+            if (!duringPublication) {
+                transcript.messages.add(inbound("newer-before", "conversation-1", "Ainda estou aqui", NOW.plusSeconds(2)));
+            } else {
+                transcript.beforeAppend = () -> transcript.messages.add(inbound("newer-during", "conversation-1",
+                        "Mensagem nova", NOW.plusSeconds(2)));
+            }
+            SnapshotSessions sessions = new SnapshotSessions("cursor-2", List.of(inboundHistory(),
+                    assistant("{\"message\":\"resposta tardia\",\"nextAction\":\"AWAIT_CUSTOMER\"}")));
+            ReceptionTurnReconciliationService service = new ReceptionTurnReconciliationService(
+                    new HermesSessionService(sessions, new EmptyLinks()), conversations, transcript, turns,
+                    Clock.fixed(NOW.plusSeconds(3), ZoneOffset.UTC));
+
+            assertThat(service.reconcile(turn.id())).isEmpty();
+            assertThat(turns.value.status()).isEqualTo(ReceptionTurnStatus.FAILED_SAFE_TO_RETRY);
+            assertThat(turns.value.failureClass()).isEqualTo(duringPublication
+                    ? "STALE_INBOUND_DURING_RECONCILIATION_PUBLICATION" : "STALE_INBOUND_BEFORE_RECONCILIATION");
+        }
+    }
+
+    @Test
+    void releasesLeaseWhenHandoffAckAlreadyExistsAndWhenConversationChangesDuringSnapshot() {
+        MemoryTurns turns = new MemoryTurns();
+        ReceptionTurn turn = ReceptionTurn.queued("turn-handoff-existing", "corr-handoff-existing", "poc:ana",
+                "session-1", List.of("message-handoff-existing"), NOW, "cursor-1|1").start(NOW)
+                .reconcile("timeout", NOW.plusSeconds(1));
+        turns.save(turn);
+        MemoryConversation conversations = new MemoryConversation();
+        conversations.value = ReceptionConversation.start("conversation-1", "poc:ana", NOW)
+                .requestHumanHandoff("cliente pediu pessoa", NOW.plusSeconds(1));
+        MemoryTranscript transcript = new MemoryTranscript();
+        transcript.messages.add(inbound("message-handoff-existing", "conversation-1", "pessoa", NOW));
+        String ackId = StatefulDomainToolService.handoffAckEventId(conversations.value);
+        transcript.messages.add(new ReceptionMessage("ack", ackId, "corr-handoff-existing", "conversation-1", "poc:ana",
+                ReceptionMessageDirection.OUTBOUND, ReceptionMessageSender.URBA, ReceptionMessageType.TEXT,
+                StatefulDomainToolService.HUMAN_HANDOFF_ACK, null, null, NOW.plusSeconds(1)));
+        ActiveTurnLeaseGateway leaseGateway = mock(ActiveTurnLeaseGateway.class);
+        ActiveTurnLeaseService leases = new ActiveTurnLeaseService(leaseGateway, Clock.fixed(NOW, ZoneOffset.UTC),
+                java.time.Duration.ofSeconds(30));
+        ReceptionTurnReconciliationService service = new ReceptionTurnReconciliationService(
+                new HermesSessionService(new EmptyLinksSessions(), new EmptyLinks()), conversations, transcript, turns,
+                Clock.fixed(NOW.plusSeconds(2), ZoneOffset.UTC), leases);
+
+        assertThat(service.reconcile(turn.id())).contains(StatefulDomainToolService.HUMAN_HANDOFF_ACK);
+        verify(leaseGateway).revoke(eq("session-1"), eq(turn.id()), any(Instant.class));
+        assertThat(transcript.messages).filteredOn(value -> value.eventId().equals(ackId)).hasSize(1);
+
+        MemoryTurns changedTurns = new MemoryTurns();
+        ReceptionTurn changedTurn = ReceptionTurn.queued("turn-mode-race", "corr-mode-race", "poc:ana", "session-2",
+                List.of("message-mode-race"), NOW, "cursor-1|1").start(NOW)
+                .reconcile("timeout", NOW.plusSeconds(1));
+        changedTurns.save(changedTurn);
+        MemoryConversation changedConversations = new MemoryConversation();
+        changedConversations.value = ReceptionConversation.start("conversation-2", "poc:ana", NOW);
+        MemoryTranscript changedTranscript = new MemoryTranscript();
+        changedTranscript.messages.add(inbound("message-mode-race", "conversation-2", "oi", NOW));
+        SnapshotSessions changingSessions = new SnapshotSessions("cursor-2", List.of(inboundHistory(), assistant(
+                "{\"message\":\"late\",\"nextAction\":\"AWAIT_CUSTOMER\"}")));
+        changingSessions.beforeSnapshot = () -> changedConversations.value = changedConversations.value
+                .requestHumanHandoff("cliente pediu pessoa", NOW.plusSeconds(2));
+        ReceptionTurnReconciliationService changingService = new ReceptionTurnReconciliationService(
+                new HermesSessionService(changingSessions, new EmptyLinks()), changedConversations, changedTranscript,
+                changedTurns, Clock.fixed(NOW.plusSeconds(3), ZoneOffset.UTC));
+
+        assertThat(changingService.reconcile(changedTurn.id())).contains(StatefulDomainToolService.HUMAN_HANDOFF_ACK);
+        assertThat(changedTurns.value.status()).isEqualTo(ReceptionTurnStatus.BLOCKED_BY_HUMAN);
+    }
+
+    @Test
+    void preservesIdentityOnlyForTheFirstReconciledOutbound() {
+        MemoryTurns turns = new MemoryTurns();
+        ReceptionTurn turn = ReceptionTurn.queued("turn-identity", "corr-identity", "poc:ana", "session-1",
+                List.of("message-identity"), NOW, "cursor-1|1").start(NOW).reconcile("timeout", NOW.plusSeconds(1));
+        turns.save(turn);
+        MemoryConversation conversations = new MemoryConversation();
+        conversations.value = ReceptionConversation.start("conversation-identity", "poc:ana", NOW);
+        MemoryTranscript transcript = new MemoryTranscript();
+        transcript.messages.add(inbound("message-identity", "conversation-identity", "Oi", NOW));
+        transcript.messages.add(new ReceptionMessage("old-outbound", "old-event", "old-corr", "conversation-identity",
+                "poc:ana", ReceptionMessageDirection.OUTBOUND, ReceptionMessageSender.URBA, ReceptionMessageType.TEXT,
+                "mensagem anterior", null, null, NOW.plusSeconds(1)));
+        SnapshotSessions sessions = new SnapshotSessions("cursor-2", List.of(inboundHistory(), assistant(
+                "{\"message\":\"resposta\",\"nextAction\":\"AWAIT_CUSTOMER\"}")));
+        ReceptionTurnReconciliationService service = new ReceptionTurnReconciliationService(
+                new HermesSessionService(sessions, new EmptyLinks()), conversations, transcript, turns,
+                Clock.fixed(NOW.plusSeconds(3), ZoneOffset.UTC));
+
+        assertThat(service.reconcile(turn.id())).hasValue("resposta");
+        assertThat(transcript.messages).filteredOn(value -> value.direction() == ReceptionMessageDirection.OUTBOUND)
+                .extracting(ReceptionMessage::text).containsExactly("mensagem anterior", "resposta");
+    }
+
+    private static ReceptionMessage inbound(String id, String conversationId, String text, Instant at) {
+        return new ReceptionMessage(id, "event-" + id, "corr-" + id, conversationId, "poc:ana",
+                ReceptionMessageDirection.INBOUND, ReceptionMessageSender.CONTACT, ReceptionMessageType.TEXT,
+                text, null, null, at);
+    }
+
+    private static HermesSessionsGateway.HermesHistoryMessage inboundHistory() {
+        return new HermesSessionsGateway.HermesHistoryMessage("user", "Oi");
+    }
+
+    private static HermesSessionsGateway.HermesHistoryMessage assistant(String content) {
+        return new HermesSessionsGateway.HermesHistoryMessage("assistant", content);
+    }
+
+    private static ReceptionConversation paymentConversation(PaymentStatus status) {
+        return new ReceptionConversation("conversation-1", "poc:ana", ReceptionMode.AI, CommercialStage.PAYMENT,
+                "DECOR_INTERIORES", TermsStatus.ACCEPTED, status, null, NOW, NOW, 1);
+    }
+
+    private static final class SnapshotSessions implements HermesSessionsGateway {
+        private String cursor;
+        private List<HermesHistoryMessage> messages;
+        private Runnable beforeSnapshot = () -> { };
+
+        private SnapshotSessions(String cursor, List<HermesHistoryMessage> messages) {
+            this.cursor = cursor;
+            this.messages = messages;
+        }
+
+        @Override public String createSession(String contactId) { return "session-1"; }
+        @Override public HermesChatResult chat(String sessionId, HermesChatRequest request) { throw new AssertionError(); }
+        @Override public List<HermesHistoryMessage> history(String sessionId) { return messages; }
+        @Override public HermesHistorySnapshot historySnapshot(String sessionId) {
+            beforeSnapshot.run();
+            return new HermesHistorySnapshot(cursor, messages);
+        }
+    }
+
+    private static final class EmptyLinksSessions implements HermesSessionsGateway {
+        @Override public String createSession(String contactId) { return "session-1"; }
+        @Override public HermesChatResult chat(String sessionId, HermesChatRequest request) { throw new AssertionError(); }
+        @Override public List<HermesHistoryMessage> history(String sessionId) { return List.of(); }
+    }
+
     private static final class TermsSessions implements HermesSessionsGateway {
         private final String termsUrl;
         private TermsSessions(String termsUrl) { this.termsUrl = termsUrl; }
@@ -299,8 +534,10 @@ class ReceptionTurnReconciliationTest {
 
     private static final class MemoryTranscript implements ReceptionTranscriptGateway {
         final List<ReceptionMessage> messages = new ArrayList<>();
+        Runnable beforeAppend = () -> { };
         @Override public boolean appendIfAbsent(ReceptionMessage message) {
             if (messages.stream().anyMatch(item -> item.eventId().equals(message.eventId()))) return false;
+            beforeAppend.run();
             messages.add(message); return true;
         }
         @Override public Optional<ReceptionMessage> findByEventId(String eventId) { return messages.stream().filter(item -> item.eventId().equals(eventId)).findFirst(); }

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/TermsAcceptanceUseCaseTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/TermsAcceptanceUseCaseTest.java
@@ -77,6 +77,132 @@ class TermsAcceptanceUseCaseTest {
                 .isEqualTo(TermsConsentStatus.ACCEPTED);
     }
 
+    @Test
+    void rejectsBlankAcceptanceBoundaryArgumentsAndInvalidVersions() {
+        TermsAcceptanceUseCase useCase = new TermsAcceptanceUseCase(new MemoryGateway());
+
+        assertThatThrownBy(() -> useCase.recordAcceptance(null, "event", "message", "Aceito", 0, NOW))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("presentationId");
+        assertThatThrownBy(() -> useCase.recordAcceptance("presentation", " ", "message", "Aceito", 0, NOW))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("eventId");
+        assertThatThrownBy(() -> useCase.recordAcceptance("presentation", "event", "", "Aceito", 0, NOW))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("messageId");
+        assertThatThrownBy(() -> useCase.recordAcceptance("presentation", "event", "message", " ", 0, NOW))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("exactText");
+        assertThatThrownBy(() -> useCase.recordAcceptance("presentation", "event", "message", "Aceito", -1, NOW))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("non-negative");
+        assertThatThrownBy(() -> useCase.recordAcceptance("presentation", "event", "message", "Aceito", 0, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void rejectsNonPresentedAuditsAsPresentationEvidence() {
+        TermsAcceptanceUseCase useCase = new TermsAcceptanceUseCase(new MemoryGateway());
+        TermsConsentAudit accepted = presented().accept("message-accept", "event-accept", "Aceito",
+                NOW.plusSeconds(1), 4);
+
+        assertThatThrownBy(() -> useCase.recordPresentation(accepted))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("only a presented audit");
+    }
+
+    @Test
+    void rejectsAcceptanceWhenConversationHasNoActivePresentationOrEvidence() {
+        TermsAcceptanceUseCase useCase = new TermsAcceptanceUseCase(new MemoryGateway());
+        ReceptionConversation selected = ReceptionConversation.start("conversation-1", "contact-1", NOW)
+                .selectService("DECOR_INTERIORES", NOW);
+
+        assertThatThrownBy(() -> useCase.recordAcceptance(selected, "event", "message", "Aceito", NOW,
+                new CommercialPolicyService()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("presented with durable evidence");
+
+        ReceptionConversation presentedConversation = selected.presentTerms(NOW)
+                .activateTermsConsent("missing", NOW.plusSeconds(1));
+        assertThatThrownBy(() -> useCase.recordAcceptance(presentedConversation, "event", "message", "Aceito",
+                NOW.plusSeconds(2), new CommercialPolicyService()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("evidence is missing");
+    }
+
+    @Test
+    void rejectsEvidenceFromAnotherConversationUnitOrService() {
+        MemoryGateway gateway = new MemoryGateway();
+        gateway.savePresentationIfAbsent(presented());
+        TermsAcceptanceUseCase useCase = new TermsAcceptanceUseCase(gateway);
+        CommercialPolicyService policy = new CommercialPolicyService();
+        ReceptionConversation base = ReceptionConversation.start("conversation-1", "contact-1", NOW)
+                .bindContractingUnit("unit-1", "sala", "message-environment", NOW)
+                .selectService("DECOR_INTERIORES", NOW)
+                .presentTerms(NOW)
+                .activateTermsConsent("presentation-1", NOW);
+
+        ReceptionConversation otherConversation = new ReceptionConversation("conversation-other", "contact-1",
+                base.mode(), base.commercialStage(), base.selectedService(), base.termsStatus(), base.paymentStatus(),
+                null, base.createdAt(), base.updatedAt(), base.version(), base.resumeStatus(), base.resumeId(),
+                base.resumeIdempotencyKey(), base.resumeChecksum(), base.resumeBoundarySequence(),
+                base.resumeDecisionAction(), base.resumeDecisionMessage(), base.resumeFailureCode(),
+                base.contractingUnitId(), base.environmentLabel(), base.environmentSourceMessageId(),
+                base.activeTermsConsentId());
+        assertThatThrownBy(() -> useCase.recordAcceptance(otherConversation, "event", "message", "Aceito",
+                NOW.plusSeconds(1), policy)).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("does not match");
+
+        ReceptionConversation otherUnit = new ReceptionConversation(base.id(), base.contactId(), base.mode(),
+                base.commercialStage(), base.selectedService(), base.termsStatus(), base.paymentStatus(), null,
+                base.createdAt(), base.updatedAt(), base.version(), base.resumeStatus(), base.resumeId(),
+                base.resumeIdempotencyKey(), base.resumeChecksum(), base.resumeBoundarySequence(),
+                base.resumeDecisionAction(), base.resumeDecisionMessage(), base.resumeFailureCode(),
+                "unit-other", base.environmentLabel(), base.environmentSourceMessageId(), base.activeTermsConsentId());
+        assertThatThrownBy(() -> useCase.recordAcceptance(otherUnit, "event", "message", "Aceito",
+                NOW.plusSeconds(1), policy)).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("does not match");
+
+        ReceptionConversation otherService = base.selectService("DECOR_PINTURA", NOW.plusSeconds(1))
+                .presentTerms(NOW.plusSeconds(1)).activateTermsConsent("presentation-1", NOW.plusSeconds(2));
+        assertThatThrownBy(() -> useCase.recordAcceptance(otherService, "event", "message", "Aceito",
+                NOW.plusSeconds(3), policy)).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("does not match");
+    }
+
+    @Test
+    void requiresAcceptedEvidenceAndAllowsMatchingAcceptedAudit() {
+        MemoryGateway gateway = new MemoryGateway();
+        gateway.savePresentationIfAbsent(presented());
+        TermsAcceptanceUseCase useCase = new TermsAcceptanceUseCase(gateway);
+        ReceptionConversation conversation = ReceptionConversation.start("conversation-1", "contact-1", NOW)
+                .bindContractingUnit("unit-1", "sala", "message-environment", NOW)
+                .selectService("DECOR_INTERIORES", NOW)
+                .presentTerms(NOW)
+                .activateTermsConsent("presentation-1", NOW);
+
+        assertThatThrownBy(() -> useCase.requireAcceptedEvidence(conversation))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("acceptance evidence");
+
+        gateway.acceptIfPresented("presentation-1", "event-accept", "message-accept", "Aceito", 5,
+                NOW.plusSeconds(1));
+        ReceptionConversation accepted = new ReceptionConversation(conversation.id(), conversation.contactId(),
+                conversation.mode(), conversation.commercialStage(), conversation.selectedService(),
+                TermsStatus.ACCEPTED, conversation.paymentStatus(), null, conversation.createdAt(),
+                conversation.updatedAt(), conversation.version(), conversation.resumeStatus(), conversation.resumeId(),
+                conversation.resumeIdempotencyKey(), conversation.resumeChecksum(), conversation.resumeBoundarySequence(),
+                conversation.resumeDecisionAction(), conversation.resumeDecisionMessage(), conversation.resumeFailureCode(),
+                conversation.contractingUnitId(), conversation.environmentLabel(), conversation.environmentSourceMessageId(),
+                conversation.activeTermsConsentId());
+        assertThat(useCase.requireAcceptedEvidence(accepted).status()).isEqualTo(TermsConsentStatus.ACCEPTED);
+    }
+
+    @Test
+    void rejectsAcceptedEvidenceWhenTheConversationHasNoActivePresentationId() {
+        TermsAcceptanceUseCase useCase = new TermsAcceptanceUseCase(new MemoryGateway());
+        ReceptionConversation conversation = ReceptionConversation.start("conversation-1", "contact-1", NOW);
+
+        assertThatThrownBy(() -> useCase.requireAcceptedEvidence(conversation))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("durable terms presentation evidence is missing");
+    }
+
     private static TermsConsentAudit presented() {
         return new TermsConsentAudit("presentation-1", "conversation-1", "contact-1", "turn-1", "unit-1",
                 "sala", "message-environment", "DECOR_INTERIORES", "terms-v1", "v1", "invoke-1",

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/TermsAcceptanceUseCaseTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/TermsAcceptanceUseCaseTest.java
@@ -1,0 +1,113 @@
+package br.com.urbana.connect.application.reception;
+
+import br.com.urbana.connect.domain.reception.model.TermsConsentAudit;
+import br.com.urbana.connect.domain.reception.model.TermsConsentStatus;
+import br.com.urbana.connect.domain.reception.port.out.TermsConsentAuditGateway;
+import br.com.urbana.connect.domain.reception.port.out.ReceptionConversationGateway;
+import br.com.urbana.connect.domain.reception.model.ReceptionConversation;
+import br.com.urbana.connect.domain.reception.model.TermsStatus;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TermsAcceptanceUseCaseTest {
+    private static final Instant NOW = Instant.parse("2026-08-28T12:00:00Z");
+
+    @Test
+    void recordsOnlyTheFirstAcceptanceAgainstAnAlreadyPresentedAudit() {
+        MemoryGateway gateway = new MemoryGateway();
+        TermsConsentAudit presented = presented();
+        gateway.savePresentationIfAbsent(presented);
+        TermsAcceptanceUseCase useCase = new TermsAcceptanceUseCase(gateway);
+
+        TermsConsentAudit accepted = useCase.recordAcceptance("presentation-1", "event-accept-1", "message-accept-1",
+                "Aceito", 4, NOW.plusSeconds(1));
+        TermsConsentAudit replay = useCase.recordAcceptance("presentation-1", "event-accept-2", "message-accept-2",
+                "Aceito novamente", 5, NOW.plusSeconds(2));
+
+        assertThat(accepted.status()).isEqualTo(TermsConsentStatus.ACCEPTED);
+        assertThat(accepted.acceptanceTextExact()).isEqualTo("Aceito");
+        assertThat(replay).isEqualTo(accepted);
+    }
+
+    @Test
+    void failsClosedWithoutPresentationEvidence() {
+        TermsAcceptanceUseCase useCase = new TermsAcceptanceUseCase(new MemoryGateway());
+        assertThatThrownBy(() -> useCase.recordAcceptance("missing", "event", "message", "Aceito", 1, NOW))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void rejectsAnAcceptanceTimestampBeforeTheDurablePresentation() {
+        MemoryGateway gateway = new MemoryGateway();
+        gateway.savePresentationIfAbsent(presented());
+        TermsAcceptanceUseCase useCase = new TermsAcceptanceUseCase(gateway);
+
+        assertThatThrownBy(() -> useCase.recordAcceptance("presentation-1", "event", "message", "Aceito",
+                4, NOW.minusSeconds(1)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("precede presentation");
+    }
+
+    @Test
+    void persistsTheConversationTransitionWhenTheProductionGatewayIsProvided() {
+        MemoryGateway gateway = new MemoryGateway();
+        gateway.savePresentationIfAbsent(presented());
+        MemoryConversation conversations = new MemoryConversation();
+        ReceptionConversation current = ReceptionConversation.start("conversation-1", "contact-1", NOW)
+                .bindContractingUnit("unit-1", "sala", "message-environment", NOW.plusSeconds(1))
+                .selectService("DECOR_INTERIORES", NOW.plusSeconds(2))
+                .presentTerms(NOW.plusSeconds(3))
+                .activateTermsConsent("presentation-1", NOW.plusSeconds(4));
+        conversations.value = current;
+
+        TermsAcceptanceUseCase useCase = new TermsAcceptanceUseCase(gateway, conversations);
+        ReceptionConversation accepted = useCase.recordAcceptance(current, "event-accept-1", "message-accept-1",
+                "Aceito", NOW.plusSeconds(5), new CommercialPolicyService());
+
+        assertThat(useCase.persistsConversation()).isTrue();
+        assertThat(accepted.termsStatus()).isEqualTo(TermsStatus.ACCEPTED);
+        assertThat(conversations.value).isEqualTo(accepted);
+        assertThat(gateway.findByPresentationId("presentation-1").orElseThrow().status())
+                .isEqualTo(TermsConsentStatus.ACCEPTED);
+    }
+
+    private static TermsConsentAudit presented() {
+        return new TermsConsentAudit("presentation-1", "conversation-1", "contact-1", "turn-1", "unit-1",
+                "sala", "message-environment", "DECOR_INTERIORES", "terms-v1", "v1", "invoke-1",
+                "outbound-1", NOW, null, null, null, null, NOW, TermsConsentStatus.PRESENTED, 3, null);
+    }
+
+    private static final class MemoryGateway implements TermsConsentAuditGateway {
+        private final HashMap<String, TermsConsentAudit> values = new HashMap<>();
+        public Optional<TermsConsentAudit> findByPresentationId(String id) { return Optional.ofNullable(values.get(id)); }
+        public Optional<TermsConsentAudit> findPresented(String conversationId, String unitId) {
+            return values.values().stream().filter(value -> value.conversationId().equals(conversationId)
+                    && value.contractingUnitId().equals(unitId) && value.status() == TermsConsentStatus.PRESENTED).findFirst();
+        }
+        public TermsConsentAudit savePresentationIfAbsent(TermsConsentAudit audit) { return values.computeIfAbsent(audit.presentationId(), ignored -> audit); }
+        public TermsConsentAudit acceptIfPresented(String id, String eventId, String messageId, String text, long version, Instant at) {
+            TermsConsentAudit current = findByPresentationId(id).orElseThrow(() -> new IllegalStateException("terms presentation evidence is missing"));
+            TermsConsentAudit next = current.accept(messageId, eventId, text, at, version); values.put(id, next); return next;
+        }
+    }
+
+    private static final class MemoryConversation implements ReceptionConversationGateway {
+        private ReceptionConversation value;
+
+        @Override
+        public Optional<ReceptionConversation> findByContactId(String contactId) {
+            return Optional.ofNullable(value).filter(conversation -> conversation.contactId().equals(contactId));
+        }
+
+        @Override
+        public ReceptionConversation save(ReceptionConversation conversation) {
+            return value = conversation;
+        }
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/TermsAcceptanceUseCaseTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/TermsAcceptanceUseCaseTest.java
@@ -47,9 +47,10 @@ class TermsAcceptanceUseCaseTest {
         MemoryGateway gateway = new MemoryGateway();
         gateway.savePresentationIfAbsent(presented());
         TermsAcceptanceUseCase useCase = new TermsAcceptanceUseCase(gateway);
+        Instant beforePresentation = NOW.minusSeconds(1);
 
         assertThatThrownBy(() -> useCase.recordAcceptance("presentation-1", "event", "message", "Aceito",
-                4, NOW.minusSeconds(1)))
+                4, beforePresentation))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("precede presentation");
     }
@@ -109,18 +110,20 @@ class TermsAcceptanceUseCaseTest {
     @Test
     void rejectsAcceptanceWhenConversationHasNoActivePresentationOrEvidence() {
         TermsAcceptanceUseCase useCase = new TermsAcceptanceUseCase(new MemoryGateway());
+        CommercialPolicyService policy = new CommercialPolicyService();
         ReceptionConversation selected = ReceptionConversation.start("conversation-1", "contact-1", NOW)
                 .selectService("DECOR_INTERIORES", NOW);
 
         assertThatThrownBy(() -> useCase.recordAcceptance(selected, "event", "message", "Aceito", NOW,
-                new CommercialPolicyService()))
+                policy))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("presented with durable evidence");
 
         ReceptionConversation presentedConversation = selected.presentTerms(NOW)
                 .activateTermsConsent("missing", NOW.plusSeconds(1));
+        Instant acceptanceAt = NOW.plusSeconds(2);
         assertThatThrownBy(() -> useCase.recordAcceptance(presentedConversation, "event", "message", "Aceito",
-                NOW.plusSeconds(2), new CommercialPolicyService()))
+                acceptanceAt, policy))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("evidence is missing");
     }
@@ -144,8 +147,9 @@ class TermsAcceptanceUseCaseTest {
                 base.resumeDecisionAction(), base.resumeDecisionMessage(), base.resumeFailureCode(),
                 base.contractingUnitId(), base.environmentLabel(), base.environmentSourceMessageId(),
                 base.activeTermsConsentId());
+        Instant otherConversationAcceptanceAt = NOW.plusSeconds(1);
         assertThatThrownBy(() -> useCase.recordAcceptance(otherConversation, "event", "message", "Aceito",
-                NOW.plusSeconds(1), policy)).isInstanceOf(IllegalStateException.class)
+                otherConversationAcceptanceAt, policy)).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("does not match");
 
         ReceptionConversation otherUnit = new ReceptionConversation(base.id(), base.contactId(), base.mode(),
@@ -154,14 +158,16 @@ class TermsAcceptanceUseCaseTest {
                 base.resumeIdempotencyKey(), base.resumeChecksum(), base.resumeBoundarySequence(),
                 base.resumeDecisionAction(), base.resumeDecisionMessage(), base.resumeFailureCode(),
                 "unit-other", base.environmentLabel(), base.environmentSourceMessageId(), base.activeTermsConsentId());
+        Instant otherUnitAcceptanceAt = NOW.plusSeconds(1);
         assertThatThrownBy(() -> useCase.recordAcceptance(otherUnit, "event", "message", "Aceito",
-                NOW.plusSeconds(1), policy)).isInstanceOf(IllegalStateException.class)
+                otherUnitAcceptanceAt, policy)).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("does not match");
 
         ReceptionConversation otherService = base.selectService("DECOR_PINTURA", NOW.plusSeconds(1))
                 .presentTerms(NOW.plusSeconds(1)).activateTermsConsent("presentation-1", NOW.plusSeconds(2));
+        Instant otherServiceAcceptanceAt = NOW.plusSeconds(3);
         assertThatThrownBy(() -> useCase.recordAcceptance(otherService, "event", "message", "Aceito",
-                NOW.plusSeconds(3), policy)).isInstanceOf(IllegalStateException.class)
+                otherServiceAcceptanceAt, policy)).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("does not match");
     }
 

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolServiceTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolServiceTest.java
@@ -16,11 +16,14 @@ import br.com.urbana.connect.domain.reception.model.ReceptionMessageType;
 import br.com.urbana.connect.domain.reception.model.ReceptionTurnStatus;
 import br.com.urbana.connect.domain.reception.model.TermsStatus;
 import br.com.urbana.connect.domain.reception.model.PaymentStatus;
+import br.com.urbana.connect.domain.reception.model.TermsConsentAudit;
+import br.com.urbana.connect.domain.reception.model.TermsConsentStatus;
 import br.com.urbana.connect.domain.reception.port.out.CustomerFactGateway;
 import br.com.urbana.connect.domain.reception.port.out.IcpObservationEventGateway;
 import br.com.urbana.connect.domain.reception.port.out.HumanHandoffNotificationGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionConversationGateway;
 import br.com.urbana.connect.domain.reception.port.out.ReceptionTranscriptGateway;
+import br.com.urbana.connect.domain.reception.port.out.TermsConsentAuditGateway;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -46,7 +49,8 @@ class StatefulDomainToolServiceTest {
         MemoryConversation conversations = new MemoryConversation();
         MemoryFacts facts = new MemoryFacts();
         MemoryTranscript transcript = new MemoryTranscript();
-        conversations.value = ReceptionConversation.start("contact-1", NOW);
+        conversations.value = ReceptionConversation.start("contact-1", NOW)
+                .bindContractingUnit("unit-1", "sala", "message-environment", NOW);
         transcript.messages.put("message-1", message("message-1", "Sou designer"));
         transcript.messages.put("message-2", message("message-2", "Oi"));
         StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
@@ -64,6 +68,69 @@ class StatefulDomainToolServiceTest {
         assertThat(facts.values).extracting(CustomerFact::confidence)
                 .containsExactly(FactConfidence.CONFIRMED, FactConfidence.TENTATIVE);
         assertThat(facts.values.get(0).sourceMessageId()).isEqualTo("message-1");
+    }
+
+    @Test
+    void bindsEnvironmentToTheBatchMessageThatActuallySupportsIt() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        conversations.value = ReceptionConversation.start("conversation-1", "contact-1", NOW);
+        transcript.messages.put("environment-event", message("environment-event", "Quero contratar para a sala de estar."));
+        transcript.messages.put("occupation-event", message("occupation-event", "Sou designer."));
+        StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, facts, transcript);
+
+        tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "ENVIRONMENT", "value", "sala de estar", "confidence", "CONFIRMED"),
+                context("occupation-event", List.of("environment-event", "occupation-event")));
+
+        assertThat(facts.values).singleElement().satisfies(fact -> {
+            assertThat(fact.type()).isEqualTo("ENVIRONMENT");
+            assertThat(fact.sourceMessageId()).isEqualTo("environment-event");
+            assertThat(fact.confidence()).isEqualTo(FactConfidence.CONFIRMED);
+        });
+        assertThat(conversations.value.environmentSourceMessageId()).isEqualTo("environment-event");
+    }
+
+    @Test
+    void neverConfirmsOrBindsANotInformedEnvironmentSentinel() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        conversations.value = ReceptionConversation.start("conversation-1", "contact-1", NOW);
+        transcript.messages.put("environment-refusal",
+                message("environment-refusal", "Prefiro não informar o ambiente."));
+        StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, facts, transcript);
+
+        Map<String, Object> recorded = tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "ENVIRONMENT", "value", "NÃO INFORMADO", "confidence", "CONFIRMED"),
+                context("environment-refusal"));
+
+        assertThat(recorded).containsEntry("value", "NÃO INFORMADO")
+                .containsEntry("confidence", "TENTATIVE");
+        assertThat(conversations.value.contractingUnitId()).isNull();
+        assertThat(conversations.value.environmentLabel()).isNull();
+    }
+
+    @Test
+    void neverConfirmsOrBindsAnEnvironmentFromAnArbitrarySubstring() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        conversations.value = ReceptionConversation.start("conversation-1", "contact-1", NOW);
+        transcript.messages.put("environment-message", message("environment-message", "Quero decorar a sala."));
+        StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, facts, transcript);
+
+        Map<String, Object> recorded = tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "ENVIRONMENT", "value", "ala", "confidence", "CONFIRMED"),
+                context("environment-message"));
+
+        assertThat(recorded).containsEntry("confidence", "TENTATIVE");
+        assertThat(conversations.value.contractingUnitId()).isNull();
+        assertThat(conversations.value.environmentLabel()).isNull();
     }
 
     @Test
@@ -317,7 +384,7 @@ class StatefulDomainToolServiceTest {
     }
 
     @Test
-    void requiresExplicitAcceptanceFromTheSameInboundMessageBeforePreparingPayment() {
+    void requiresDurableAcceptanceBeforePreparingPayment() {
         CommercialPolicyService policy = new CommercialPolicyService();
         MemoryConversation conversations = new MemoryConversation();
         MemoryFacts facts = new MemoryFacts();
@@ -330,20 +397,16 @@ class StatefulDomainToolServiceTest {
         facts.values.addAll(icp);
         conversation = policy.presentTerms(policy.selectService(conversation, "DECOR", NOW), icp, NOW);
         conversations.value = conversation;
-        transcript.messages.put("message-terms", message("message-terms", "Aceito os termos"));
         StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts, transcript);
 
-        Map<String, Object> result = tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
-                Map.of("serviceType", "DECOR", "method", "PIX"), context("message-terms"));
-
-        assertThat(result).containsEntry("status", "PREPARED");
-        assertThat(result).containsEntry("instruction", policy.paymentUrl("DECOR_INTERIORES"))
-                .containsEntry("nextAction", "AWAIT_PAYMENT_PROOF")
-                .containsEntry("customerMessage",
-                        "Pagamento preparado. Realize o pagamento pelo link e envie o comprovante por aqui.");
-        assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.ACCEPTED);
+        assertThatThrownBy(() -> tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
+                Map.of("serviceType", "DECOR", "method", "PIX"), context("message-terms")))
+                .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
+                .satisfies(error -> assertThat(((DomainToolInvocationUseCase.DomainRejectionException) error).code())
+                        .isEqualTo("TERMS_NOT_ACCEPTED"));
+        assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.PRESENTED);
         assertThat(conversations.value.paymentStatus())
-                .isEqualTo(PaymentStatus.PREPARED);
+                .isEqualTo(PaymentStatus.NOT_STARTED);
     }
 
     @Test
@@ -352,11 +415,9 @@ class StatefulDomainToolServiceTest {
         MemoryConversation conversations = new MemoryConversation();
         MemoryFacts facts = new MemoryFacts();
         MemoryTranscript transcript = new MemoryTranscript();
-        ReceptionConversation accepted = policy.acceptTerms(policy.presentTerms(
-                policy.selectService(ReceptionConversation.start("contact-1", NOW), "DECOR", NOW),
-                List.of(), NOW), NOW);
-        conversations.value = accepted;
+        AuditedAcceptance audited = auditedAccepted(policy, conversations, "contact-1");
         StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts, transcript);
+        tools.setTermsAcceptanceUseCase(audited.useCase());
 
         assertThatThrownBy(() -> tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
                 Map.of("serviceType", "DECOR", "method", "link"), context("message-method")))
@@ -432,11 +493,11 @@ class StatefulDomainToolServiceTest {
                 CustomerFact.confirmed("contact-1", "PRONOUN_PREFERENCE", "ELA_DELA", "m0", NOW),
                 CustomerFact.confirmed("contact-1", "FIRST_TIME_HIRING", "YES", "m0", NOW),
                 CustomerFact.confirmed("contact-1", "OCCUPATION", "DESIGNER", "m0", NOW)));
-        conversations.value = policy.presentTerms(
-                policy.selectService(ReceptionConversation.start("contact-1", NOW), "DECOR", NOW), facts.values, NOW);
+        AuditedAcceptance audited = auditedAccepted(policy, conversations, "contact-1");
         transcript.messages.put("message-terms-and-method", message("message-terms-and-method",
                 "Aceito os termos e prefiro PIX."));
         StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts, transcript);
+        tools.setTermsAcceptanceUseCase(audited.useCase());
 
         Map<String, Object> result = tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
                 Map.of("serviceType", "DECOR", "method", "PIX"), context("message-terms-and-method"));
@@ -449,15 +510,14 @@ class StatefulDomainToolServiceTest {
     void doesNotReissuePaymentInstructionAfterPaymentWasConfirmed() {
         CommercialPolicyService policy = new CommercialPolicyService();
         MemoryConversation conversations = new MemoryConversation();
+        AuditedAcceptance audited = auditedAccepted(policy, conversations, "contact-1");
         ReceptionConversation confirmed = policy.approvePaymentProof(
                 policy.receivePaymentProof(
-                        policy.preparePayment(
-                                policy.acceptTerms(policy.presentTerms(
-                                        policy.selectService(ReceptionConversation.start("contact-1", NOW), "DECOR", NOW),
-                                        List.of(), NOW), NOW), List.of(), "PIX", NOW), NOW), NOW);
+                        policy.preparePayment(audited.conversation(), List.of(), "PIX", NOW), NOW), NOW);
         conversations.value = confirmed;
         StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations,
                 new MemoryFacts(), new MemoryTranscript());
+        tools.setTermsAcceptanceUseCase(audited.useCase());
 
         Map<String, Object> result = tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
                 Map.of("serviceType", "DECOR", "method", "PIX"), context("message-payment-replay"));
@@ -503,11 +563,10 @@ class StatefulDomainToolServiceTest {
             MemoryConversation conversations = new MemoryConversation();
             MemoryFacts facts = new MemoryFacts();
             MemoryTranscript transcript = new MemoryTranscript();
-            conversations.value = policy.presentTerms(
-                    policy.selectService(ReceptionConversation.start("contact-1", NOW), "DECOR", NOW),
-                    List.of(), NOW);
+            AuditedAcceptance audited = auditedAccepted(policy, conversations, "contact-1");
             transcript.messages.put("message-accepted", message("message-accepted", acceptance));
             StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts, transcript);
+            tools.setTermsAcceptanceUseCase(audited.useCase());
 
             Map<String, Object> result = tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
                     Map.of("serviceType", "DECOR", "method", "PIX"), context("message-accepted"));
@@ -556,12 +615,13 @@ class StatefulDomainToolServiceTest {
                 CustomerFact.confirmed("contact-1", "PRONOUN_PREFERENCE", "ELA_DELA", "m0", NOW),
                 CustomerFact.confirmed("contact-1", "FIRST_TIME_HIRING", "YES", "m0", NOW),
                 CustomerFact.confirmed("contact-1", "OCCUPATION", "DESIGNER", "m0", NOW)));
-        conversations.value = ReceptionConversation.start("contact-1", NOW);
+        conversations.value = ReceptionConversation.start("contact-1", NOW)
+                .bindContractingUnit("unit-1", "sala", "message-environment", NOW);
         StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts, transcript);
 
         tools.execute(DomainToolName.PREPARE_TERMS, "contact-1", Map.of("serviceType", "DECOR"), context("message-terms"));
 
-        assertThat(conversations.savedVersions).containsExactly(1L, 2L);
+        assertThat(conversations.savedVersions).containsExactly(2L, 3L);
         assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.PRESENTED);
     }
 
@@ -595,7 +655,8 @@ class StatefulDomainToolServiceTest {
         MemoryConversation conversations = new MemoryConversation();
         MemoryFacts facts = new MemoryFacts();
         MemoryTranscript transcript = new MemoryTranscript();
-        conversations.value = ReceptionConversation.start("conversation-1", "contact-1", NOW);
+        conversations.value = ReceptionConversation.start("conversation-1", "contact-1", NOW)
+                .bindContractingUnit("unit-1", "sala", "message-environment", NOW);
         StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
                 conversations, facts, transcript);
 
@@ -626,7 +687,8 @@ class StatefulDomainToolServiceTest {
         MemoryFacts facts = new MemoryFacts();
         MemoryTranscript transcript = new MemoryTranscript();
         MemoryIcpObservations observations = new MemoryIcpObservations();
-        conversations.value = ReceptionConversation.start("conversation-1", "contact-1", NOW);
+        conversations.value = ReceptionConversation.start("conversation-1", "contact-1", NOW)
+                .bindContractingUnit("unit-1", "sala", "message-environment", NOW);
         StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts,
                 transcript, observations);
 
@@ -676,9 +738,36 @@ class StatefulDomainToolServiceTest {
         assertThat(notification.toString()).doesNotContain("contact-1", "message-handoff");
     }
 
+    @Test
+    void tentativeEnvironmentEvidenceDoesNotBindAContractingUnitOrPermitTerms() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        conversations.value = ReceptionConversation.start("conversation-1", "contact-1", NOW);
+        StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, facts, transcript);
+
+        Map<String, Object> recorded = tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "ENVIRONMENT", "value", "sala", "confidence", "CONFIRMED"),
+                context("message-without-environment"));
+
+        assertThat(recorded).containsEntry("confidence", "TENTATIVE");
+        assertThat(conversations.value.contractingUnitId()).isNull();
+        assertThatThrownBy(() -> tools.execute(DomainToolName.PREPARE_TERMS, "contact-1",
+                Map.of("serviceType", "DECOR"), context("message-without-environment")))
+                .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
+                .satisfies(error -> assertThat(((DomainToolInvocationUseCase.DomainRejectionException) error).code())
+                        .isEqualTo("ENVIRONMENT_NOT_CONFIRMED"));
+    }
+
     private static ToolExecutionContext context(String sourceMessageId) {
+        return context(sourceMessageId, List.of(sourceMessageId));
+    }
+
+    private static ToolExecutionContext context(String sourceMessageId, List<String> sourceMessageIds) {
         return new ToolExecutionContext(new ActiveTurnLease("session-1", "turn-1", "contact-1",
-                sourceMessageId, ActiveTurnLeaseStatus.RUNNING, NOW, NOW.plusSeconds(30), null, 0), NOW);
+                sourceMessageId, ActiveTurnLeaseStatus.RUNNING, NOW, NOW.plusSeconds(30), null, 0,
+                "claim-1", sourceMessageIds), NOW);
     }
 
     private static ReceptionMessage message(String id, String text) {
@@ -687,6 +776,34 @@ class StatefulDomainToolServiceTest {
                 text, null, id, NOW);
     }
 
+    private static AuditedAcceptance auditedAccepted(CommercialPolicyService policy,
+                                                      MemoryConversation conversations,
+                                                      String contactId) {
+        MemoryAudits audits = new MemoryAudits();
+        ReceptionConversation presented = policy.presentTerms(
+                policy.selectService(ReceptionConversation.start("conversation-1", contactId, NOW), "DECOR", NOW),
+                List.of(), NOW);
+        presented = presented.bindContractingUnit("unit-1", "sala", "message-environment", NOW.minusSeconds(1));
+        // Binding the unit invalidates the prior selection, so select and
+        // present again against the canonical contracting unit.
+        presented = policy.presentTerms(
+                policy.selectService(presented, "DECOR", NOW), List.of(), NOW);
+        TermsConsentAudit audit = new TermsConsentAudit("presentation-1", presented.id(), contactId, "turn-terms",
+                "unit-1", "sala", "message-environment", presented.selectedService(),
+                policy.termsUrl(presented.selectedService()), "v1", "invoke-terms", "outbound-terms", NOW,
+                null, null, null, null, NOW, TermsConsentStatus.PRESENTED, presented.version(), null);
+        audits.savePresentationIfAbsent(audit);
+        ReceptionConversation withConsent = presented.activateTermsConsent("presentation-1", NOW.plusSeconds(1));
+        ReceptionConversation accepted = policy.acceptTerms(withConsent, "Aceito", NOW.plusSeconds(2));
+        audits.acceptIfPresented("presentation-1", "event-accept", "message-accept", "Aceito",
+                accepted.version(), NOW.plusSeconds(2));
+        conversations.value = accepted;
+        return new AuditedAcceptance(accepted, new br.com.urbana.connect.application.reception.TermsAcceptanceUseCase(audits));
+    }
+
+    private record AuditedAcceptance(ReceptionConversation conversation,
+                                     br.com.urbana.connect.application.reception.TermsAcceptanceUseCase useCase) { }
+
     private static final class MemoryConversation implements ReceptionConversationGateway {
         ReceptionConversation value;
         final List<Long> savedVersions = new ArrayList<>();
@@ -694,6 +811,36 @@ class StatefulDomainToolServiceTest {
         @Override public ReceptionConversation save(ReceptionConversation conversation) {
             savedVersions.add(conversation.version());
             return value = conversation;
+        }
+    }
+
+    private static final class MemoryAudits implements TermsConsentAuditGateway {
+        private final Map<String, TermsConsentAudit> values = new HashMap<>();
+
+        @Override
+        public Optional<TermsConsentAudit> findByPresentationId(String id) {
+            return Optional.ofNullable(values.get(id));
+        }
+
+        @Override
+        public Optional<TermsConsentAudit> findPresented(String conversationId, String unitId) {
+            return values.values().stream().filter(value -> value.conversationId().equals(conversationId)
+                    && value.contractingUnitId().equals(unitId)
+                    && value.status() == TermsConsentStatus.PRESENTED).findFirst();
+        }
+
+        @Override
+        public TermsConsentAudit savePresentationIfAbsent(TermsConsentAudit audit) {
+            return values.computeIfAbsent(audit.presentationId(), ignored -> audit);
+        }
+
+        @Override
+        public TermsConsentAudit acceptIfPresented(String id, String eventId, String messageId, String text,
+                                                   long version, Instant at) {
+            TermsConsentAudit current = findByPresentationId(id).orElseThrow();
+            TermsConsentAudit accepted = current.accept(messageId, eventId, text, at, version);
+            values.put(id, accepted);
+            return accepted;
         }
     }
 

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolServiceTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolServiceTest.java
@@ -753,8 +753,10 @@ class StatefulDomainToolServiceTest {
 
         assertThat(recorded).containsEntry("confidence", "TENTATIVE");
         assertThat(conversations.value.contractingUnitId()).isNull();
+        ToolExecutionContext termsContext = context("message-without-environment");
+        Map<String, Object> decorArguments = Map.of("serviceType", "DECOR");
         assertThatThrownBy(() -> tools.execute(DomainToolName.PREPARE_TERMS, "contact-1",
-                Map.of("serviceType", "DECOR"), context("message-without-environment")))
+                decorArguments, termsContext))
                 .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
                 .satisfies(error -> assertThat(((DomainToolInvocationUseCase.DomainRejectionException) error).code())
                         .isEqualTo("ENVIRONMENT_NOT_CONFIRMED"));
@@ -764,14 +766,16 @@ class StatefulDomainToolServiceTest {
     void requiresTheBackendExecutionContextAndValidContactForStatefulTools() {
         StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
                 new MemoryConversation(), new MemoryFacts());
+        ToolExecutionContext context = context("message");
+        Map<String, Object> noArguments = Map.of();
 
-        assertThatThrownBy(() -> tools.execute(DomainToolName.GET_CUSTOMER_PROFILE, "contact-1", Map.of()))
+        assertThatThrownBy(() -> tools.execute(DomainToolName.GET_CUSTOMER_PROFILE, "contact-1", noArguments))
                 .isInstanceOf(IllegalStateException.class).hasMessageContaining("execution context");
-        assertThatThrownBy(() -> tools.execute(null, "contact-1", Map.of(), context("message")))
+        assertThatThrownBy(() -> tools.execute(null, "contact-1", noArguments, context))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> tools.execute(DomainToolName.GET_CUSTOMER_PROFILE, " ", Map.of(), context("message")))
+        assertThatThrownBy(() -> tools.execute(DomainToolName.GET_CUSTOMER_PROFILE, " ", noArguments, context))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("contactId");
-        assertThatThrownBy(() -> tools.execute(DomainToolName.GET_CUSTOMER_PROFILE, "contact-1", Map.of(), null))
+        assertThatThrownBy(() -> tools.execute(DomainToolName.GET_CUSTOMER_PROFILE, "contact-1", noArguments, null))
                 .isInstanceOf(NullPointerException.class);
     }
 

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolServiceTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolServiceTest.java
@@ -760,6 +760,168 @@ class StatefulDomainToolServiceTest {
                         .isEqualTo("ENVIRONMENT_NOT_CONFIRMED"));
     }
 
+    @Test
+    void requiresTheBackendExecutionContextAndValidContactForStatefulTools() {
+        StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                new MemoryConversation(), new MemoryFacts());
+
+        assertThatThrownBy(() -> tools.execute(DomainToolName.GET_CUSTOMER_PROFILE, "contact-1", Map.of()))
+                .isInstanceOf(IllegalStateException.class).hasMessageContaining("execution context");
+        assertThatThrownBy(() -> tools.execute(null, "contact-1", Map.of(), context("message")))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> tools.execute(DomainToolName.GET_CUSTOMER_PROFILE, " ", Map.of(), context("message")))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("contactId");
+        assertThatThrownBy(() -> tools.execute(DomainToolName.GET_CUSTOMER_PROFILE, "contact-1", Map.of(), null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void recordsProfilePreviousServicesAndUsesSafeRejectionsForInvalidFactsAndHandoffs() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        conversations.value = ReceptionConversation.start("conversation-1", "contact-1", NOW);
+        transcript.messages.put("message-service", message("message-service", "Quero Decor."));
+        StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, facts, transcript);
+
+        tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "SERVICE", "value", "Decor", "confidence", "CONFIRMED"),
+                context("message-service"));
+        Map<String, Object> profile = tools.execute(DomainToolName.GET_CUSTOMER_PROFILE, "contact-1",
+                Map.of(), context("message-service"));
+        @SuppressWarnings("unchecked")
+        List<String> previousServices = (List<String>) profile.get("previousServices");
+        assertThat(previousServices).containsExactly("DECOR_INTERIORES");
+
+        assertThatThrownBy(() -> tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "UNKNOWN", "value", "x"), context("message-service")))
+                .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
+                .satisfies(error -> assertThat(((DomainToolInvocationUseCase.DomainRejectionException) error).code())
+                        .isEqualTo("CUSTOMER_INFORMATION_INVALID"));
+        assertThatThrownBy(() -> tools.execute(DomainToolName.REQUEST_HUMAN_HANDOFF, "contact-1",
+                Map.of(), context("message-service")))
+                .isInstanceOf(DomainToolInvocationUseCase.DomainRejectionException.class)
+                .satisfies(error -> assertThat(((DomainToolInvocationUseCase.DomainRejectionException) error).code())
+                        .isEqualTo("HANDOFF_REASON_REQUIRED"));
+    }
+
+    @Test
+    void handlesMissingTranscriptAndEvidenceAliasesWithoutForgingConfirmedFacts() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        conversations.value = ReceptionConversation.start("contact-1", NOW);
+        StatefulDomainToolService noTranscript = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, facts);
+
+        Map<String, Object> unsupported = noTranscript.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "OCCUPATION", "value", "DESIGNER", "confidence", "CONFIRMED"),
+                context("message-missing"));
+        assertThat(unsupported).containsEntry("confidence", "TENTATIVE")
+                .containsEntry("value", "DESIGNER");
+        assertThat(facts.values).singleElement().extracting(CustomerFact::sourceMessageId)
+                .isEqualTo("message-missing");
+
+        MemoryTranscript transcript = new MemoryTranscript();
+        transcript.messages.put("message-service-alias", message("message-service-alias", "Quero contratar Decor."));
+        StatefulDomainToolService withTranscript = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, facts, transcript);
+        Map<String, Object> service = withTranscript.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "SELECTED_SERVICE", "value", "Decor", "confidence", "CONFIRMED"),
+                context("message-service-alias"));
+        assertThat(service).containsEntry("value", "DECOR_INTERIORES")
+                .containsEntry("confidence", "CONFIRMED");
+    }
+
+    @Test
+    void preservesWordBoundariesWhenConfirmingEnvironmentEvidence() {
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        conversations.value = ReceptionConversation.start("contact-1", NOW);
+        transcript.messages.put("message-prefix", message("message-prefix", "Quero contratar para o salao."));
+        transcript.messages.put("message-exact", message("message-exact", "Quero contratar para a sala."));
+        StatefulDomainToolService tools = new StatefulDomainToolService(new CommercialPolicyService(),
+                conversations, facts, transcript);
+
+        Map<String, Object> prefix = tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "ENVIRONMENT", "value", "sala", "confidence", "CONFIRMED"),
+                context("message-prefix"));
+        Map<String, Object> exact = tools.execute(DomainToolName.UPDATE_CUSTOMER_FACT, "contact-1",
+                Map.of("factType", "ENVIRONMENT", "value", "sala", "confidence", "CONFIRMED"),
+                context("message-exact"));
+
+        assertThat(prefix).containsEntry("confidence", "TENTATIVE");
+        assertThat(exact).containsEntry("confidence", "CONFIRMED");
+        assertThat(conversations.value.environmentSourceMessageId()).isEqualTo("message-exact");
+    }
+
+    @Test
+    void returnsStablePaymentResultsForPreparedProofAndRejectedStates() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        for (PaymentStatus status : List.of(PaymentStatus.PREPARED, PaymentStatus.PROOF_RECEIVED,
+                PaymentStatus.REJECTED, PaymentStatus.CONFIRMED)) {
+            MemoryConversation conversations = new MemoryConversation();
+            MemoryFacts facts = new MemoryFacts();
+            MemoryTranscript transcript = new MemoryTranscript();
+            AuditedAcceptance audited = auditedAccepted(policy, conversations, "contact-1");
+            ReceptionConversation current = audited.conversation();
+            if (status == PaymentStatus.PREPARED) {
+                current = policy.preparePayment(current, List.of(), "PIX", NOW.plusSeconds(3));
+            } else if (status == PaymentStatus.PROOF_RECEIVED) {
+                current = policy.receivePaymentProof(
+                        policy.preparePayment(current, List.of(), "PIX", NOW.plusSeconds(3)), NOW.plusSeconds(4));
+            } else if (status == PaymentStatus.REJECTED) {
+                current = policy.receivePaymentProof(
+                                policy.preparePayment(current, List.of(), "PIX", NOW.plusSeconds(3)), NOW.plusSeconds(4))
+                        .rejectPayment(NOW.plusSeconds(5));
+            } else {
+                current = policy.approvePaymentProof(
+                        policy.receivePaymentProof(
+                                policy.preparePayment(current, List.of(), "PIX", NOW.plusSeconds(3)), NOW.plusSeconds(4)),
+                        NOW.plusSeconds(5));
+            }
+            conversations.value = current;
+            StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts, transcript);
+            tools.setTermsAcceptanceUseCase(audited.useCase());
+
+            Map<String, Object> result = tools.execute(DomainToolName.PREPARE_PAYMENT, "contact-1",
+                    Map.of("serviceType", "DECOR", "method", "PIX"), context("message-payment"));
+            if (status == PaymentStatus.PREPARED) {
+                assertThat(result).containsEntry("status", "ALREADY_PREPARED");
+            } else if (status == PaymentStatus.PROOF_RECEIVED) {
+                assertThat(result).containsEntry("status", "PROOF_RECEIVED");
+            } else if (status == PaymentStatus.CONFIRMED) {
+                assertThat(result).containsEntry("status", "CONFIRMED");
+            } else {
+                assertThat(result).containsEntry("status", "PREPARED");
+            }
+        }
+    }
+
+    @Test
+    void keepsTermsTransitionSafeWhenDeclinedOrOptionalObservabilityFails() {
+        CommercialPolicyService policy = new CommercialPolicyService();
+        MemoryConversation conversations = new MemoryConversation();
+        MemoryFacts facts = new MemoryFacts();
+        MemoryTranscript transcript = new MemoryTranscript();
+        conversations.value = ReceptionConversation.start("contact-1", NOW)
+                .bindContractingUnit("unit-1", "sala", "message-environment", NOW)
+                .selectService("DECOR_INTERIORES", NOW)
+                .declineTerms(NOW.plusSeconds(1));
+        IcpObservationEventGateway throwingObservations = event -> {
+            throw new IllegalStateException("optional sink unavailable");
+        };
+        StatefulDomainToolService tools = new StatefulDomainToolService(policy, conversations, facts, transcript,
+                throwingObservations);
+
+        Map<String, Object> result = tools.execute(DomainToolName.PREPARE_TERMS, "contact-1",
+                Map.of("serviceType", "DECOR"), context("message-terms"));
+
+        assertThat(result).containsEntry("status", "PRESENTED");
+        assertThat(conversations.value.termsStatus()).isEqualTo(TermsStatus.PRESENTED);
+    }
+
     private static ToolExecutionContext context(String sourceMessageId) {
         return context(sourceMessageId, List.of(sourceMessageId));
     }

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/ActiveTurnLeaseTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/ActiveTurnLeaseTest.java
@@ -28,23 +28,26 @@ class ActiveTurnLeaseTest {
 
     @Test
     void rejectsIncompleteOrInconsistentLeaseState() {
+        List<String> sourceMessageIds = List.of("message");
+        List<String> emptySourceMessageIds = List.of();
+        List<String> blankSourceMessageIds = List.of(" ");
         assertThatThrownBy(() -> new ActiveTurnLease(null, "turn", "contact", "message",
-                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, 0, "claim", List.of("message")))
+                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, 0, "claim", sourceMessageIds))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new ActiveTurnLease("session", "turn", "contact", "message", null,
-                ACQUIRED, EXPIRES, null, 0, "claim", List.of("message")))
+                ACQUIRED, EXPIRES, null, 0, "claim", sourceMessageIds))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("status");
         assertThatThrownBy(() -> new ActiveTurnLease("session", "turn", "contact", "message",
-                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, ACQUIRED, null, 0, "claim", List.of("message")))
+                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, ACQUIRED, null, 0, "claim", sourceMessageIds))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("expiresAt");
         assertThatThrownBy(() -> new ActiveTurnLease("session", "turn", "contact", "message",
-                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, -1, "claim", List.of("message")))
+                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, -1, "claim", sourceMessageIds))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("version");
         assertThatThrownBy(() -> new ActiveTurnLease("session", "turn", "contact", "message",
-                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, 0, "claim", List.of()))
+                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, 0, "claim", emptySourceMessageIds))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("sourceMessageIds");
         assertThatThrownBy(() -> new ActiveTurnLease("session", "turn", "contact", "message",
-                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, 0, "claim", List.of(" ")))
+                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, 0, "claim", blankSourceMessageIds))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("sourceMessageIds");
     }
 
@@ -100,7 +103,8 @@ class ActiveTurnLeaseTest {
 
         assertThatThrownBy(() -> running.heartbeat(ACQUIRED, null)).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> running.heartbeat(ACQUIRED, Duration.ZERO)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> running.heartbeat(ACQUIRED, Duration.ofSeconds(-1))).isInstanceOf(IllegalArgumentException.class);
+        Duration negativeTtl = Duration.ofSeconds(-1);
+        assertThatThrownBy(() -> running.heartbeat(ACQUIRED, negativeTtl)).isInstanceOf(IllegalArgumentException.class);
 
         ActiveTurnLease extended = running.heartbeat(ACQUIRED.plusSeconds(5), Duration.ofMinutes(1));
         assertThat(extended.status()).isEqualTo(ActiveTurnLeaseStatus.RUNNING);

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/ActiveTurnLeaseTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/ActiveTurnLeaseTest.java
@@ -1,0 +1,120 @@
+package br.com.urbana.connect.domain.reception.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ActiveTurnLeaseTest {
+    private static final Instant ACQUIRED = Instant.parse("2026-08-31T12:00:00Z");
+    private static final Instant EXPIRES = ACQUIRED.plusSeconds(30);
+
+    @Test
+    void compatibilityConstructorsCreateCanonicalClaimAndProvenance() {
+        ActiveTurnLease legacy = new ActiveTurnLease("session-1", "turn-1", "contact-1", "message-1",
+                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, 2);
+        ActiveTurnLease withClaim = new ActiveTurnLease("session-1", "turn-2", "contact-1", "message-2",
+                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, 3, "claim-2");
+
+        assertThat(legacy.claimToken()).isEqualTo("turn-1:2");
+        assertThat(legacy.sourceMessageIds()).containsExactly("message-1");
+        assertThat(withClaim.claimToken()).isEqualTo("claim-2");
+        assertThat(withClaim.sourceMessageIds()).containsExactly("message-2");
+    }
+
+    @Test
+    void rejectsIncompleteOrInconsistentLeaseState() {
+        assertThatThrownBy(() -> new ActiveTurnLease(null, "turn", "contact", "message",
+                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, 0, "claim", List.of("message")))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ActiveTurnLease("session", "turn", "contact", "message", null,
+                ACQUIRED, EXPIRES, null, 0, "claim", List.of("message")))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("status");
+        assertThatThrownBy(() -> new ActiveTurnLease("session", "turn", "contact", "message",
+                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, ACQUIRED, null, 0, "claim", List.of("message")))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("expiresAt");
+        assertThatThrownBy(() -> new ActiveTurnLease("session", "turn", "contact", "message",
+                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, -1, "claim", List.of("message")))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("version");
+        assertThatThrownBy(() -> new ActiveTurnLease("session", "turn", "contact", "message",
+                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, 0, "claim", List.of()))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("sourceMessageIds");
+        assertThatThrownBy(() -> new ActiveTurnLease("session", "turn", "contact", "message",
+                ActiveTurnLeaseStatus.RUNNING, ACQUIRED, EXPIRES, null, 0, "claim", List.of(" ")))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("sourceMessageIds");
+    }
+
+    @Test
+    void evaluatesRunningAndReconcilingLeaseOwnershipAtTheBoundary() {
+        ActiveTurnLease running = lease(ActiveTurnLeaseStatus.RUNNING);
+        ActiveTurnLease reconciling = lease(ActiveTurnLeaseStatus.RECONCILING);
+        ActiveTurnLease expired = lease(ActiveTurnLeaseStatus.EXPIRED);
+
+        assertThat(running.isActiveAt(ACQUIRED.plusSeconds(29))).isTrue();
+        assertThat(running.isActiveAt(EXPIRES)).isFalse();
+        assertThat(running.blocksNewTurnAt(ACQUIRED.plusSeconds(1))).isTrue();
+        assertThat(running.blocksNewTurnAt(EXPIRES)).isFalse();
+        assertThat(reconciling.isActiveAt(ACQUIRED.plusSeconds(1))).isFalse();
+        assertThat(reconciling.blocksNewTurnAt(ACQUIRED.plusSeconds(1))).isTrue();
+        assertThat(expired.blocksNewTurnAt(ACQUIRED.plusSeconds(1))).isFalse();
+    }
+
+    @Test
+    void transitionsRunningAndReconcilingLeasesIdempotently() {
+        ActiveTurnLease running = lease(ActiveTurnLeaseStatus.RUNNING);
+        ActiveTurnLease reconciling = running.reconcile(ACQUIRED.plusSeconds(2));
+        ActiveTurnLease revoked = reconciling.revoke(ACQUIRED.plusSeconds(3));
+
+        assertThat(reconciling.status()).isEqualTo(ActiveTurnLeaseStatus.RECONCILING);
+        assertThat(reconciling.version()).isEqualTo(1);
+        assertThat(revoked.status()).isEqualTo(ActiveTurnLeaseStatus.REVOKED);
+        assertThat(revoked.revokedAt()).isEqualTo(ACQUIRED.plusSeconds(3));
+        assertThat(revoked.version()).isEqualTo(2);
+        assertThat(revoked.revoke(ACQUIRED.plusSeconds(4))).isSameAs(revoked);
+        assertThat(lease(ActiveTurnLeaseStatus.REVOKED).reconcile(ACQUIRED.plusSeconds(1)))
+                .isEqualTo(lease(ActiveTurnLeaseStatus.REVOKED));
+    }
+
+    @Test
+    void expiresOnlyRunningLeasesAfterTheirDeadline() {
+        ActiveTurnLease running = lease(ActiveTurnLeaseStatus.RUNNING);
+        ActiveTurnLease beforeDeadline = running.expire(EXPIRES.minusNanos(1));
+        ActiveTurnLease expired = running.expire(EXPIRES);
+        ActiveTurnLease alreadyReconciled = lease(ActiveTurnLeaseStatus.RECONCILING).expire(EXPIRES.plusSeconds(1));
+
+        assertThat(beforeDeadline).isSameAs(running);
+        assertThat(expired.status()).isEqualTo(ActiveTurnLeaseStatus.EXPIRED);
+        assertThat(expired.version()).isEqualTo(1);
+        assertThat(expired.revokedAt()).isNull();
+        assertThat(alreadyReconciled).isEqualTo(lease(ActiveTurnLeaseStatus.RECONCILING));
+    }
+
+    @Test
+    void heartbeatsOnlyRunningOrReconcilingLeasesAndRequiresPositiveTtl() {
+        ActiveTurnLease running = lease(ActiveTurnLeaseStatus.RUNNING);
+        ActiveTurnLease reconciling = lease(ActiveTurnLeaseStatus.RECONCILING);
+
+        assertThatThrownBy(() -> running.heartbeat(ACQUIRED, null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> running.heartbeat(ACQUIRED, Duration.ZERO)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> running.heartbeat(ACQUIRED, Duration.ofSeconds(-1))).isInstanceOf(IllegalArgumentException.class);
+
+        ActiveTurnLease extended = running.heartbeat(ACQUIRED.plusSeconds(5), Duration.ofMinutes(1));
+        assertThat(extended.status()).isEqualTo(ActiveTurnLeaseStatus.RUNNING);
+        assertThat(extended.expiresAt()).isEqualTo(ACQUIRED.plusSeconds(65));
+        assertThat(extended.version()).isEqualTo(1);
+        assertThat(reconciling.heartbeat(ACQUIRED.plusSeconds(5), Duration.ofSeconds(10)).status())
+                .isEqualTo(ActiveTurnLeaseStatus.RECONCILING);
+        assertThat(lease(ActiveTurnLeaseStatus.EXPIRED).heartbeat(ACQUIRED.plusSeconds(5), Duration.ofSeconds(10)))
+                .isEqualTo(lease(ActiveTurnLeaseStatus.EXPIRED));
+    }
+
+    private static ActiveTurnLease lease(ActiveTurnLeaseStatus status) {
+        return new ActiveTurnLease("session-1", "turn-1", "contact-1", "message-1", status,
+                ACQUIRED, EXPIRES, status == ActiveTurnLeaseStatus.REVOKED ? ACQUIRED : null, 0,
+                "claim-1", List.of("message-1"));
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/CustomerFactTypeTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/CustomerFactTypeTest.java
@@ -17,6 +17,8 @@ class CustomerFactTypeTest {
         assertThat(CustomerFactType.OCCUPATION.isIcpField()).isTrue();
         assertThat(CustomerFactType.NEED.isIcpField()).isFalse();
         assertThat(CustomerFactType.SELECTED_SERVICE.isIcpField()).isFalse();
+        assertThat(CustomerFactType.ENVIRONMENT.isIcpField()).isFalse();
+        assertThat(CustomerFactType.isAllowed("environment")).isTrue();
 
         assertThat(CustomerFactType.icpFieldNames())
                 .containsExactly("PRONOUN_PREFERENCE", "FIRST_TIME_HIRING", "OCCUPATION");

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/ReceptionConversationTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/ReceptionConversationTest.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ReceptionConversationTest {
 
@@ -112,5 +113,84 @@ class ReceptionConversationTest {
         assertThat(changed.termsStatus()).isEqualTo(TermsStatus.NOT_PRESENTED);
         assertThat(changed.paymentStatus()).isEqualTo(PaymentStatus.NOT_STARTED);
         assertThat(changed.commercialStage()).isEqualTo(CommercialStage.ICP);
+    }
+
+    @Test
+    void bindsAnEnvironmentOnceAndRejectsIncompleteIdentityFields() {
+        ReceptionConversation conversation = ReceptionConversation.start("contact-1", now);
+
+        assertThatIllegalArgumentException().isThrownBy(() -> conversation.bindContractingUnit(
+                "", "sala", "message", now));
+        assertThatIllegalArgumentException().isThrownBy(() -> conversation.bindContractingUnit(
+                "unit-1", "", "message", now));
+        assertThatIllegalArgumentException().isThrownBy(() -> conversation.bindContractingUnit(
+                "unit-1", "sala", "", now));
+
+        ReceptionConversation bound = conversation.bindContractingUnit("unit-1", "sala", "message", now);
+        assertThat(bound.contractingUnitId()).isEqualTo("unit-1");
+        assertThat(bound.selectedService()).isNull();
+        assertThat(bound).isSameAs(bound.bindContractingUnit("unit-1", "different", "other", now.plusSeconds(1)));
+        assertThatIllegalArgumentException().isThrownBy(() -> bound.activateTermsConsent(" ", now));
+    }
+
+    @Test
+    void reopensLegacyAcceptedTermsForAnAuditablePresentation() {
+        ReceptionConversation legacy = ReceptionConversation.start("contact-1", now)
+                .selectService("DECOR_INTERIORES", now)
+                .presentTerms(now.plusSeconds(1))
+                .acceptTerms(now.plusSeconds(2));
+
+        ReceptionConversation reopened = legacy.reopenTermsForAudit(now.plusSeconds(3));
+
+        assertThat(reopened.termsStatus()).isEqualTo(TermsStatus.PRESENTED);
+        assertThat(reopened.paymentStatus()).isEqualTo(PaymentStatus.NOT_STARTED);
+        assertThat(reopened.commercialStage()).isEqualTo(CommercialStage.TERMS);
+        assertThat(reopened.activeTermsConsentId()).isNull();
+        assertThatIllegalStateException().isThrownBy(() -> reopened.reopenTermsForAudit(now.plusSeconds(4)));
+        ReceptionConversation auditedLegacy = legacy.activateTermsConsent("consent-1", now.plusSeconds(4));
+        assertThatIllegalStateException().isThrownBy(() -> auditedLegacy.reopenTermsForAudit(now.plusSeconds(5)));
+        assertThatThrownBy(() -> legacy.reopenTermsForAudit(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void paymentEvidenceTransitionsAreIdempotentAndFailClosedOutOfOrder() {
+        ReceptionConversation selected = ReceptionConversation.start("contact-1", now)
+                .selectService("DECOR_INTERIORES", now)
+                .presentTerms(now.plusSeconds(1))
+                .acceptTerms(now.plusSeconds(2));
+
+        assertThatIllegalStateException().isThrownBy(() -> selected.receivePaymentProof(now));
+        ReceptionConversation prepared = selected.preparePayment(false, "PIX", now.plusSeconds(3));
+        assertThat(prepared.preparePayment(false, "CARD", now.plusSeconds(4)).paymentStatus())
+                .isEqualTo(PaymentStatus.PREPARED);
+        ReceptionConversation proof = prepared.receivePaymentProof(now.plusSeconds(5));
+        assertThatIllegalStateException().isThrownBy(() -> proof.receivePaymentProof(now.plusSeconds(6)));
+        ReceptionConversation confirmed = proof.confirmPayment(now.plusSeconds(7));
+        assertThatIllegalStateException().isThrownBy(() -> confirmed.confirmPayment(now.plusSeconds(8)));
+        assertThatIllegalStateException().isThrownBy(() -> selected.confirmPayment(now));
+        assertThatIllegalStateException().isThrownBy(() -> selected.rejectPayment(now));
+
+        ReceptionConversation rejected = proof.rejectPayment(now.plusSeconds(8));
+        assertThat(rejected.paymentStatus()).isEqualTo(PaymentStatus.REJECTED);
+        assertThatIllegalStateException().isThrownBy(() -> rejected.rejectPayment(now.plusSeconds(9)));
+    }
+
+    @Test
+    void rejectsInvalidResumeTransitionsAndSupportsReturnToHuman() {
+        ReceptionConversation ai = ReceptionConversation.start("contact-1", now);
+        assertThatIllegalArgumentException().isThrownBy(() -> ai.beginResume("", "key", "checksum", 0, now));
+        assertThatIllegalArgumentException().isThrownBy(() -> ai.beginResume("id", "", "checksum", 0, now));
+        assertThatIllegalArgumentException().isThrownBy(() -> ai.beginResume("id", "key", "", 0, now));
+        assertThatIllegalStateException().isThrownBy(() -> ai.beginResume("id", "key", "checksum", 0, now));
+
+        ReceptionConversation human = ai.requestHumanHandoff("cliente pediu uma pessoa", now.plusSeconds(1));
+        assertThatIllegalStateException().isThrownBy(() -> human.markResumeDeciding(now));
+        ReceptionConversation syncing = human.beginResume("resume-1", "key-1", "checksum", 0, now.plusSeconds(2));
+        ReceptionConversation deciding = syncing.markResumeDeciding(now.plusSeconds(3));
+        assertThat(deciding.resumeStatus()).isEqualTo(ResumeStatus.DECIDING);
+        ReceptionConversation returned = deciding.returnResumeToHuman("arquiteta continuará", now.plusSeconds(4));
+        assertThat(returned.resumeStatus()).isEqualTo(ResumeStatus.RETURNED_TO_HUMAN);
+        assertThat(returned.mode()).isEqualTo(ReceptionMode.HUMAN);
+        assertThatIllegalStateException().isThrownBy(() -> returned.completeResume("WAIT", null, now));
     }
 }

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/TermsConsentAuditTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/TermsConsentAuditTest.java
@@ -1,0 +1,85 @@
+package br.com.urbana.connect.domain.reception.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TermsConsentAuditTest {
+    private static final Instant PRESENTED_AT = Instant.parse("2026-08-31T12:00:00Z");
+
+    @Test
+    void requiresCompletePresentationEvidenceAndNonNegativeVersion() {
+        TermsConsentAudit valid = presented();
+        assertThat(valid.status()).isEqualTo(TermsConsentStatus.PRESENTED);
+
+        assertThatThrownBy(() -> new TermsConsentAudit(null, "conversation", "contact", "turn", "unit",
+                "sala", "message-environment", "DECOR", "terms", null, "invocation", "outbound",
+                PRESENTED_AT, null, null, null, null, PRESENTED_AT, TermsConsentStatus.PRESENTED, 0, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new TermsConsentAudit("presentation", "conversation", "contact", "turn", "unit",
+                "sala", "message-environment", "DECOR", "terms", null, "invocation", "outbound",
+                PRESENTED_AT, null, null, null, null, PRESENTED_AT, TermsConsentStatus.PRESENTED, -1, null))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("version");
+    }
+
+    @Test
+    void rejectsAcceptanceEvidenceOnPresentedAuditAndIncompleteAcceptedAudit() {
+        assertThatThrownBy(() -> new TermsConsentAudit("presentation", "conversation", "contact", "turn", "unit",
+                "sala", "message-environment", "DECOR", "terms", null, "invocation", "outbound",
+                PRESENTED_AT, "message", null, null, null, PRESENTED_AT, TermsConsentStatus.PRESENTED, 0, null))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("presented audit");
+
+        assertThatThrownBy(() -> new TermsConsentAudit("presentation", "conversation", "contact", "turn", "unit",
+                "sala", "message-environment", "DECOR", "terms", null, "invocation", "outbound",
+                PRESENTED_AT, null, null, null, null, PRESENTED_AT, TermsConsentStatus.ACCEPTED, 0, 1L))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("acceptanceMessageId");
+        assertThatThrownBy(() -> new TermsConsentAudit("presentation", "conversation", "contact", "turn", "unit",
+                "sala", "message-environment", "DECOR", "terms", null, "invocation", "outbound",
+                PRESENTED_AT, "message", "event", "Aceito", PRESENTED_AT, PRESENTED_AT,
+                TermsConsentStatus.ACCEPTED, 0, null))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("acceptance version");
+    }
+
+    @Test
+    void acceptsOnlyAfterPresentationAndKeepsTheFirstAcceptanceOnReplay() {
+        TermsConsentAudit presented = presented();
+        TermsConsentAudit accepted = presented.accept("message-accept", "event-accept", "Aceito",
+                PRESENTED_AT.plusSeconds(1), 2);
+        TermsConsentAudit replay = accepted.accept("message-replay", "event-replay", "Outro texto",
+                PRESENTED_AT.plusSeconds(2), 3);
+
+        assertThat(accepted.status()).isEqualTo(TermsConsentStatus.ACCEPTED);
+        assertThat(accepted.acceptanceMessageId()).isEqualTo("message-accept");
+        assertThat(accepted.acceptanceEventId()).isEqualTo("event-accept");
+        assertThat(accepted.acceptanceTextExact()).isEqualTo("Aceito");
+        assertThat(accepted.conversationVersionAtAcceptance()).isEqualTo(2L);
+        assertThat(replay).isSameAs(accepted);
+    }
+
+    @Test
+    void rejectsBlankOrPrematureAcceptanceData() {
+        TermsConsentAudit presented = presented();
+        assertThatThrownBy(() -> presented.accept("", "event", "Aceito", PRESENTED_AT.plusSeconds(1), 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> presented.accept("message", " ", "Aceito", PRESENTED_AT.plusSeconds(1), 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> presented.accept("message", "event", " ", PRESENTED_AT.plusSeconds(1), 1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> presented.accept("message", "event", "Aceito", PRESENTED_AT.minusSeconds(1), 1))
+                .isInstanceOf(IllegalStateException.class).hasMessageContaining("precede");
+        assertThatThrownBy(() -> presented.accept("message", "event", "Aceito", PRESENTED_AT.plusSeconds(1), -1))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("version");
+        assertThatThrownBy(() -> presented.accept("message", "event", "Aceito", null, 1))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    private static TermsConsentAudit presented() {
+        return new TermsConsentAudit("presentation-1", "conversation-1", "contact-1", "turn-1", "unit-1",
+                "sala", "message-environment", "DECOR_INTERIORES", "https://example.test/terms", "v1",
+                "invocation-1", "outbound-1", PRESENTED_AT, null, null, null, null, PRESENTED_AT,
+                TermsConsentStatus.PRESENTED, 1, null);
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/TermsConsentAuditTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/reception/model/TermsConsentAuditTest.java
@@ -62,15 +62,17 @@ class TermsConsentAuditTest {
     @Test
     void rejectsBlankOrPrematureAcceptanceData() {
         TermsConsentAudit presented = presented();
-        assertThatThrownBy(() -> presented.accept("", "event", "Aceito", PRESENTED_AT.plusSeconds(1), 1))
+        Instant afterPresentation = PRESENTED_AT.plusSeconds(1);
+        Instant beforePresentation = PRESENTED_AT.minusSeconds(1);
+        assertThatThrownBy(() -> presented.accept("", "event", "Aceito", afterPresentation, 1))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> presented.accept("message", " ", "Aceito", PRESENTED_AT.plusSeconds(1), 1))
+        assertThatThrownBy(() -> presented.accept("message", " ", "Aceito", afterPresentation, 1))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> presented.accept("message", "event", " ", PRESENTED_AT.plusSeconds(1), 1))
+        assertThatThrownBy(() -> presented.accept("message", "event", " ", afterPresentation, 1))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> presented.accept("message", "event", "Aceito", PRESENTED_AT.minusSeconds(1), 1))
+        assertThatThrownBy(() -> presented.accept("message", "event", "Aceito", beforePresentation, 1))
                 .isInstanceOf(IllegalStateException.class).hasMessageContaining("precede");
-        assertThatThrownBy(() -> presented.accept("message", "event", "Aceito", PRESENTED_AT.plusSeconds(1), -1))
+        assertThatThrownBy(() -> presented.accept("message", "event", "Aceito", afterPresentation, -1))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("version");
         assertThatThrownBy(() -> presented.accept("message", "event", "Aceito", null, 1))
                 .isInstanceOf(NullPointerException.class);

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItemTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItemTest.java
@@ -74,7 +74,7 @@ class ServiceCatalogItemTest {
             assertThat(item.paymentResource()).startsWith("https://fixtures.urbana.local/");
             assertThat(item.briefingResource()).startsWith("https://fixtures.urbana.local/");
             assertThat(item.deliverables()).containsExactly(
-                    "Manual PDF", "Tour Virtual", "3 opções de solução", "2 rodadas consolidadas");
+                    "Manual do Espaço em PDF", "Tour Virtual", "3 opções de solução", "2 rodadas de alterações ou ajustes");
             assertThat(item.process()).anyMatch(value -> value.equals("briefing"));
             assertThat(item.process()).anyMatch(value -> value.equals("medidas, fotos e vídeos"));
             assertThat(item.process()).anyMatch(value -> value.contains("Google Meet"));
@@ -120,5 +120,21 @@ class ServiceCatalogItemTest {
                 .containsIgnoringCase("fachada")
                 .contains("externa")
                 .doesNotContain("20 m²");
+        assertThat(byType.get(ServiceType.DECOR_REFORMA).scope())
+                .containsIgnoringCase("reforma")
+                .containsIgnoringCase("ambiente interno")
+                .containsIgnoringCase("arquiteta")
+                .contains("20 m²");
+        assertThat(byType.get(ServiceType.DECOR_REFORMA).deliverables())
+                .contains("Manual do Espaço em PDF", "Tour Virtual", "3 opções de solução",
+                        "2 rodadas de alterações ou ajustes");
+        assertThat(byType.get(ServiceType.DECOR_REFORMA).support())
+                .contains("3 meses", "WhatsApp", "Manual", "cores")
+                .containsIgnoringCase("sem visita")
+                .containsIgnoringCase("sem gestão de obra");
+        String reformExclusions = String.join(" ", byType.get(ServiceType.DECOR_REFORMA).exclusions());
+        assertThat(reformExclusions).containsIgnoringCase("não executa a obra");
+        assertThat(reformExclusions).containsIgnoringCase("não compra materiais");
+        assertThat(reformExclusions).containsIgnoringCase("nem contrata profissionais");
     }
 }

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItemTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItemTest.java
@@ -133,8 +133,9 @@ class ServiceCatalogItemTest {
                 .containsIgnoringCase("sem visita")
                 .containsIgnoringCase("sem gestão de obra");
         String reformExclusions = String.join(" ", byType.get(ServiceType.DECOR_REFORMA).exclusions());
-        assertThat(reformExclusions).containsIgnoringCase("não executa a obra");
-        assertThat(reformExclusions).containsIgnoringCase("não compra materiais");
-        assertThat(reformExclusions).containsIgnoringCase("nem contrata profissionais");
+        assertThat(reformExclusions)
+                .containsIgnoringCase("não executa a obra")
+                .containsIgnoringCase("não compra materiais")
+                .containsIgnoringCase("nem contrata profissionais");
     }
 }

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoTermsConsentAuditGatewayTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoTermsConsentAuditGatewayTest.java
@@ -10,11 +10,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.dao.DuplicateKeyException;
 
 import java.time.Instant;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -60,6 +62,136 @@ class MongoTermsConsentAuditGatewayTest {
         assertThat(query.getValue().getQueryObject().toString())
                 .contains("status=PRESENTED")
                 .contains("presentedAt");
+    }
+
+    @Test
+    void mapsRepositoryQueriesAndEveryAuditFieldBackToTheDomain() {
+        TermsConsentAuditDocument document = document(TermsConsentStatus.ACCEPTED);
+        when(repository.findById("presentation-1")).thenReturn(Optional.of(document));
+        when(repository.findFirstByConversationIdAndContractingUnitIdAndStatusOrderByPresentedAtDesc(
+                "conversation-1", "unit-1", TermsConsentStatus.PRESENTED)).thenReturn(Optional.of(document));
+
+        MongoTermsConsentAuditGateway gateway = gateway();
+        TermsConsentAudit byId = gateway.findByPresentationId("presentation-1").orElseThrow();
+        TermsConsentAudit presented = gateway.findPresented("conversation-1", "unit-1").orElseThrow();
+
+        assertThat(byId).isEqualTo(presented);
+        assertThat(byId).satisfies(value -> {
+            assertThat(value.presentationId()).isEqualTo("presentation-1");
+            assertThat(value.conversationId()).isEqualTo("conversation-1");
+            assertThat(value.contactId()).isEqualTo("contact-1");
+            assertThat(value.turnId()).isEqualTo("turn-1");
+            assertThat(value.contractingUnitId()).isEqualTo("unit-1");
+            assertThat(value.environmentLabelSnapshot()).isEqualTo("sala");
+            assertThat(value.environmentSourceMessageId()).isEqualTo("message-environment");
+            assertThat(value.serviceType()).isEqualTo("DECOR_INTERIORES");
+            assertThat(value.termsResource()).contains("terms/decor");
+            assertThat(value.termsVersion()).isEqualTo("v1");
+            assertThat(value.prepareTermsInvocationId()).isEqualTo("invoke-1");
+            assertThat(value.termsOutboundMessageId()).isEqualTo("outbound-1");
+            assertThat(value.acceptanceMessageId()).isEqualTo("message-accept-1");
+            assertThat(value.acceptanceEventId()).isEqualTo("event-accept-1");
+            assertThat(value.acceptanceTextExact()).isEqualTo("Aceito");
+            assertThat(value.acceptedAt()).isEqualTo(PRESENTED_AT.plusSeconds(1));
+            assertThat(value.recordedAt()).isEqualTo(PRESENTED_AT);
+            assertThat(value.conversationVersionAtPresentation()).isEqualTo(3);
+            assertThat(value.conversationVersionAtAcceptance()).isEqualTo(4L);
+        });
+    }
+
+    @Test
+    void insertsPresentedEvidenceAndPreservesTheMappedDocument() {
+        TermsConsentAuditDocument inserted = document(TermsConsentStatus.PRESENTED);
+        when(repository.findById("presentation-1")).thenReturn(Optional.empty());
+        when(repository.insert(any(TermsConsentAuditDocument.class))).thenReturn(inserted);
+
+        TermsConsentAudit result = gateway().savePresentationIfAbsent(presented());
+
+        assertThat(result).isEqualTo(presented());
+        ArgumentCaptor<TermsConsentAuditDocument> captured = ArgumentCaptor.forClass(TermsConsentAuditDocument.class);
+        verify(repository).insert(captured.capture());
+        assertThat(captured.getValue()).satisfies(value -> {
+            assertThat(value.getPresentationId()).isEqualTo("presentation-1");
+            assertThat(value.getPrepareTermsInvocationId()).isEqualTo("invoke-1");
+            assertThat(value.getAcceptanceEventId()).isNull();
+            assertThat(value.getStatus()).isEqualTo(TermsConsentStatus.PRESENTED);
+        });
+    }
+
+    @Test
+    void handlesDuplicatePresentationRacesUsingTheWinnerOrRethrowsWhenItDisappears() {
+        TermsConsentAuditDocument winner = document(TermsConsentStatus.ACCEPTED);
+        when(repository.findById("presentation-1")).thenReturn(Optional.empty(), Optional.of(winner));
+        DuplicateKeyException duplicate = new DuplicateKeyException("duplicate presentation");
+        when(repository.insert(any(TermsConsentAuditDocument.class))).thenThrow(duplicate);
+
+        TermsConsentAudit recovered = gateway().savePresentationIfAbsent(presented());
+        assertThat(recovered.status()).isEqualTo(TermsConsentStatus.ACCEPTED);
+        assertThat(recovered.acceptanceTextExact()).isEqualTo("Aceito");
+
+        when(repository.findById("presentation-2")).thenReturn(Optional.empty());
+        TermsConsentAudit second = new TermsConsentAudit("presentation-2", "conversation-1", "contact-1", "turn-1",
+                "unit-1", "sala", "message-environment", "DECOR_INTERIORES",
+                "https://fixtures.urbana.local/terms/decor", "v1", "invoke-2", "outbound-2", PRESENTED_AT,
+                null, null, null, null, PRESENTED_AT, TermsConsentStatus.PRESENTED, 3, null);
+        when(repository.insert(any(TermsConsentAuditDocument.class))).thenThrow(duplicate);
+
+        assertThatThrownBy(() -> gateway().savePresentationIfAbsent(second))
+                .isSameAs(duplicate);
+    }
+
+    @Test
+    void rejectsInvalidPresentationPayloadsAndAcceptanceBoundaryArguments() {
+        TermsConsentAudit accepted = presented().accept("message-accept", "event-accept", "Aceito",
+                PRESENTED_AT.plusSeconds(1), 4);
+        assertThatThrownBy(() -> gateway().savePresentationIfAbsent(null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> gateway().savePresentationIfAbsent(accepted))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> gateway().acceptIfPresented(null, "event", "message", "Aceito", 0, PRESENTED_AT))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("presentationId");
+        assertThatThrownBy(() -> gateway().acceptIfPresented("id", "", "message", "Aceito", 0, PRESENTED_AT))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("acceptanceEventId");
+        assertThatThrownBy(() -> gateway().acceptIfPresented("id", "event", " ", "Aceito", 0, PRESENTED_AT))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("acceptanceMessageId");
+        assertThatThrownBy(() -> gateway().acceptIfPresented("id", "event", "message", "", 0, PRESENTED_AT))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("acceptanceTextExact");
+        assertThatThrownBy(() -> gateway().acceptIfPresented("id", "event", "message", "Aceito", -1, PRESENTED_AT))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("non-negative");
+        assertThatThrownBy(() -> gateway().acceptIfPresented("id", "event", "message", "Aceito", 0, null))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("acceptedAt");
+    }
+
+    @Test
+    void returnsExistingAcceptedEvidenceWhenCompareAndSetFindsNoChange() {
+        TermsConsentAuditDocument accepted = document(TermsConsentStatus.ACCEPTED);
+        when(template.findAndModify(any(Query.class), any(), any(FindAndModifyOptions.class),
+                eq(TermsConsentAuditDocument.class))).thenReturn(null);
+        when(repository.findById("presentation-1")).thenReturn(Optional.of(accepted));
+
+        assertThat(gateway().acceptIfPresented("presentation-1", "event-new", "message-new", "new text", 9,
+                PRESENTED_AT.plusSeconds(5))).satisfies(result -> {
+            assertThat(result.status()).isEqualTo(TermsConsentStatus.ACCEPTED);
+            assertThat(result.acceptanceEventId()).isEqualTo("event-accept-1");
+            assertThat(result.acceptanceTextExact()).isEqualTo("Aceito");
+        });
+    }
+
+    @Test
+    void failsClosedWhenCompareAndSetCannotFindPresentationOrAcceptedWinner() {
+        when(template.findAndModify(any(Query.class), any(), any(FindAndModifyOptions.class),
+                eq(TermsConsentAuditDocument.class))).thenReturn(null);
+        when(repository.findById("missing")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> gateway().acceptIfPresented("missing", "event", "message", "Aceito", 1,
+                PRESENTED_AT)).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("evidence is missing");
+
+        TermsConsentAuditDocument stillPresented = document(TermsConsentStatus.PRESENTED);
+        when(repository.findById("presentation-1")).thenReturn(Optional.of(stillPresented));
+        assertThatThrownBy(() -> gateway().acceptIfPresented("presentation-1", "event", "message", "Aceito", 1,
+                PRESENTED_AT)).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("was not recorded");
     }
 
     private MongoTermsConsentAuditGateway gateway() {

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoTermsConsentAuditGatewayTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoTermsConsentAuditGatewayTest.java
@@ -1,0 +1,103 @@
+package br.com.urbana.connect.infrastructure.persistence.mongodb.reception;
+
+import br.com.urbana.connect.domain.reception.model.TermsConsentAudit;
+import br.com.urbana.connect.domain.reception.model.TermsConsentStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.FindAndModifyOptions;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MongoTermsConsentAuditGatewayTest {
+    private static final Instant PRESENTED_AT = Instant.parse("2026-08-28T12:00:00Z");
+
+    @Mock
+    private SpringDataTermsConsentAuditRepository repository;
+
+    @Mock
+    private MongoTemplate template;
+
+    @Test
+    void neverOverwritesAnExistingAcceptedPresentationWhenAConversationRetriesPublication() {
+        TermsConsentAuditDocument existing = document(TermsConsentStatus.ACCEPTED);
+        when(repository.findById("presentation-1")).thenReturn(Optional.of(existing));
+
+        TermsConsentAudit result = gateway().savePresentationIfAbsent(presented());
+
+        assertThat(result.status()).isEqualTo(TermsConsentStatus.ACCEPTED);
+        assertThat(result.acceptanceTextExact()).isEqualTo("Aceito");
+        verify(repository, never()).insert(any(TermsConsentAuditDocument.class));
+        verify(repository, never()).save(any(TermsConsentAuditDocument.class));
+    }
+
+    @Test
+    void acceptanceCasRequiresPresentedStatusAndAResourceAlreadyVisibleInTime() {
+        TermsConsentAuditDocument accepted = document(TermsConsentStatus.ACCEPTED);
+        when(template.findAndModify(any(Query.class), any(), any(FindAndModifyOptions.class),
+                eq(TermsConsentAuditDocument.class))).thenReturn(accepted);
+
+        TermsConsentAudit result = gateway().acceptIfPresented("presentation-1", "event-1", "message-1",
+                "Aceito", 4, PRESENTED_AT.plusSeconds(1));
+
+        assertThat(result.status()).isEqualTo(TermsConsentStatus.ACCEPTED);
+        ArgumentCaptor<Query> query = ArgumentCaptor.forClass(Query.class);
+        verify(template).findAndModify(query.capture(), any(), any(FindAndModifyOptions.class),
+                eq(TermsConsentAuditDocument.class));
+        assertThat(query.getValue().getQueryObject().toString())
+                .contains("status=PRESENTED")
+                .contains("presentedAt");
+    }
+
+    private MongoTermsConsentAuditGateway gateway() {
+        return new MongoTermsConsentAuditGateway(repository, template);
+    }
+
+    private static TermsConsentAudit presented() {
+        return new TermsConsentAudit("presentation-1", "conversation-1", "contact-1", "turn-1", "unit-1",
+                "sala", "message-environment", "DECOR_INTERIORES", "https://fixtures.urbana.local/terms/decor",
+                "v1", "invoke-1", "outbound-1", PRESENTED_AT, null, null, null, null, PRESENTED_AT,
+                TermsConsentStatus.PRESENTED, 3, null);
+    }
+
+    private static TermsConsentAuditDocument document(TermsConsentStatus status) {
+        TermsConsentAuditDocument document = new TermsConsentAuditDocument();
+        document.setPresentationId("presentation-1");
+        document.setConversationId("conversation-1");
+        document.setContactId("contact-1");
+        document.setTurnId("turn-1");
+        document.setContractingUnitId("unit-1");
+        document.setEnvironmentLabelSnapshot("sala");
+        document.setEnvironmentSourceMessageId("message-environment");
+        document.setServiceType("DECOR_INTERIORES");
+        document.setTermsResource("https://fixtures.urbana.local/terms/decor");
+        document.setTermsVersion("v1");
+        document.setPrepareTermsInvocationId("invoke-1");
+        document.setTermsOutboundMessageId("outbound-1");
+        document.setPresentedAt(PRESENTED_AT);
+        document.setRecordedAt(PRESENTED_AT);
+        document.setStatus(status);
+        document.setConversationVersionAtPresentation(3);
+        if (status == TermsConsentStatus.ACCEPTED) {
+            document.setAcceptanceMessageId("message-accept-1");
+            document.setAcceptanceEventId("event-accept-1");
+            document.setAcceptanceTextExact("Aceito");
+            document.setAcceptedAt(PRESENTED_AT.plusSeconds(1));
+            document.setConversationVersionAtAcceptance(4L);
+        }
+        return document;
+    }
+}

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoTermsConsentAuditGatewayTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoTermsConsentAuditGatewayTest.java
@@ -75,8 +75,7 @@ class MongoTermsConsentAuditGatewayTest {
         TermsConsentAudit byId = gateway.findByPresentationId("presentation-1").orElseThrow();
         TermsConsentAudit presented = gateway.findPresented("conversation-1", "unit-1").orElseThrow();
 
-        assertThat(byId).isEqualTo(presented);
-        assertThat(byId).satisfies(value -> {
+        assertThat(byId).isEqualTo(presented).satisfies(value -> {
             assertThat(value.presentationId()).isEqualTo("presentation-1");
             assertThat(value.conversationId()).isEqualTo("conversation-1");
             assertThat(value.contactId()).isEqualTo("contact-1");
@@ -125,7 +124,8 @@ class MongoTermsConsentAuditGatewayTest {
         DuplicateKeyException duplicate = new DuplicateKeyException("duplicate presentation");
         when(repository.insert(any(TermsConsentAuditDocument.class))).thenThrow(duplicate);
 
-        TermsConsentAudit recovered = gateway().savePresentationIfAbsent(presented());
+        MongoTermsConsentAuditGateway auditGateway = gateway();
+        TermsConsentAudit recovered = auditGateway.savePresentationIfAbsent(presented());
         assertThat(recovered.status()).isEqualTo(TermsConsentStatus.ACCEPTED);
         assertThat(recovered.acceptanceTextExact()).isEqualTo("Aceito");
 
@@ -136,7 +136,7 @@ class MongoTermsConsentAuditGatewayTest {
                 null, null, null, null, PRESENTED_AT, TermsConsentStatus.PRESENTED, 3, null);
         when(repository.insert(any(TermsConsentAuditDocument.class))).thenThrow(duplicate);
 
-        assertThatThrownBy(() -> gateway().savePresentationIfAbsent(second))
+        assertThatThrownBy(() -> auditGateway.savePresentationIfAbsent(second))
                 .isSameAs(duplicate);
     }
 
@@ -144,22 +144,23 @@ class MongoTermsConsentAuditGatewayTest {
     void rejectsInvalidPresentationPayloadsAndAcceptanceBoundaryArguments() {
         TermsConsentAudit accepted = presented().accept("message-accept", "event-accept", "Aceito",
                 PRESENTED_AT.plusSeconds(1), 4);
-        assertThatThrownBy(() -> gateway().savePresentationIfAbsent(null))
+        MongoTermsConsentAuditGateway auditGateway = gateway();
+        assertThatThrownBy(() -> auditGateway.savePresentationIfAbsent(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> gateway().savePresentationIfAbsent(accepted))
+        assertThatThrownBy(() -> auditGateway.savePresentationIfAbsent(accepted))
                 .isInstanceOf(IllegalArgumentException.class);
 
-        assertThatThrownBy(() -> gateway().acceptIfPresented(null, "event", "message", "Aceito", 0, PRESENTED_AT))
+        assertThatThrownBy(() -> auditGateway.acceptIfPresented(null, "event", "message", "Aceito", 0, PRESENTED_AT))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("presentationId");
-        assertThatThrownBy(() -> gateway().acceptIfPresented("id", "", "message", "Aceito", 0, PRESENTED_AT))
+        assertThatThrownBy(() -> auditGateway.acceptIfPresented("id", "", "message", "Aceito", 0, PRESENTED_AT))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("acceptanceEventId");
-        assertThatThrownBy(() -> gateway().acceptIfPresented("id", "event", " ", "Aceito", 0, PRESENTED_AT))
+        assertThatThrownBy(() -> auditGateway.acceptIfPresented("id", "event", " ", "Aceito", 0, PRESENTED_AT))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("acceptanceMessageId");
-        assertThatThrownBy(() -> gateway().acceptIfPresented("id", "event", "message", "", 0, PRESENTED_AT))
+        assertThatThrownBy(() -> auditGateway.acceptIfPresented("id", "event", "message", "", 0, PRESENTED_AT))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("acceptanceTextExact");
-        assertThatThrownBy(() -> gateway().acceptIfPresented("id", "event", "message", "Aceito", -1, PRESENTED_AT))
+        assertThatThrownBy(() -> auditGateway.acceptIfPresented("id", "event", "message", "Aceito", -1, PRESENTED_AT))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("non-negative");
-        assertThatThrownBy(() -> gateway().acceptIfPresented("id", "event", "message", "Aceito", 0, null))
+        assertThatThrownBy(() -> auditGateway.acceptIfPresented("id", "event", "message", "Aceito", 0, null))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("acceptedAt");
     }
 
@@ -183,13 +184,14 @@ class MongoTermsConsentAuditGatewayTest {
         when(template.findAndModify(any(Query.class), any(), any(FindAndModifyOptions.class),
                 eq(TermsConsentAuditDocument.class))).thenReturn(null);
         when(repository.findById("missing")).thenReturn(Optional.empty());
-        assertThatThrownBy(() -> gateway().acceptIfPresented("missing", "event", "message", "Aceito", 1,
+        MongoTermsConsentAuditGateway auditGateway = gateway();
+        assertThatThrownBy(() -> auditGateway.acceptIfPresented("missing", "event", "message", "Aceito", 1,
                 PRESENTED_AT)).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("evidence is missing");
 
         TermsConsentAuditDocument stillPresented = document(TermsConsentStatus.PRESENTED);
         when(repository.findById("presentation-1")).thenReturn(Optional.of(stillPresented));
-        assertThatThrownBy(() -> gateway().acceptIfPresented("presentation-1", "event", "message", "Aceito", 1,
+        assertThatThrownBy(() -> auditGateway.acceptIfPresented("presentation-1", "event", "message", "Aceito", 1,
                 PRESENTED_AT)).isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("was not recorded");
     }

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/MongoServiceCatalogGatewayIntegrationTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/MongoServiceCatalogGatewayIntegrationTest.java
@@ -58,7 +58,7 @@ class MongoServiceCatalogGatewayIntegrationTest {
             assertThat(item.areaRule()).isNotNull();
             assertThat(item.scope()).isNotBlank();
             assertThat(item.deliverables()).contains(
-                "Manual PDF", "Tour Virtual", "3 opções de solução", "2 rodadas consolidadas");
+                "Manual do Espaço em PDF", "Tour Virtual", "3 opções de solução", "2 rodadas de alterações ou ajustes");
             assertThat(item.process()).anyMatch(value -> value.contains("briefing"));
             assertThat(item.process()).anyMatch(value -> value.contains("Google Meet"));
             assertThat(item.process()).anyMatch(value -> value.contains("7 dias úteis"));

--- a/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/ServiceCatalogSeederTest.java
+++ b/apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/servicecatalog/ServiceCatalogSeederTest.java
@@ -33,7 +33,7 @@ class ServiceCatalogSeederTest {
         assertThat(saved).allSatisfy(item -> {
             assertThat(item.isAvailable()).isTrue();
             assertThat(item.getAreaRule()).isNotNull();
-            assertThat(item.getDeliverables()).contains("Manual PDF", "Tour Virtual");
+            assertThat(item.getDeliverables()).contains("Manual do Espaço em PDF", "Tour Virtual");
             assertThat(item.getProcess()).anyMatch(value -> value.contains("Google Meet"));
             assertThat(item.getProcess()).anyMatch(value -> value.contains("7 dias úteis"));
             assertThat(item.getTermsResource()).startsWith("https://fixtures.urbana.local/");

--- a/integrations/hermes-agent/plugins/urbana-domain/__init__.py
+++ b/integrations/hermes-agent/plugins/urbana-domain/__init__.py
@@ -25,7 +25,7 @@ TOOL_DESCRIPTIONS = {
         "o que recebe, etapas, escopo, limites, disponibilidade ou preço. O resultado contém o "
         "catálogo rico; responda à dúvida sem iniciar termos, pagamento ou handoff por esse motivo. "
         "Ao detalhar um serviço identificado, explicite que é uma consultoria online e mencione "
-        "processo, Manual em PDF, Tour Virtual, 3 opções e até 2 rodadas de ajustes."
+        "processo, Manual do Espaço em PDF, Tour Virtual, 3 opções, até 2 rodadas de ajustes e suporte."
     ),
     "prepare_terms": (
         "Prepara os termos de um serviço já escolhido para uma intenção clara de contratação. "
@@ -37,6 +37,8 @@ TOOL_DESCRIPTIONS = {
         "As formas aceitas são PIX ou CARD (cartão de crédito). Se a forma não tiver sido "
         "informada, não use a ferramenta: pergunte se a pessoa prefere PIX ou cartão de crédito. "
         "Nunca use `link` como método; o link é a instrução retornada após o preparo. "
+        "Depois do preparo, oriente 1 serviço por ambiente e peça o comprovante; a POC usa uma simulação "
+        "e não confirma que o player real permite escolher quantidade. "
         "Não repita a chamada com os mesmos argumentos depois de uma rejeição: corrija a informação "
         "ou faça a pergunta necessária ao cliente."
     ),
@@ -54,7 +56,7 @@ def _schema(tool_name: str) -> dict:
     if tool_name == "update_customer_fact":
         parameters["properties"] = {
             "factType": {"type": "string", "enum": [
-                "PRONOUN_PREFERENCE", "FIRST_TIME_HIRING", "OCCUPATION", "NEED", "SELECTED_SERVICE"
+                "PRONOUN_PREFERENCE", "FIRST_TIME_HIRING", "OCCUPATION", "NEED", "SELECTED_SERVICE", "ENVIRONMENT"
             ]},
             "value": {},
             "evidence": {"type": "string"},

--- a/integrations/hermes-agent/plugins/urbana-domain/test_tools.py
+++ b/integrations/hermes-agent/plugins/urbana-domain/test_tools.py
@@ -40,6 +40,7 @@ class PluginToolsTest(unittest.TestCase):
                              if item["name"] == "update_customer_fact")
         self.assertEqual(update_schema["parameters"]["required"],
                          ["factType", "value", "evidence", "confidence"])
+        self.assertIn("ENVIRONMENT", update_schema["parameters"]["properties"]["factType"]["enum"])
 
     def test_surface_contains_only_six_domain_tools(self):
         self.assertEqual(len(TOOL_NAMES), 6)
@@ -63,6 +64,8 @@ class PluginToolsTest(unittest.TestCase):
         self.assertIn("intenção clara", descriptions["prepare_terms"].lower())
         self.assertIn("não use para dúvidas", descriptions["prepare_terms"].lower())
         self.assertIn("aceitos", descriptions["prepare_payment"].lower())
+        self.assertIn("1 serviço por ambiente", descriptions["prepare_payment"].lower())
+        self.assertIn("simulação", descriptions["prepare_payment"].lower())
 
     def test_prepare_payment_schema_enumerates_canonical_methods_with_natural_labels(self):
         registered = []
@@ -83,12 +86,17 @@ class PluginToolsTest(unittest.TestCase):
     def test_soul_requires_progressive_replies_and_safe_payment_method_question(self):
         soul = (Path(__file__).resolve().parents[2] / "profile" / "SOUL.md").read_text()
         normalized = soul.lower()
+        collapsed = " ".join(normalized.split())
 
         self.assertIn("responda somente à nova dúvida ou decisão", normalized)
         self.assertIn("não repita a lista completa", normalized)
         self.assertIn("pix ou cartão de crédito", normalized)
         self.assertIn("não chame `prepare_payment`", normalized)
         self.assertIn("não exponha ao cliente", normalized)
+        self.assertIn("manual do espaço", collapsed)
+        self.assertIn("tour virtual", collapsed)
+        self.assertIn("suporte", collapsed)
+        self.assertIn("uma pergunta de perfil por vez", collapsed)
         self.assertNotIn("await_payment_approval", normalized)
         self.assertNotIn("terms_not_accepted", normalized)
 

--- a/integrations/hermes-agent/profile/SOUL.md
+++ b/integrations/hermes-agent/profile/SOUL.md
@@ -23,18 +23,22 @@ Nas demais, não repita a apresentação sem necessidade.
   no que a pessoa contou e peça confirmação. Não declare antecipadamente que
   encontrou a solução certa, não escolha pela pessoa e não pressione por uma
   contratação.
-- Emojis são opcionais, nunca necessários para completar uma mensagem e, quando
+- Emojis são opcionais, porém bem vindos quando
   realmente acrescentarem acolhimento em uma conversa leve, use no máximo um.
-  Não use emojis em termos, pagamento, comprovante, falha, recusa, frustração ou
-  handoff.
+  Em descoberta, recomendação, apresentação de serviço ou confirmação positiva,
+  use um emoji contextual quando ele tornar a conversa mais acolhedora.
+  Segue alguns exemplos de emojis alinhados com a marca:
+  💜, 😃, 😊, 😄, 👷🏽‍♂️, ✨, ✅, 🚫, 🛋️, 🏡, 🎨, 🧱, 🤓, 😉, 👇🏾, 🤩, 🔎, 💬, 📅
+  Não use emojis em falha, recusa ou frustração.
 - Ajuste o tom ao momento: na descoberta, seja leve e curiosa; na explicação,
   clara e progressiva; na recomendação, confiante como hipótese; em termos e
   pagamento, sóbria e precisa; diante de falha, recusa, frustração ou informação
   indisponível, calma, breve e orientada ao próximo passo; no handoff, direta e
   tranquilizadora, sem prometer prazo de resposta.
 - Evite entusiasmo automático, superlativos, elogios genéricos, humor em
-  situações sensíveis e linguagem teatralizada. Não use expressões como “Que
-  máximo!”, “Show!”, “modo Einstein” ou “Grita!”.
+  situações sensíveis e linguagem teatralizada. Em um avanço leve e concreto,
+  expressões como “Show!”, “Perfeito!”, “Legal!” ou “Vamos lá!” podem ser usadas
+  com naturalidade, sem virar bordão ou interromper uma dúvida.
 - Qualquer exemplo de voz neste perfil é apenas uma referência adaptável, nunca
   uma resposta obrigatória ou uma sequência fixa. Responda ao contexto real da
   pessoa sem repetir saudações, confirmações ou explicações sem necessidade.
@@ -51,7 +55,7 @@ Nas demais, não repita a apresentação sem necessidade.
 - Quando a pessoa apenas cumprimentar, responda com uma apresentação breve e
   pergunte como pode ajudar. Não cite os serviços nem ofereça o catálogo em uma
   saudação genérica. Uma referência possível é: `Oi! Eu sou a Urba, assistente
-  virtual da Urbana do Brasil. Como posso te ajudar hoje?` Adapte a frase ao
+  virtual da Urbana do Brasil. Como posso te ajudar hoje? 😃` Adapte a frase ao
   contexto, sem transformá-la em um texto fixo ou longo.
 - Quando a primeira mensagem já trouxer uma necessidade, reconheça brevemente
   o contexto e faça uma pergunta curta para entender o próximo passo. Não repita
@@ -74,10 +78,19 @@ Nas demais, não repita a apresentação sem necessidade.
   transfira para a arquiteta apenas por a pessoa pedir mais detalhes.
 - Ao explicar o funcionamento ou os detalhes de um serviço já identificado,
   diga explicitamente que se trata de uma consultoria online e cubra, de forma
-  natural e proporcional à pergunta, o processo e as entregas comuns: Manual
-  em PDF, Tour Virtual, 3 opções de solução e até 2 rodadas consolidadas de
-  ajustes. Não omita esses pontos na primeira explicação relevante só porque o
+  natural e proporcional à pergunta, o processo e as entregas comuns: Manual do
+  Espaço em PDF, Tour Virtual, 3 opções de solução, 2 rodadas de alterações ou
+  ajustes e suporte de 3 meses pelo WhatsApp para dúvidas sobre o Manual e as
+  cores. Não omita esses pontos na primeira explicação relevante só porque o
   cliente já escolheu o serviço.
+- Ao apresentar a Decor Reforma, explique que é uma consultoria online para
+  reforma de ambiente interno, custa R$ 450 por ambiente contratado e atende até
+  20 m² por ambiente. Cada ambiente recebe sua própria solução; mudanças técnicas
+  dependem da avaliação da arquiteta. A Urbana não executa a obra, não compra
+  materiais e não contrata profissionais. Não prometa viabilidade de estrutura,
+  elétrica, hidráulica, gás, ART/RRT ou aprovações; encaminhe esses casos para
+  avaliação da arquiteta. Para área acima de 20 m² ou não confirmada, não prometa
+  o preço padrão.
 - Depois que o pacote já tiver sido explicado, responda somente à nova dúvida ou decisão.
   Não repita a lista completa de entregas, etapas ou responsabilidades
   sem necessidade; só recapitule se a pessoa pedir um resumo ou se uma
@@ -95,17 +108,20 @@ Nas demais, não repita a apresentação sem necessidade.
   exemplos curtos de resposta para deixar claro o que está sendo perguntado.
   Os exemplos não são opções obrigatórias: aceite texto livre, outras respostas
   e a recusa explícita. Use, conforme o campo atual:
-  - `Como prefere que eu me refira a você? Você pode responder: ela/dela,
-    ele/dele, elu/delu ou prefiro não responder.`
-  - `É sua primeira vez contratando um serviço de arquitetura ou design? Pode
-    responder sim, não ou prefiro não responder.`
-  - `Com o que você trabalha hoje? Pode responder livremente — por exemplo,
-    microempreendedora, assalariada, autônoma ou outra área.`
+  - `Como prefere que eu me refira a você? 😊
+
+    Ela / Dela (Feminino)
+    Ele / Dele (Masculino)
+    Elu / Delu (Neutro)
+    Prefiro não responder`
+  - `É sua primeira vez contratando um serviço de arquitetura ou design?`
+  - `Com o que você trabalha hoje? 👷🏽‍♂️
+
+  Pode responder livremente — por exemplo, microempreendedora, assalariada, autônoma ou outra área.`
   Não envie exemplos dos outros campos no mesmo turno se não forem o campo atual.
   Nunca use o termo técnico “ICP” ao falar com o cliente.
-- Dê a cada campo ausente no máximo uma segunda oportunidade. Uma recusa
-  explícita conclui o campo imediatamente; se não houver resposta na segunda
-  oportunidade, use `update_customer_fact` para registrar `NÃO INFORMADO`
+- Uma recusa explícita as solicitações de ICP conclui o campo imediatamente;
+  se não houver resposta na segunda oportunidade, use `update_customer_fact` para registrar `NÃO INFORMADO`
   somente nos campos que continuam ausentes e siga sem insistir.
   `NÃO INFORMADO` é o valor canônico também para recusa de pronome; não use
   `PREFER_NOT_TO_ANSWER` como valor persistido.
@@ -114,8 +130,12 @@ Nas demais, não repita a apresentação sem necessidade.
 - Quando todos os campos ausentes tiverem sido respondidos, recusados ou
   marcados como `NÃO INFORMADO`, avance automaticamente para `prepare_terms`.
   O perfil não é bloqueio de pagamento: `prepare_payment` depende apenas de
-  termos apresentados e aceite textual claro. Nunca apresente termos antes de
-  serviço confirmado e intenção clara de contratação.
+  termos apresentados e aceite textual claro. Ao apresentar os termos, diga que
+  a pessoa pode responder apenas `Aceito`; não exija uma fórmula longa nem peça
+  que ela repita o nome completo dos termos. Respostas como `Ok`, `talvez` ou
+  `vou ler` não são aceite claro e devem receber uma orientação breve, sem
+  liberar o pagamento. Nunca apresente termos antes de serviço confirmado e
+  intenção clara de contratação.
 - Registre silenciosamente declarações espontâneas e explícitas sobre esses
   campos em qualquer etapa, sem interromper a conversa para repetir a pergunta.
   Se a pessoa corrigir um valor, atualize silenciosamente o valor explícito
@@ -132,8 +152,10 @@ Nas demais, não repita a apresentação sem necessidade.
 ## Controles operacionais
 
 - Ao chamar `update_customer_fact`, use exatamente um destes `factType`:
-  `PRONOUN_PREFERENCE`, `FIRST_TIME_HIRING`, `OCCUPATION`, `NEED` ou
-  `SELECTED_SERVICE`. Nunca use rótulos naturais no lugar do enum.
+  `PRONOUN_PREFERENCE`, `FIRST_TIME_HIRING`, `OCCUPATION`, `NEED`,
+  `SELECTED_SERVICE` ou `ENVIRONMENT`. Nunca use rótulos naturais no lugar do
+  enum. Use `ENVIRONMENT` somente quando a pessoa tiver informado claramente o
+  ambiente; ele vincula a contratação à mensagem de origem sem expor IDs técnicos.
 - Identidade, contato, turno e chave de idempotência são definidos pela Urbana
   Connect. Nunca peça nem forneça esses identificadores técnicos.
 - Um comprovante pode ser recebido, mas nunca confirma pagamento. A aprovação é
@@ -155,6 +177,7 @@ Nas demais, não repita a apresentação sem necessidade.
   pergunte, em uma mensagem curta, se a pessoa prefere PIX ou cartão de crédito. Ao chamar a ferramenta, use exatamente `PIX` ou `CARD`;
   `link` é a instrução retornada depois do preparo, não uma forma de pagamento.
   Depois de um preparo bem-sucedido, envie o link recebido e peça o comprovante;
+  explique que a orientação é de 1 serviço para cada ambiente contratado;
   só comunique que ele aguarda validação humana depois que o comprovante chegar.
 - Não use terminal, arquivos, navegador, web, mensagens, credenciais, banco de
   dados ou ferramentas que não estejam explicitamente expostas.

--- a/specs/010-refine-urba-sales-dialogue/checklists/coverage-remediation.md
+++ b/specs/010-refine-urba-sales-dialogue/checklists/coverage-remediation.md
@@ -1,0 +1,40 @@
+# Checklist de qualidade — Remediação da cobertura Sonar
+
+**Feature**: [coverage-remediation.md](../coverage-remediation.md)
+**Ticket**: PEE-106
+**Criado**: 2026-08-31
+
+## Contrato
+
+- [x] O problema está quantificado com a análise do PR e o relatório JaCoCo.
+- [x] A meta é explícita: cobertura de código novo do Sonar ≥ 80%.
+- [x] O escopo preserva comportamento e prioriza testes.
+- [x] O fora de escopo impede reduzir threshold ou esconder código.
+
+## Cobertura comportamental
+
+- [x] Orquestrador: aceite, auditoria de apresentação e fences.
+- [x] Reconciliação: handoff, corridas, leases e fallbacks.
+- [x] Aceite: validações, mismatches, CAS e idempotência.
+- [x] Persistência: insert, duplicidade, CAS sem alteração e documentos legados.
+- [x] Ferramentas/modelos: rejeições seguras e invariantes de borda.
+
+## Validação
+
+- [x] Suítes focadas verdes.
+- [x] Suíte Gradle completa e JaCoCo verdes.
+- [x] Cálculo contra `origin/hml` registrado: `595/699 = 85,12%` (linhas `363/387`, condições `232/312`).
+- [ ] Check Sonar do PR ≥ 80%.
+- [x] Plugin, contratos, isolamento e lint do frontend sem regressão observada.
+- [x] `git diff --check` verde.
+
+Nota: o teste/build completo do frontend não foi executado localmente porque o
+ambiente não possui o binding nativo opcional do `rolldown`; o lint passou e a
+validação equivalente do CI deverá fechar esse item.
+
+## Handoff
+
+- [x] Arquivos alterados e justificativas listados no handoff do writer/QA.
+- [x] Comandos e resultados registrados no handoff do QA.
+- [x] Critérios cobertos e riscos residuais descritos.
+- [x] QA independente executada após o escritor parar.

--- a/specs/010-refine-urba-sales-dialogue/checklists/coverage-remediation.md
+++ b/specs/010-refine-urba-sales-dialogue/checklists/coverage-remediation.md
@@ -24,13 +24,13 @@
 - [x] Suítes focadas verdes.
 - [x] Suíte Gradle completa e JaCoCo verdes.
 - [x] Cálculo contra `origin/hml` registrado: `595/699 = 85,12%` (linhas `363/387`, condições `232/312`).
-- [ ] Check Sonar do PR ≥ 80%.
+- [x] Check Sonar do PR ≥ 80% (passou no PR #63 após o commit `e57b00c`).
 - [x] Plugin, contratos, isolamento e lint do frontend sem regressão observada.
 - [x] `git diff --check` verde.
 
 Nota: o teste/build completo do frontend não foi executado localmente porque o
-ambiente não possui o binding nativo opcional do `rolldown`; o lint passou e a
-validação equivalente do CI deverá fechar esse item.
+ambiente não possui o binding nativo opcional do `rolldown`; o lint local passou
+e os checks `Testes do poc-chat` e `Build, Teste e Análise` do PR #63 passaram.
 
 ## Handoff
 

--- a/specs/010-refine-urba-sales-dialogue/checklists/requirements.md
+++ b/specs/010-refine-urba-sales-dialogue/checklists/requirements.md
@@ -1,0 +1,45 @@
+# Specification Quality Checklist: Refinamento da conversa comercial da Urba
+
+**Purpose**: Validar completude e qualidade da especificação antes do planejamento
+
+**Created**: 2026-08-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Iteração 1: a exigência de emoji foi tornada positiva e mensurável, evitando
+  que o fluxo volte a passar sem nenhum uso contextual.
+- Iteração 1: o aceite e a forma de pagamento na mesma mensagem receberam
+  comportamento observável explícito.
+- Iteração 2: a revisão independente pediu precisão adicional para etapas sem
+  emoji, aceite auditável, a orientação textual de quantidade e o TODO do player
+  de pagamento, perguntas de perfil concorrentes, Decor Reforma e handoff após
+  comprovante. Esses pontos
+  foram incorporados à spec e ao baseline reproduzível da conversa Yohanna.
+- Segunda passagem independente aprovada; os ajustes editoriais não bloqueantes
+  foram incorporados antes da submissão a Emanuel.

--- a/specs/010-refine-urba-sales-dialogue/checklists/sonar-issues-remediation.md
+++ b/specs/010-refine-urba-sales-dialogue/checklists/sonar-issues-remediation.md
@@ -21,11 +21,24 @@
 - [x] Suítes focadas verdes.
 - [x] Suíte Gradle completa e JaCoCo verdes (JDK 21, 466 testes).
 - [x] Cobertura de código novo permanece ≥ 80%: `606/698 = 86,82%` (linhas `369/390`, condições `237/308`).
-- [ ] Issues Sonar do PR eliminados ou justificados.
+- [x] Issues Sonar do PR eliminados ou justificados: a API oficial registrou
+  `52` issues na primeira análise, `4` residuais após o primeiro refactor e
+  `0` issues abertos após `9e3ad1c` (run `33415584508`).
 - [x] Nenhuma alteração em plugin/frontend/configuração foi introduzida; regressões remotas serão confirmadas no PR.
 - [x] `git diff --check` verde.
 
 ## Handoff
 
 - [x] QA independente executada após o escritor parar (revisão do inventário e diff).
-- [x] Contagem Sonar antes/depois, comandos, arquivos e riscos registrados; análise oficial pós-push pendente.
+- [x] Contagem Sonar antes/depois, comandos, arquivos e riscos registrados; a
+  análise oficial pós-push terminou com quality gate aprovado.
+
+## Evidência final
+
+- Commit de remediação inicial: `67125b1`.
+- Commit da correção dos quatro achados residuais: `9e3ad1c`.
+- Checks remotos do PR `#63` no run `33415584508`: Build/Test/Análise,
+  SonarCloud e poc-chat aprovados.
+- Consulta `api/issues/search` do PR `#63` após o run: `total = 0` issues
+  abertos.
+- Arquivos preexistentes em `docs/plans/` permaneceram fora do commit.

--- a/specs/010-refine-urba-sales-dialogue/checklists/sonar-issues-remediation.md
+++ b/specs/010-refine-urba-sales-dialogue/checklists/sonar-issues-remediation.md
@@ -1,0 +1,31 @@
+# Checklist de qualidade — Issues Sonar do PR
+
+**Feature**: [sonar-issues-remediation.md](../sonar-issues-remediation.md)
+**Ticket**: PEE-106
+**Criado**: 2026-08-31
+
+## Contrato
+
+- [x] A contagem e as regras foram extraídas da análise do PR.
+- [x] O escopo diferencia refactor de produção e higiene dos testes.
+- [x] O contrato proíbe supressões, exclusões e mudanças de quality gate.
+
+## Implementação
+
+- [x] Regex, construtor longo, constantes, atribuições e declarações de produção ajustados.
+- [x] Lambdas e asserções dos testes refatoradas sem perda de verificações.
+- [x] Testes de caracterização preservam aceite, reconciliação e guardrails.
+
+## Validação
+
+- [x] Suítes focadas verdes.
+- [x] Suíte Gradle completa e JaCoCo verdes (JDK 21, 466 testes).
+- [x] Cobertura de código novo permanece ≥ 80%: `606/698 = 86,82%` (linhas `369/390`, condições `237/308`).
+- [ ] Issues Sonar do PR eliminados ou justificados.
+- [x] Nenhuma alteração em plugin/frontend/configuração foi introduzida; regressões remotas serão confirmadas no PR.
+- [x] `git diff --check` verde.
+
+## Handoff
+
+- [x] QA independente executada após o escritor parar (revisão do inventário e diff).
+- [x] Contagem Sonar antes/depois, comandos, arquivos e riscos registrados; análise oficial pós-push pendente.

--- a/specs/010-refine-urba-sales-dialogue/coverage-remediation.md
+++ b/specs/010-refine-urba-sales-dialogue/coverage-remediation.md
@@ -1,0 +1,190 @@
+# Especificação — Remediação da cobertura do código novo
+
+**Feature**: `010-refine-urba-sales-dialogue`
+**Ticket Jira**: `PEE-106` (subtask de `PEE-23`)
+**PR**: `#63`
+**Branch**: `010-refine-urba-sales-dialogue` → `hml`
+**Status**: aprovado para execução
+**Data**: 2026-08-31
+
+## 1. Contexto
+
+O PR #63 tem o build, os testes do backend e os testes do frontend aprovados,
+mas o quality gate do SonarCloud falha com **64,3% de cobertura no código novo**
+quando o projeto exige **80%**. O gate JaCoCo do Gradle continua sendo um piso de
+60% de linhas e não substitui o gate de código novo do Sonar.
+
+O diagnóstico do relatório gerado pelo PR mostrou que a métrica nova combina
+linhas e condições/branches:
+
+| Medida do código novo | Coberto | Total |
+| --- | ---: | ---: |
+| Linhas executáveis | 290 | 387 |
+| Condições/branches | 159 | 312 |
+| Métrica combinada | 449 | 699 |
+
+São necessários pelo menos mais 111 elementos cobertos para atingir 80%. A
+maior parte do gap está no código Java de auditoria de aceite, reconciliação de
+turnos, persistência Mongo e rejeições seguras introduzido pela feature. O
+`SOUL.md` e os demais arquivos Markdown não são a causa desse indicador.
+
+## 2. Objetivo
+
+Complementar a suíte automatizada para que o código novo do PR alcance cobertura
+SonarCloud de pelo menos 80%, preservando integralmente o comportamento comercial,
+os guardrails de segurança e o contrato Hermes já validados.
+
+A implementação desta remediação deve ser centrada em testes. Não deve alterar
+regras de negócio, integrações, o perfil da Urba ou o threshold/configuração do
+Sonar apenas para fazer o indicador passar.
+
+## 3. Comportamentos e cenários obrigatórios
+
+### 3.1 Orquestração e publicação
+
+1. Dado um aceite recebido após uma apresentação durável de termos, quando o
+   turno é processado, então o aceite é associado à mensagem inbound exata,
+   registrado na auditoria e a conversa avança uma única vez.
+2. Dado um `TermsAcceptanceUseCase` ausente, uma conversa sem unidade/ambiente,
+   uma invocação inexistente ou uma URL que não aparece na mensagem publicada,
+   quando a apresentação é reconciliada, então nenhum aceite é ativado e a
+   conversa permanece segura.
+3. Dado um inbound mais novo persistido enquanto um turno antigo ainda está
+   gerando ou publicando sua resposta, então o turno antigo fica retryable,
+   nenhuma resposta obsoleta é considerada a resposta final e a liberação do
+   lease ocorre de modo seguro.
+4. Dado um turno que não possui inbound mais novo, quando sua resposta é
+   publicada, então a mensagem é idempotente, a auditoria de termos é registrada
+   quando aplicável e o turno é concluído normalmente.
+
+### 3.2 Reconciliação e fallback comercial
+
+1. Dado um turno em reconciliação, quando a conversa está sob atendimento humano,
+   então somente o ack de handoff é publicado, com e sem ack pré-existente e com
+   e sem lease.
+2. Dado um inbound novo antes da reconciliação, antes da primeira publicação ou
+   durante a publicação, então cada fence correspondente deixa o turno seguro
+   para retry sem publicar texto tardio.
+3. Dado um candidato Hermes rejeitado pela política, então o fallback é correto
+   para `NOT_STARTED`, `PREPARED`, `PROOF_RECEIVED`, `CONFIRMED` e `REJECTED`,
+   sem confirmar pagamento ou liberar briefing indevidamente.
+4. Dado texto Hermes válido ou inválido para a apresentação inicial, então a
+   identidade da Urba é adicionada somente quando necessária.
+
+### 3.3 Aceite e evidência durável
+
+1. Entradas nulas, vazias, versões negativas, status diferente de `PRESENTED`,
+   timestamps anteriores à apresentação e evidências ausentes devem falhar
+   fechadas com erro determinístico.
+2. Evidência de outra conversa, unidade ou serviço deve ser rejeitada.
+3. Um primeiro aceite deve vencer; replays posteriores não podem sobrescrever o
+   texto, evento, mensagem ou horário do primeiro aceite.
+4. Tanto o caminho com gateway de conversa quanto o construtor de compatibilidade
+   sem gateway devem permanecer cobertos.
+
+### 3.4 Persistência e compatibilidade
+
+1. O gateway de auditoria deve ser testado em inserção, registro já existente,
+   corrida de chave duplicada, CAS bem-sucedido, CAS sem alteração, evidência
+   ausente e evidência ainda não aceita.
+2. O mapeamento de auditoria e de conversa deve preservar os novos campos.
+3. Documentos legados sem `sourceMessageIds` devem recuperar o fallback para o
+   `sourceMessageId` único; listas válidas devem ser preservadas.
+
+### 3.5 Ferramentas e modelos
+
+1. As rejeições seguras devem cobrir método de pagamento ausente/inválido,
+   serviço não confirmado, ambiente não confirmado, termos sem evidência,
+   handoff e a rejeição genérica.
+2. A origem de fatos deve cobrir transcript ausente, evidência explícita,
+   negação, alias de serviço, frase vazia e frase com limites de palavra.
+3. Os invariantes de `ActiveTurnLease`, `ReceptionConversation` e
+   `TermsConsentAudit` devem cobrir valores nulos/vazios, modos incompatíveis,
+   versões inválidas, reabertura de aceite legado e replay idempotente.
+
+## 4. Matriz de implementação e prioridade
+
+Os testes devem priorizar os maiores gaps observados no relatório atual:
+
+| Área | Cobertura combinada atual | Entrega esperada |
+| --- | ---: | --- |
+| `ReceptionOrchestrator` | 26/95 | testes de aceite durável, auditoria de apresentação e fences |
+| `ReceptionTurnReconciliationService` | 99/157 | testes de corridas, handoff, leases e todos os fallbacks |
+| `MongoTermsConsentAuditGateway` | 34/62 | testes de insert, CAS, duplicidade, ausência e mapeamento |
+| `TermsAcceptanceUseCase` | 59/86 | testes de entradas inválidas e mismatches de evidência |
+| `StatefulDomainToolService` | 77/104 | testes de rejeições, provenance e normalização |
+| Modelos/adapters restantes |  —  | completar invariantes e compatibilidade legada |
+
+Os testes podem reutilizar doubles em memória e mocks existentes. Nenhum teste
+deve depender de credencial, serviço externo ou player de pagamento real.
+
+## 5. Critérios de aceite
+
+- [ ] O check `SonarCloud Code Analysis` do PR #63 informa **Coverage on New
+  Code ≥ 80%**.
+- [ ] A cobertura calculada localmente contra `origin/hml` confirma pelo menos
+  80% da combinação de linhas e condições novas, ou a diferença é explicada
+  pelos metadados da análise e confirmada no check do Sonar.
+- [ ] `./gradlew --no-daemon --max-workers=1 clean test jacocoTestReport` passa
+  com zero falhas e o relatório XML é gerado no caminho configurado.
+- [ ] As suítes focadas de orquestração, reconciliação, aceite, ferramentas,
+  modelos e persistência passam isoladamente.
+- [ ] Não há alteração no threshold JaCoCo, em `sonar.exclusions`, na superfície
+  de ferramentas Hermes, no `SOUL.md` ou nas integrações produtivas como parte
+  desta remediação.
+- [ ] Não há regressão nos testes do plugin, frontend, contratos ou isolamento.
+- [ ] `git diff --check` passa e o diff contém somente a especificação/checklist
+  e testes necessários, salvo justificativa técnica explícita.
+- [ ] O relatório de handoff lista comandos, resultados, cobertura antes/depois,
+  arquivos alterados, critérios cobertos e riscos residuais.
+
+## 6. Edge cases e falhas a preservar
+
+- Aceite isolado só é válido depois de termos apresentados e auditados.
+- Aceite ambíguo, negativo ou antecipado não pode liberar pagamento.
+- Inbound novo não pode ser respondido por um turno obsoleto.
+- Comprovante recebido continua aguardando decisão humana.
+- Falha de CAS, duplicidade de insert e documento legado não podem apagar
+  evidência anterior.
+- O branch impossível de `NoSuchAlgorithmException` não deve ser coberto com
+  alteração artificial de produção; só pode permanecer não exercitado se os
+  critérios globais forem atingidos e a decisão ficar documentada.
+
+## 7. Validação e evidências
+
+### Durante a implementação
+
+- Executar os testes focados após cada grupo de cenários.
+- Regenerar o JaCoCo com JDK 21.
+- Comparar as linhas/condições novas contra a base `hml` e registrar o cálculo.
+
+### Antes do handoff para QA
+
+- Executar a suíte Gradle completa, incluindo `jacocoTestReport`.
+- Executar plugin/profile, contratos, isolamento e frontend quando o diff exigir
+  regressão nessas áreas.
+- Executar `git diff --check`.
+
+### Aceitação independente
+
+- QA deve revisar os testes novos, executar as suítes e verificar o check do
+  Sonar no PR sem aceitar a própria implementação.
+- A aprovação depende do indicador do Sonar e dos testes, não apenas do número
+  de testes adicionados.
+
+## 8. Fora de escopo
+
+- Alterar comportamento conversacional, catálogo, preços, termos, pagamento ou
+  handoff.
+- Alterar o `SOUL.md` ou a superfície do plugin Hermes.
+- Reduzir o threshold de 80%, mudar quality gate ou adicionar exclusões para
+  esconder código novo.
+- Criar player/link de pagamento, transação real, nova integração ou deploy.
+- Reescrever a suíte inteira ou remover testes existentes.
+- Fazer merge do PR ou promover para `main`.
+
+## 9. Dúvidas em aberto
+
+Nenhuma decisão de negócio está pendente. Se o Sonar e o cálculo local
+discordarem, o check do SonarCloud do próprio PR é a fonte de aceitação e a
+diferença deve ser registrada no handoff para investigação posterior.

--- a/specs/010-refine-urba-sales-dialogue/data-model.md
+++ b/specs/010-refine-urba-sales-dialogue/data-model.md
@@ -1,0 +1,72 @@
+# Data model — Refinamento da conversa comercial da Urba
+
+Esta feature cria uma entidade persistente aditiva para não depender de
+reconstrução heurística. Os modelos existentes continuam sendo a fonte
+operacional, enquanto o registro de consentimento preserva a associação
+histórica entre termos apresentados e aceite.
+
+| Entidade | Fonte atual | Uso na feature | Invariantes |
+|---|---|---|---|
+| `ServiceCatalogItem` / `ServiceFixture` | catálogo canônico Java | preço, área, escopo, entregas, suporte, exclusões e recursos | quatro serviços disponíveis; preços e limites da PEE-102 |
+| `ReceptionConversation` | estado operacional Java/Mongo | serviço atual, termos, pagamento, modo e etapa | termos precedem pagamento; comprovante precede aprovação humana |
+| `CustomerFact` | fatos versionados Mongo | campos de perfil e ambiente já informados | somente versão atual/reutilizável guia a coleta |
+| Transcript de recepção | coleção de mensagens | texto exato de `Aceito`, contexto e ordem de mensagens | mensagens não são reescritas para esconder retrabalho |
+| `DomainToolInvocation` | invocações Mongo | recurso/resultado de `prepare_terms` e `prepare_payment` | idempotência e payload preservados |
+| `TermsConsentAudit` | nova coleção Mongo `reception_terms_consent_audits` | prova estruturada da apresentação e do aceite por unidade | apresentação durável precede aceite; transição condicional e idempotente; registros são imutáveis após aceite |
+
+## `TermsConsentAudit`
+
+Campos obrigatórios:
+
+- `presentationId` — identidade determinística da apresentação;
+- `conversationId`, `contactId`, `turnId`;
+- `contractingUnitId` — identificador opaco gerado pelo backend;
+- `environmentLabelSnapshot` e `environmentSourceMessageId`;
+- `serviceType`;
+- `termsResource` e, quando existir, `termsVersion`;
+- `prepareTermsInvocationId`, `termsOutboundMessageId`;
+- `presentedAt`, `acceptanceMessageId`, `acceptanceEventId`,
+  `acceptanceTextExact`, `acceptedAt`, `recordedAt`;
+- `status` (`PRESENTED` ou `ACCEPTED`),
+  `conversationVersionAtPresentation` e
+  `conversationVersionAtAcceptance`.
+
+Índices/garantias:
+
+- único em `presentationId`;
+- único esparso em `prepareTermsInvocationId`, evitando duas evidências para a
+  mesma preparação de termos sem quebrar documentos legados que não possuem o
+  campo;
+- único esparso em `acceptanceEventId`, impedindo que o mesmo inbound seja
+  associado a duas apresentações;
+- consulta por `conversationId + contractingUnitId + status` para localizar a
+  apresentação corrente;
+- atualização aceita somente de `PRESENTED` para `ACCEPTED`; o primeiro aceite
+  válido vence e replays retornam o mesmo registro.
+
+O backend cria `contractingUnitId` somente quando o ambiente foi explicitado de
+forma inequívoca no contexto. Uma etiqueta sozinha não é identidade suficiente
+para dois ambientes iguais; mensagens ambíguas permanecem em esclarecimento.
+
+## Evidência mínima do aceite
+
+Um aceite válido deve poder ser lido diretamente no registro estruturado e
+conferido contra o transcript/invocações:
+
+1. serviço e unidade/ambiente identificável;
+2. recurso (e versão, quando disponível) apresentado;
+3. timestamps e IDs de apresentação e aceite;
+4. mensagem inbound textual exata;
+5. transição da conversa para `ACCEPTED` antes de `PREPARED`.
+
+Registros legados sem `TermsConsentAudit` não são backfillados por proximidade
+de mensagens. O fluxo deve reapresentar os termos e criar uma nova evidência.
+
+## Transições relevantes
+
+```text
+service selected -> TERMS/PRESENTED -> ACCEPTED -> PAYMENT/PREPARED
+PAYMENT/PREPARED -> PROOF_RECEIVED -> CONFIRMED/BRIEFING (somente humano)
+```
+
+O player de quantidade não é uma entidade nem uma transição nesta feature.

--- a/specs/010-refine-urba-sales-dialogue/evidence/validation-report.md
+++ b/specs/010-refine-urba-sales-dialogue/evidence/validation-report.md
@@ -1,0 +1,131 @@
+# Relatório de validação — Refinamento da conversa comercial da Urba
+
+**Feature:** `010-refine-urba-sales-dialogue`
+**Ticket:** PEE-106 (subtask de PEE-23)
+**Data da rodada:** 2026-08-28
+**Status desta evidência:** `implemented_unverified`
+
+## Escopo validado
+
+A implementação foi mantida no fluxo canônico Hermes da POC. Foram alterados
+o perfil `SOUL.md`, a cópia/catálogo de serviços, os guardrails determinísticos
+do backend, o registro estruturado de aceite e a reconciliação de turnos. Não
+foi criado player, integração financeira, link real ou nova ferramenta Hermes.
+
+O seletor de quantidade do futuro player continua sendo um TODO de pré-
+homologação: os links usados pela POC são fixtures/simulações e não permitem
+inferir a capacidade do provedor real.
+
+## Validações automatizadas
+
+| Verificação | Resultado observado |
+|---|---|
+| Suíte Gradle completa com JDK 21 | `BUILD SUCCESSFUL`; 423 testes, 0 falhas; JaCoCo gerado |
+| Foco final de política, ferramenta e reconciliação | 58 testes passantes (24 política, 28 ferramenta, 6 reconciliação), incluindo copy obrigatória, ambiente tentativo e aceite ambíguo |
+| `python3 -m unittest test_tools.py` | 14 testes passantes |
+| `npm test -- --run` | 19 arquivos / 81 testes passantes |
+| `npm run typecheck` | passante |
+| `npm run lint` | passante |
+| `npm run build` | passante (Vite 8.2.1) |
+| `scripts/verify-tool-surface.sh` | `tool_surface=urbana-domain:6` |
+| `scripts/smoke-contract.sh` | contrato Hermes passante em `http://127.0.0.1:8652` |
+| `scripts/smoke-isolation.sh` | filesystem, profile read-only e rede isolada passantes |
+| `git diff --check` | passante |
+
+A revisão independente final da QA ficou `verified`: confirmou os três
+hardening P1 — ambiente sem vínculo quando a evidência é sentinela, parcial ou
+ausente; fallback de pagamento com simulação, uma unidade por ambiente e
+comprovante; e rejeição de aceite ambíguo com intenção de ler/analisar/revisar
+ou equivalente. Nenhum arquivo foi editado pela QA.
+
+Após o primeiro teste ao vivo, foi encontrada e corrigida uma incompatibilidade
+de checksum na retomada Hermes: o Java escapava emoji suplementar como surrogate
+pair, enquanto o gateway Python canonicaliza UTF-8 literal. A correção usa os
+mesmos bytes UTF-8 canônicos e tem regressão unitária para `🦕`.
+
+## Validação live no frontend
+
+O stack local foi reconstruído com o profile candidato, ficou saudável (`READY`
+no backend e `ok` no frontend) e o fluxo E2E executou:
+
+```bash
+PLAYWRIGHT_LIVE=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 \
+PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' \
+npx playwright test e2e/quality-chat.spec.ts
+```
+
+Resultado: **1 teste passante, rubric 18/18**. A execução cobriu, em uma sessão
+nova, saudação, descoberta, comparação, catálogo, coleta de um campo de perfil
+por mensagem, termos, `Ok.` ambíguo, `Aceito` isolado, pagamento simulado,
+orientação de uma unidade por ambiente, comprovante, handoff, silêncio sob
+ownership humano, aprovação humana, decisão humana e retomada
+`HUMANO → URBA` com status `COMPLETED` e uma continuação proativa.
+
+### Transcrição candidata observada (resumo do fluxo live)
+
+O teste preserva a projeção canônica completa e anexa o transcript ao resultado
+Playwright. As mensagens abaixo registram os pontos de controle observados; não
+constituem texto fixo que o modelo deva repetir.
+
+| Etapa | Entrada do cliente | Evidência observada |
+|---|---|---|
+| Saudação | `Olá!` | Urba se identifica como assistente virtual da Urbana do Brasil e pergunta como ajudar, sem despejar o catálogo |
+| Descoberta | quarto infantil com dinossauros/dragões, pintura temática e reaproveitamento de móveis | recomendação de Decor Pintura em tom leve, com emoji contextual |
+| Comparação | diferença entre Decor Pintura e Decor Interiores | distinção factual entre pintura temática e organização de mobiliário/composição |
+| Serviço | confirmação de Decor Pintura e pedido de detalhes | consultoria online, Manual do Espaço, Tour Virtual, 3 opções, 2 rodadas e suporte; sem avanço comercial durante dúvida informativa |
+| ICP | contratação, pronome, primeira contratação e ocupação | uma pergunta por mensagem; resposta parcial não repete o campo já respondido |
+| Termos | `Ok.` e depois `Aceito` | `Ok.` permanece ambíguo; `Aceito` muda para `ACCEPTED` sem pedir frase longa |
+| Pagamento | preferência por PIX | estado `PREPARED`; mensagem informa que é simulação POC, orienta 1 serviço por ambiente e pede comprovante |
+| Comprovante | comprovante sintético | `PROOF_RECEIVED`, ownership humano e apenas um handoff canônico; sem confirmação automática |
+| Atendimento humano | dúvida durante espera | nenhuma resposta automática enquanto ownership é humano; aprovação/decisão ficam registradas como eventos humanos |
+| Retomada | devolução para Urba | sincronização concluída, status `COMPLETED` e uma continuação proativa sobre briefing/medidas/fotos/vídeos/material |
+
+### Limitação do navegador
+
+O Chromium bundled pelo Playwright não é suportado no macOS 12 deste ambiente.
+A validação live foi feita com o Google Chrome instalado no sistema, usando o
+mesmo frontend e os mesmos endpoints locais. Isso não altera o produto, mas deve
+ser repetido em CI/homologação com um navegador suportado.
+
+## Replay Yohanna e corpus
+
+O transcript baseline integral de 31 mensagens permanece em
+[`yohanna-baseline.md`](yohanna-baseline.md). A execução live acima é o fluxo de
+qualidade automatizado da POC, não uma reprodução literal desses 31 eventos.
+O replay literal Yohanna, os 12 pares cegos C01–C12 e a execução independente
+de C15/C16 ainda não foram realizados nesta rodada; portanto a média qualitativa
+da PO e os Gates 3–5 não podem ser declarados completos.
+
+Os testes determinísticos cobrem as regras equivalentes mais críticas: aceite
+isolado contextual, aceite composto, negação e intenção ambígua de ler/analisar/
+revisar, auditoria CAS, pagamento fail-closed, copy obrigatória de
+quantidade/comprovante, ambiente tentativo sem vínculo, catálogo/Decor Reforma,
+handoff e reconciliação.
+
+## Critérios e riscos residuais
+
+- CA-001–CA-015, CA-017–CA-020: cobertos por mudanças no profile/catalogo,
+  testes determinísticos e pelo fluxo live 18/18, com a ressalva de que o
+  replay literal de Yohanna ainda falta.
+- CA-016: o fluxo de reconciliação possui fences antes e depois da publicação
+  tardia e testes de mensagens consecutivas. No caminho normal ainda existe uma
+  janela residual entre a última leitura e o append do outbound; eliminá-la
+  exigiria uma operação transacional/CAS no gateway de transcript e não foi
+  ampliado o escopo desta feature.
+- CA-014a: atendido como documentação de limitação; nenhum player real foi
+  validado ou afirmado como existente.
+- O registro `TermsConsentAudit` torna serviço, ambiente/unidade, recurso dos
+  termos, instantes, IDs e texto exato do aceite recuperáveis. A concorrência
+  real do adaptador Mongo precisa ser exercitada na homologação com Mongo
+  disponível.
+
+## Próximos passos obrigatórios
+
+1. Executar o replay literal da Yohanna no frontend e registrar a transcrição
+   candidata completa.
+2. Executar C01–C16 nas sessões definidas pela spec; comparar C01–C12 com o
+   baseline sem identificar a origem das transcrições para a PO.
+3. Escolher o player de pagamento, verificar seleção de quantidade e registrar
+   uma alternativa operacional caso o provedor não suporte múltiplas unidades.
+4. Repetir a validação em CI/homologação com Mongo e navegador suportados antes
+   de promover a branch para `hml`.

--- a/specs/010-refine-urba-sales-dialogue/evidence/yohanna-baseline.md
+++ b/specs/010-refine-urba-sales-dialogue/evidence/yohanna-baseline.md
@@ -1,0 +1,88 @@
+# Baseline reproduzível — conversa Yohanna
+
+**Origem**: transcript canônico da POC manual
+
+**Contato sintético**: `poc:manual-fd690838-ec20-465c-b5d6-fb8819466303`
+
+**Conversa**: `94ffb84e-a4d9-4464-9d18-10ad9bc59f3a`
+
+**Período**: 2026-08-27 19:06:27–19:25:43 UTC
+**Quantidade**: 31 mensagens
+
+## Estado final observado
+
+- modo: `AI`;
+- etapa comercial: `PAYMENT`;
+- serviço selecionado: `DECOR_INTERIORES`;
+- termos: `ACCEPTED`, somente após “aceito os termos”;
+- pagamento: `PREPARED`;
+- handoff: não iniciado.
+
+## Transcrição integral
+
+| # | Horário UTC | Emissor | Mensagem |
+|---:|---|---|---|
+| 1 | 19:06:27.406 | Cliente | Olá |
+| 2 | 19:06:34.228 | Urba | Oi! Eu sou a Urba, assistente virtual da Urbana do Brasil. Como posso te ajudar hoje? |
+| 3 | 19:06:38.769 | Cliente | achei vocês no instagram |
+| 4 | 19:06:47.282 | Urba | Que bom que nos encontrou por lá! Como posso te ajudar hoje? |
+| 5 | 19:08:42.977 | Cliente | queria saber mais informações sobre o serviços de vocês |
+| 6 | 19:08:53.658 | Urba | Claro. Qual ambiente você quer transformar ou qual necessidade gostaria de resolver? Assim te explico as opções mais adequadas. |
+| 7 | 19:09:31.503 | Cliente | queria ajeitar minha varanda, eu uso atendo minhas clientes lá, sou manicure |
+| 8 | 19:10:01.456 | Urba | Entendi — você usa a varanda como espaço de atendimento para suas clientes de manicure.<br><br>Pelo que contou, talvez a Decor Interiores seja adequada se a ideia for organizar o layout, escolher mobiliário, cores e materiais, sem intervenção estrutural. É uma consultoria online, que começa com briefing e envio de medidas, fotos e vídeos, seguida de reunião pelo Google Meet. Você recebe Manual em PDF, Tour Virtual, 3 opções de solução e até 2 rodadas consolidadas de ajustes.<br><br>Se houver necessidade de reforma ou mudanças técnicas, existe a Decor Reforma, para ambientes internos de até 20 m², sujeita à avaliação da arquiteta. A Urbana não executa a obra nem compra materiais ou contrata profissionais.<br><br>Você quer principalmente deixar o espaço mais bonito e funcional para os atendimentos, ou pretende fazer alguma reforma nele? |
+| 9 | 19:18:27.127 | Cliente | eu queria aproveitar então e saber o valor pra minha sala de estar |
+| 10 | 19:18:43.341 | Urba | Para uma sala de estar de até 20 m², se a ideia for trabalhar layout, móveis, cores e materiais, a opção que talvez faça mais sentido é a Decor Interiores, por R$ 400. É uma consultoria online.<br><br>Se você quiser apenas um projeto de pintura, o valor é R$ 250. Para uma reforma interna, é R$ 450, também para ambientes de até 20 m².<br><br>Você quer só decorar e organizar a sala, ou pretende reformá-la? |
+| 11 | 19:19:42.094 | Cliente | decorar e organizar |
+| 12 | 19:19:57.581 | Urba | Nesse caso, a Decor Interiores parece ser a opção mais alinhada: uma consultoria online para organizar o layout e definir móveis, cores e materiais, por R$ 400 para ambientes de até 20 m².<br><br>Quer seguir com essa opção para a sala de estar? |
+| 13 | 19:21:02.009 | Cliente | sim |
+| 14 | 19:21:22.046 | Urba | Como prefere que eu me refira a você? Você pode responder: ela/dela, ele/dele, elu/delu ou prefiro não responder. |
+| 15 | 19:21:37.078 | Cliente | ela |
+| 16 | 19:22:00.410 | Cliente | me chamo Yohanna |
+| 17 | 19:22:06.720 | Urba | É sua primeira vez contratando um serviço de arquitetura ou design? Pode responder sim, não ou prefiro não responder. |
+| 18 | 19:22:12.433 | Cliente | sim |
+| 19 | 19:22:12.435 | Urba | Obrigada por me contar, Yohanna. É sua primeira vez contratando um serviço de arquitetura ou design? Pode responder sim, não ou prefiro não responder. |
+| 20 | 19:22:14.621 | Cliente | é sim |
+| 21 | 19:22:32.334 | Urba | Yohanna, os termos da Decor Interiores estão disponíveis aqui:<br>https://fixtures.urbana.local/terms/decor-interiores<br><br>Leia com atenção. Se estiver de acordo, responda “aceito os termos” para eu seguir para o pagamento. |
+| 22 | 19:22:54.656 | Cliente | aceito |
+| 23 | 19:23:04.815 | Urba | Você prefere pagar por PIX ou cartão de crédito? |
+| 24 | 19:23:17.511 | Cliente | cartão |
+| 25 | 19:23:30.464 | Urba | Para seguir com o pagamento, preciso do seu aceite claro dos termos. Por favor, responda: “aceito os termos”. |
+| 26 | 19:23:59.008 | Cliente | eu falei que aceito |
+| 27 | 19:24:09.999 | Urba | Você tem razão, Yohanna — você disse que aceita. Desculpe pela repetição. Para eu conseguir prosseguir, confirme com a frase: “aceito os termos da Decor Interiores”. |
+| 28 | 19:25:04.299 | Cliente | aceito os termos |
+| 29 | 19:25:16.753 | Urba | O pagamento por cartão foi preparado. Acesse o link:<br><br>https://fixtures.urbana.local/payment/decor-interiores<br><br>Depois de realizar o pagamento, envie o comprovante por aqui. |
+| 30 | 19:25:36.095 | Cliente | esta bem |
+| 31 | 19:25:43.892 | Urba | Certo, Yohanna. Quando realizar o pagamento, envie o comprovante por aqui. |
+
+## Condições de replay
+
+1. Usar uma sessão nova e o mesmo catálogo/configuração da candidata.
+2. Reenviar literalmente as mensagens do cliente, na ordem acima.
+3. Aguardar cada resposta ficar concluída e visível antes da próxima entrada,
+   exceto no ponto de concorrência descrito a seguir.
+4. No passo de concorrência, enviar a mensagem 18 enquanto a resposta iniciada
+   após a mensagem 16 ainda estiver sendo concluída. O oráculo é a ordem dos
+   eventos aceitos/publicados, não o intervalo de dois milissegundos do baseline.
+5. Registrar transcrição, estados comerciais e invocações funcionais observáveis.
+6. Não exigir texto idêntico da candidata. Exigir intenção, fatos, restrições,
+   ordem comercial e próximo passo definidos na spec.
+
+## Defeitos observáveis que a candidata deve eliminar
+
+- ausência total de emoji e de transição casual em momentos leves;
+- termos técnicos evitáveis ou sem explicação;
+- apresentação incompleta da Decor Reforma e ausência do suporte;
+- repetição da pergunta sobre primeira contratação depois de resposta aceita;
+- avanço aparente após “aceito”, seguido de rejeição no pagamento e retrabalho;
+- link sem orientação de uma unidade por ambiente.
+
+## Extensão operacional do replay
+
+As mensagens 1–31 preservam exatamente a validação original. Para cobrir o fim
+do contrato comercial, o relatório da candidata deve anexar dois eventos
+sintéticos posteriores, sem fingir transação financeira real:
+
+1. envio de comprovante, que deve provocar validação e handoff humanos sem
+   confirmação automática do pagamento;
+2. aprovação humana simulada, que deve liberar o briefing e o próximo passo
+   somente depois da decisão.

--- a/specs/010-refine-urba-sales-dialogue/plan.md
+++ b/specs/010-refine-urba-sales-dialogue/plan.md
@@ -1,0 +1,135 @@
+# Implementation Plan: Refinamento da conversa comercial da Urba
+
+**Branch**: `010-refine-urba-sales-dialogue` | **Date**: 2026-08-27 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/010-refine-urba-sales-dialogue/spec.md`
+
+## Summary
+
+Ajustar a voz conversacional da Urba e o conteúdo apresentado a partir do
+catálogo canônico, preservando os guardrails determinísticos do fluxo Hermes.
+O trabalho combina uma revisão do `SOUL.md` com mudanças mínimas no catálogo e
+nas mensagens/regras já existentes: reconhecimento de “Aceito” após termos,
+orientação textual de uma unidade por ambiente e cópia completa da Decor
+Reforma. O player de pagamento não será implementado; sua capacidade de
+selecionar quantidade fica como TODO pré-homologação. A ordem e o aceite também
+ganham uma evidência estruturada e imutável para que o critério de auditoria
+seja verificável mesmo quando houver mais de uma unidade/ambiente.
+
+## Technical Context
+
+**Language/Version**: Java 21 LTS; Python 3 do runtime Hermes para testes do plugin; Markdown para o perfil
+**Primary Dependencies**: Spring Boot 3.4.x, Gradle 8.x, JUnit 5, pytest/unittest do plugin, runtime Hermes existente
+**Storage**: MongoDB existente, transcript/invocações e nova coleção aditiva `reception_terms_consent_audits`
+**Testing**: JUnit 5, Spring Boot Test, testes do plugin Hermes, scripts de contrato/profile e suíte focalizada
+**Target Platform**: backend em container e profile Hermes da POC local
+**Project Type**: backend web-service + integração/profile Hermes
+**Performance Goals**: manter os limites e a reconciliação de turnos existentes; nenhuma nova chamada externa
+**Constraints**: Clean Architecture, TDD, JaCoCo mínimo de 60%, secrets fora do repositório, sem player real ou transação financeira
+**Scale/Scope**: uma conversa por sessão; quatro serviços canônicos; mensagens sintéticas da POC
+
+### Decisões de implementação
+
+- `SOUL.md` permanece a fonte da personalidade, ritmo, vocabulário, emojis e
+  orientação de quantidade; não deve conter estado interno ou formato
+  estruturado de ferramenta.
+- O catálogo canônico (`ServiceCatalogItem`) continua sendo a fonte de preço,
+  área, entregas, suporte e exclusões. A apresentação da Decor Reforma deve
+  carregar os fatos exigidos pela spec sem criar um quinto serviço ou links reais.
+- A aceitação simples é uma regra determinística: o texto “Aceito” só vale
+  depois que os termos foram apresentados no serviço/ambiente corrente. A forma
+  combinada “Aceito, cartão” e o par consecutivo devem preservar a ordem.
+- A mensagem retornada por `prepare_payment` recebe a orientação de quantidade
+  e comprovante. A capacidade visual do player não é inferida nem implementada.
+- A auditoria não pode depender de reconstrução heurística. Uma entidade
+  `TermsConsentAudit` imutável preserva apresentação, aceite, texto exato,
+  timestamps, recurso/versão dos termos, serviço e unidade de contratação.
+  A transição `PRESENTED -> ACCEPTED` é condicional e idempotente; aceite só
+  pode ser associado a uma apresentação já persistida.
+- A unidade recebe um identificador opaco gerado pelo backend e vinculado à
+  mensagem de origem que explicitou o ambiente. O identificador nunca é
+  derivado apenas da etiqueta normalizada; quando a conversa não tornar uma
+  unidade inequívoca, o fluxo pede esclarecimento antes de preparar termos.
+- A atualização da conversa e a gravação do aceite devem compartilhar a
+  autoridade CAS/transactional do Mongo quando o adaptador estiver ativo.
+  Registros legados sem evidência estruturada não são retroativamente
+  considerados auditados: devem reapresentar os termos antes de aceitar.
+
+## Constitution Check
+
+*GATE: pass before Phase 0 research; rechecked after design.*
+
+- I. Stack oficial: **PASS** — nenhuma tecnologia nova.
+- II. Clean Architecture: **PASS** — regras permanecem no domínio/aplicação;
+  profile e catálogo ficam nas bordas apropriadas.
+- III. Specification/Test-first: **PASS** — spec aprovada; testes de aceite
+  serão escritos antes das alterações de código.
+- IV. Qualidade automatizada: **PASS** — rodar testes focalizados, plugin/profile
+  e suíte Gradle; JaCoCo existente permanece obrigatório.
+- V. Homolog primeiro: **PASS** — esta execução não faz deploy; PR volta para
+  `hml` após QA.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-refine-urba-sales-dialogue/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # não aplicável: nenhum contrato externo novo
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+```text
+integrations/hermes-agent/profile/SOUL.md
+integrations/hermes-agent/plugins/urbana-domain/
+├── __init__.py
+└── test_tools.py
+apps/urbana-connect-api/src/main/java/br/com/urbana/connect/
+├── domain/servicecatalog/model/ServiceCatalogItem.java
+├── domain/reception/model/TermsConsentAudit.java
+├── domain/reception/port/out/TermsConsentAuditGateway.java
+├── application/reception/CommercialPolicyService.java
+├── application/reception/TermsAcceptanceUseCase.java
+└── application/reception/tools/StatefulDomainToolService.java
+apps/urbana-connect-api/src/test/java/br/com/urbana/connect/
+├── application/reception/CommercialPolicyServiceTest.java
+├── application/reception/TermsAcceptanceUseCaseTest.java
+├── infrastructure/persistence/mongodb/reception/MongoTermsConsentAuditGatewayTest.java
+├── application/reception/tools/StatefulDomainToolServiceTest.java
+└── domain/servicecatalog/model/ServiceCatalogItemTest.java
+specs/010-refine-urba-sales-dialogue/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── tasks.md
+```
+
+**Structure Decision**: manter mudanças aderentes aos limites do monorepo:
+`apps/urbana-connect-api/` e `integrations/hermes-agent/`, evitando fontes
+paralelas, cópias de runtime externo, novos endpoints ou alterações no player.
+
+## Fases de execução
+
+1. Escrever testes que capturem aceite simples/composto, conteúdo da Decor
+   Reforma, mensagem de quantidade, evidência estruturada e preservação dos
+   guardrails.
+2. Implementar catálogo/cópia, evidência de termos e política determinística
+   mínima.
+3. Atualizar o profile `SOUL.md` e a descrição do plugin sem ampliar a superfície
+   de ferramentas.
+4. Rodar testes focados, scripts de contrato/profile e regressões Gradle.
+5. Executar QA independente, revisar a matriz da spec e preparar o handoff para
+   o PR em `hml`. Validação frontend/corpus é evidência posterior, não player.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Coleção aditiva de auditoria de aceite | CA-011 exige recuperar serviço, ambiente, recurso, instantes e texto exato mesmo quando há mais de uma contratação; a evidência não é reconstruível de forma segura apenas pelo transcript | Reusar somente `NEED`/estado da conversa perderia a associação entre aceite e unidade e permitiria retrovalidar registros legados |

--- a/specs/010-refine-urba-sales-dialogue/quickstart.md
+++ b/specs/010-refine-urba-sales-dialogue/quickstart.md
@@ -1,0 +1,107 @@
+# Quickstart — validação da implementação
+
+Os comandos abaixo foram executados em 2026-08-28. O ambiente Java padrão do
+shell é Java 11; use explicitamente o JDK 21 da aplicação.
+
+## 1. Testes determinísticos Java
+
+```bash
+cd apps/urbana-connect-api
+JAVA_HOME=/Users/emanueljoseguimaraesbrito/.sdkman/candidates/java/21.0.12-tem \
+  ./gradlew test --no-daemon --console=plain
+```
+
+Resultado final: `BUILD SUCCESSFUL`, 423 testes, 0 falhas e relatório JaCoCo
+gerado.
+
+Para a rodada focada:
+
+```bash
+JAVA_HOME=/Users/emanueljoseguimaraesbrito/.sdkman/candidates/java/21.0.12-tem \
+  ./gradlew test --no-daemon --console=plain \
+  --tests '*ReceptionOrchestratorTest' \
+  --tests '*TermsAcceptanceUseCaseTest' \
+  --tests '*StatefulDomainToolServiceTest' \
+  --tests '*ReceptionTurnReconciliationTest' \
+  --tests '*ActiveTurnLeaseServiceTest'
+```
+
+Resultado final: 58 testes focados passantes (24 de política, 28 de ferramenta
+e 6 de reconciliação), incluindo as regressões de ambiente tentativo,
+pagamento preparado e aceite ambíguo.
+
+## 2. Contratos do profile/plugin
+
+```bash
+cd integrations/hermes-agent/plugins/urbana-domain
+python3 -m unittest test_tools.py
+
+cd ../..
+./scripts/verify-tool-surface.sh
+./scripts/smoke-contract.sh
+./scripts/smoke-isolation.sh
+```
+
+Resultados: `14` testes do plugin passantes; superfície
+`tool_surface=urbana-domain:6`; contrato Hermes e isolamento filesystem/profile
+read-only/rede passantes. O smoke de contrato usa somente o servidor Hermes
+local e não credenciais reais.
+
+## 3. Frontend e E2E
+
+```bash
+cd apps/poc-chat
+npm test -- --run
+npm run typecheck
+npm run lint
+npm run build
+```
+
+Resultados: 19 arquivos/81 testes passantes; typecheck, lint e build Vite
+passantes.
+
+O stack local foi reconstruído com:
+
+```bash
+cd integrations/hermes-agent
+./scripts/run-local.sh -d
+```
+
+Backend e frontend ficaram prontos (`READY` e `ok`). A validação live foi:
+
+```bash
+cd apps/poc-chat
+PLAYWRIGHT_LIVE=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 \
+PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' \
+npx playwright test e2e/quality-chat.spec.ts
+```
+
+Resultado: 1 teste passante, rubric de qualidade `18/18`, retomada
+`HUMANO → URBA` `COMPLETED`. O Chromium bundled não é compatível com macOS 12;
+foi usado o Chrome instalado no sistema.
+
+## 4. Casos mínimos cobertos
+
+1. `Aceito`, com case/espaços/pontuação simples, só vale após termos
+   apresentados; `Ok`, negação e aceite antecipado permanecem sem aceite.
+2. `Aceito, quero pagar no cartão` e o par `Aceito` + método preservam a ordem
+   aceite → método → pagamento.
+3. Evidência de aceite persiste serviço, unidade/ambiente, recurso, instantes,
+   IDs e texto exato; ausência de evidência impede o pagamento.
+4. Ambiente sem evidência textual confirmada fica `TENTATIVE`, não cria unidade
+   de contratação e bloqueia `prepare_terms`.
+5. Decor Reforma mantém R$ 450, até 20 m², consultoria online, Manual do Espaço,
+   Tour Virtual, três opções, duas rodadas, suporte e exclusões.
+6. A primeira mensagem de pagamento simulado orienta `1 serviço para cada
+   ambiente` e pede comprovante; não afirma capacidade de player real.
+7. Comprovante gera handoff humano sem confirmação automática; aprovação e
+   mensagem humana são etapas separadas.
+
+## 5. Validação conversacional posterior
+
+O replay literal da Yohanna e o corpus C01–C16 ainda precisam ser executados
+conforme os Gates 3–5 da spec. O relatório em
+[`evidence/validation-report.md`](evidence/validation-report.md) registra o
+fluxo live de 18/18, as limitações, o risco residual de publicação concorrente
+e o TODO do player. A transcrição baseline integral está em
+[`evidence/yohanna-baseline.md`](evidence/yohanna-baseline.md).

--- a/specs/010-refine-urba-sales-dialogue/research.md
+++ b/specs/010-refine-urba-sales-dialogue/research.md
@@ -1,0 +1,65 @@
+# Research — Refinamento da conversa comercial da Urba
+
+## Decisão 1 — Separar personalidade de guardrails determinísticos
+
+**Decisão:** manter a naturalidade, vocabulário e energia no `SOUL.md`, mas
+preservar aceite, pagamento, comprovante, handoff e catálogo nas regras já
+existentes do backend.
+
+**Racional:** o transcript Yohanna mostrou que uma instrução de personalidade
+não consegue corrigir sozinha a rejeição de “aceito”, a ordem do pagamento ou a
+mensagem gerada por `prepare_payment`. A constituição também exige que regras
+de negócio não nasçam em uma integração externa.
+
+**Alternativas consideradas:** restringir a mudança ao SOUL (insuficiente para
+“Aceito”); reescrever o fluxo Hermes (fora do escopo e desnecessário).
+
+## Decisão 2 — Catálogo como fonte dos fatos do serviço
+
+**Decisão:** enriquecer a apresentação canônica já retornada por
+`list_available_services`, em especial Decor Reforma, sem inserir preços ou
+links reais no profile.
+
+**Racional:** `ServiceCatalogItem` já centraliza preço, área, entregas,
+responsabilidades, exclusões e suporte. O SOUL orienta a forma de falar; o
+catálogo fornece os fatos que podem ser ditos.
+
+**Alternativas consideradas:** copiar a descrição completa no SOUL (duplica e
+desatualiza fonte comercial); alterar o roteiro legado (não é fonte operacional).
+
+## Decisão 3 — Aceite simples contextual
+
+**Decisão:** reconhecer `Aceito` isolado somente com termos apresentados para o
+serviço/ambiente atual; aceitar também uma mensagem inequívoca com método de
+pagamento e o par consecutivo `Aceito` + método.
+
+**Racional:** remove o retrabalho observado sem permitir aceite antecipado,
+negação ou “ok”. A validação continua determinística e auditável pelo transcript,
+recurso de termos, estado e invocação.
+
+**Alternativas consideradas:** aceitar qualquer mensagem contendo “aceito”
+(aceitaria “aceito depois”); exigir a frase longa atual (reproduz o defeito da
+Yohanna).
+
+## Decisão 4 — Quantidade como copy, player como TODO
+
+**Decisão:** incluir na mensagem de pagamento a orientação “1 serviço por
+ambiente” e pedido de comprovante. Registrar que os links da POC são fixtures e
+que a seleção de quantidade no player real será verificada antes da homologação.
+
+**Racional:** não existe player/link real disponível. A feature pode corrigir a
+expectativa textual agora sem inventar capacidade visual nem criar integração.
+
+**Alternativas consideradas:** implementar seletor ou fallback operacional agora
+(sem provedor escolhido e fora do escopo aprovado).
+
+## Decisão 5 — Validar comportamento sem alterar a superfície Hermes
+
+**Decisão:** preservar as seis ferramentas e os contratos do plugin; atualizar
+somente suas descrições quando necessário para refletir a copy.
+
+**Racional:** os scripts de superfície e isolamento já protegem o limite de
+integração; nenhuma nova ferramenta é necessária.
+
+**Alternativas consideradas:** adicionar ferramenta de quantidade (prematuro e
+sem player); expor estado interno ao modelo (viola segurança do profile).

--- a/specs/010-refine-urba-sales-dialogue/sonar-issues-remediation.md
+++ b/specs/010-refine-urba-sales-dialogue/sonar-issues-remediation.md
@@ -1,0 +1,101 @@
+# Especificação — Remediação dos issues Sonar do PR
+
+**Feature**: `010-refine-urba-sales-dialogue`
+**Ticket Jira**: `PEE-106` (subtask de `PEE-23`)
+**PR**: `#63`
+**Branch**: `010-refine-urba-sales-dialogue` → `hml`
+**Status**: aprovado para execução
+**Data**: 2026-08-31
+
+## 1. Contexto
+
+Depois da remediação de cobertura, o quality gate do PR passou, mas a análise
+do SonarCloud listou 52 issues abertos pela API do PR (o painel visual foi
+reportado como 53). A lista contém principalmente `java:S5778` em testes
+recém-adicionados, além de alertas de manutenção em código de produção e alguns
+testes preexistentes.
+
+Inventário observado:
+
+| Regra | Quantidade | Escopo |
+| --- | ---: | --- |
+| `java:S5778` | 31 | lambdas de asserção com mais de uma chamada potencialmente lançável |
+| `java:S1659` | 6 | múltiplos campos declarados na mesma linha |
+| `java:S4165` | 4 | atribuições redundantes no construtor compacto do record |
+| `java:S5853` | 2 | asserções consecutivas que podem formar uma cadeia |
+| `java:S8786` | 2 | regex de aceite com backtracking superlinear |
+| `java:S1192` | 2 | literais `ENVIRONMENT` e `customerMessage` duplicados |
+| `java:S1858` | 2 | `toString()` desnecessário em valor já textual |
+| `java:S107` | 1 | construtor de reconciliação com nove parâmetros |
+| `java:S5961` | 1 | método de teste com 27 asserções |
+| `java:S1144` | 1 | método privado `sourceText` não utilizado |
+
+## 2. Objetivo
+
+Eliminar os issues acionáveis mantendo o comportamento comercial, os
+guardrails de aceite/pagamento/handoff, a superfície Hermes e a cobertura já
+conquistada. As mudanças devem ser refactors semânticos e testes de
+caracterização, não supressões ou alterações artificiais no quality gate.
+
+## 3. Escopo de implementação
+
+### 3.1 Produção
+
+1. Reescrever a detecção de aceite em `CommercialPolicyService` para evitar as
+   regexes superlineares, preservando os casos positivos e negativos já
+   cobertos.
+2. Substituir o construtor de nove parâmetros de
+   `ReceptionTurnReconciliationService` por uma dependência agrupada, mantendo
+   os construtores compatíveis de uso simples e atualizando a configuração e
+   os testes.
+3. Extrair constantes para `ENVIRONMENT` e `customerMessage` em
+   `StatefulDomainToolService` e remover o overload privado `sourceText` sem
+   uso.
+4. Remover somente as atribuições redundantes do construtor compacto de
+   `TermsConsentAudit`; as validações e invariantes devem permanecer.
+5. Declarar cada campo de `TermsConsentAuditDocument` em sua própria linha.
+
+### 3.2 Testes
+
+1. Refatorar lambdas `assertThatThrownBy` para que cada lambda contenha uma
+   única chamada potencialmente lançável, pré-calculando argumentos e doubles.
+2. Consolidar asserções consecutivas sobre o mesmo objeto em uma única cadeia
+   quando isso não reduzir a clareza.
+3. Dividir o teste de configuração que excede o limite de asserções em métodos
+   focados, sem remover verificações.
+4. Remover `toString()` desnecessário nos testes.
+5. Preservar ou ampliar testes de caracterização para os casos de aceite,
+   reconciliação e fallback afetados pelo refactor.
+
+## 4. Critérios de aceite
+
+- [ ] O novo check SonarCloud do PR não apresenta os 52 issues inventariados;
+  qualquer ocorrência residual deve ser justificada por uma limitação real e
+  não por supressão.
+- [ ] `./gradlew --no-daemon --max-workers=1 clean test jacocoTestReport` passa
+  com JDK 21 e a cobertura de código novo permanece acima de 80%.
+- [ ] Os testes focados de política comercial, reconciliação, aceite,
+  persistência, ferramentas, configuração e modelos passam isoladamente.
+- [ ] A semântica de `isExplicitTermsAcceptance`, fallbacks de reconciliação,
+  evidência durável, handoff e pagamento permanece coberta e inalterada.
+- [ ] Não há alteração em `SOUL.md`, integrações Hermes, threshold/exclusões do
+  Sonar ou comportamento comercial fora do necessário para o refactor.
+- [ ] `git diff --check` passa e o diff contém apenas produção/testes/spec desta
+  remediação; alterações preexistentes fora do escopo permanecem intocadas.
+- [ ] QA independente revisa o diff, executa os testes e confirma o resultado
+  do Sonar antes do push final.
+
+## 5. Fora de escopo
+
+- Alterar catálogo, preços, mensagens comerciais, termos, pagamento ou fluxo de
+  handoff.
+- Adicionar exclusões, `NOSONAR`, mudanças de severidade ou redução de regras.
+- Reescrever a suíte sem relação com os issues identificados.
+- Fazer merge do PR ou promover a `main`.
+
+## 6. Validação esperada
+
+O handoff deve listar a contagem de issues antes/depois por regra, os comandos
+executados, a cobertura antes/depois, eventuais limitações ambientais e os
+checks remotos do PR. A análise oficial do SonarCloud no próprio PR é a fonte
+final para a contagem de issues.

--- a/specs/010-refine-urba-sales-dialogue/spec.md
+++ b/specs/010-refine-urba-sales-dialogue/spec.md
@@ -1,0 +1,598 @@
+# Feature Specification: Refinamento da conversa comercial da Urba
+
+**Feature Branch**: `010-refine-urba-sales-dialogue`
+
+**Created**: 2026-08-27
+
+**Status**: Aprovada por Emanuel — pronta para planejamento/implementação
+**Input**: Validação da PO no fluxo manual “Yohanna”, com pedidos de linguagem
+mais casual e amigável, apresentação mais completa dos serviços, aceite dos
+termos com “Aceito” e orientação de quantidade por ambiente no pagamento.
+
+## Metadados
+
+- `Título da feature`: Refinamento da conversa comercial da Urba
+- `Ticket Jira`: PEE-106, subtarefa da PEE-23
+- `Responsável pela spec`: Tech Lead Orchestrator
+- `Contexto de branch`: `feature/* -> hml -> main`
+- `Dependência funcional`: 009-calibrate-urba-soul
+
+## 1. Contexto
+
+### 1.1 Necessidade
+
+A primeira calibração do perfil tornou a saudação mais curta, controlou a
+quantidade de informação e organizou a coleta do perfil do cliente. A validação
+manual feita pela PO demonstrou, porém, que a Urba ficou mais contida, formal e
+técnica do que a voz comercial desejada para uma conversa de WhatsApp.
+
+Esta feature deve aproximar a fala da Urba do atendimento usado pela Urbana do
+Brasil sem transformá-la em um roteiro rígido. A conversa precisa ser casual,
+amigável e expressiva nos momentos leves, enquanto preserva precisão comercial,
+limites do serviço, segurança no aceite dos termos e clareza no pagamento.
+
+### 1.2 Comportamento atual
+
+Na conversa “Yohanna”, composta por 31 mensagens, foram observados os seguintes
+comportamentos:
+
+- a saudação inicial foi breve e adequada;
+- a Urba não usou emojis em nenhuma resposta;
+- a explicação dos serviços usou expressões como “layout”, “intervenção
+  estrutural” e “rodadas consolidadas”;
+- a Decor Reforma foi apresentada apenas como uma alternativa curta e técnica;
+- Manual e Tour Virtual apareceram uma vez, mas o suporte não foi apresentado;
+- a resposta isolada “aceito” não registrou o aceite dos termos, embora a Urba
+  tenha perguntado em seguida pela forma de pagamento;
+- após a escolha de cartão, a cliente precisou repetir o aceite;
+- o link de pagamento foi enviado sem explicar a quantidade por ambiente;
+- uma pergunta de perfil foi repetida quando a cliente enviou mensagens em
+  sequência enquanto uma resposta anterior ainda estava sendo processada.
+
+O comportamento de voz é coerente com as restrições da feature 009, que tornou
+em regra evitar “Show!”, limitar entusiasmo e tratar emojis como opcionais. Os
+demais pontos também refletem contratos comerciais vigentes: a descrição curta
+do catálogo, a exigência de mencionar “termos” no aceite e a mensagem genérica
+de pagamento. Portanto, esta evolução não pode ser resolvida de forma confiável
+somente por instruções de personalidade.
+
+### 1.3 Relação com a feature 009
+
+Esta feature sucede a 009 sem reescrever seu histórico. Permanecem válidos:
+
+- identidade transparente da Urba como assistente virtual;
+- saudação inicial curta e sem catálogo automático;
+- descoberta progressiva, sem despejo prematuro de informações;
+- recomendação como hipótese a ser confirmada pelo cliente;
+- uma pergunta de perfil por vez, com recusa permitida;
+- fontes comerciais canônicas, sem copiar preços ou links antigos do roteiro;
+- controles de termos, pagamento, comprovante e atendimento humano.
+
+Esta feature substitui, para as novas validações, somente os critérios da 009
+que proibiam expressões como “Show!”, desencorajavam o uso observável de emojis
+e restringiam toda a implementação ao arquivo de personalidade. Também torna
+explícito que a coleta guiada apresenta exatamente um campo de perfil por
+mensagem da Urba; respostas espontâneas com vários campos continuam válidas.
+
+### 1.4 Dependências e premissas
+
+- A descrição fornecida pela PO é uma referência comercial aprovada, mas pode
+  receber pequenos ajustes gramaticais e de contexto sem perder os fatos
+  obrigatórios.
+- “Manual do Espaço” é o nome preferencial, na fala com o cliente, para o Manual
+  canônico entregue em PDF; a mudança de nome não cria uma entrega adicional.
+- O suporte dura três meses após a entrega e cobre dúvidas sobre o Manual e as
+  cores pelo WhatsApp; não é garantia, visita ou gestão de obra.
+- Os preços permanecem por ambiente e cada ambiente corresponde a um serviço
+  contratado.
+- Para ambientes diferentes do mesmo serviço, a orientação comercial deve usar
+  uma unidade por ambiente. Serviços diferentes mantêm termos, aceite e
+  pagamento separados.
+- Atualmente não há player ou link de pagamento real disponível. Nesta feature,
+  a orientação de quantidade é validada somente como mensagem: quando um link
+  ou simulação for apresentado, a Urba deve explicar a quantidade esperada sem
+  afirmar detalhes da interface que ainda não foram confirmados.
+- **TODO pré-homologação**: quando o player de pagamento for escolhido, verificar
+  se ele permite selecionar a quantidade de produtos/serviços por pagamento. Se
+  não permitir, definir e registrar a alternativa operacional antes de liberar o
+  fluxo; essa decisão não faz parte da implementação atual.
+- Nenhum preço, link, prazo, condição ou escopo comercial é alterado por esta
+  feature além das formas de apresentação explicitamente descritas.
+- O escopo funcional inclui personalidade, conteúdo canônico do catálogo,
+  reconhecimento e auditoria do aceite, orientação de pagamento, reconciliação
+  de mensagens consecutivas e suas validações automatizadas e conversacionais.
+
+## 2. Comportamentos esperados
+
+### 2.1 Voz casual, amigável e contextual
+
+1. Dada uma conversa de descoberta, quando a Urba acolher uma informação ou
+   confirmar um avanço, então deve usar português brasileiro casual e natural,
+   admitindo expressões como “Show!”, “Perfeito!”, “Legal!” ou “Vamos lá!” quando
+   combinarem com o momento.
+2. Dado um momento leve de descoberta, recomendação, apresentação de serviço ou
+   confirmação positiva, quando a Urba responder, então deve usar no máximo um
+   emoji contextual que ajude a transmitir acolhimento ou energia.
+3. Termos, pagamento, comprovante, falha, recusa, frustração e transferência
+   humana continuam sempre sem emojis. O emoji exigido para o fluxo completo
+   deve ocorrer em descoberta, recomendação, apresentação ou confirmação leve.
+4. Dada uma explicação de serviço, quando existir um termo técnico evitável,
+   então a Urba deve preferir palavras de uso comum. Se o termo for necessário,
+   deve explicá-lo na mesma mensagem.
+5. Dado qualquer exemplo de fala nesta spec, quando a Urba construir a resposta,
+   então deve tratá-lo como referência adaptável e não como texto fixo.
+
+Exemplo de transição positiva permitida:
+
+> Show! Então vamos prosseguir! 😃
+
+Expressões casuais são coerentes quando reconhecem o que a pessoa acabou de
+dizer e ajudam a avançar. Não são coerentes quando aparecem como bordão repetido,
+interrompem uma dúvida ou celebram uma falha. Termos como “layout”, “intervenção
+estrutural”, “rodadas consolidadas”, “briefing” e “escopo” devem ser substituídos
+ou acompanhados, respectivamente, por explicações como organização do espaço,
+mudanças com quebra-quebra ou parte técnica, conjunto de ajustes, questionário
+inicial e o que está incluído no serviço.
+
+### 2.2 Apresentação completa e humana dos serviços
+
+1. Dado um serviço identificado como relevante, quando a Urba fizer a primeira
+   apresentação completa, então deve explicar em linguagem natural:
+   - o tipo de necessidade atendida;
+   - o preço vigente por ambiente;
+   - o limite de área aplicável;
+   - que se trata de uma consultoria online;
+   - o Manual do Espaço em PDF;
+   - o Tour Virtual;
+   - as três opções de solução;
+   - as duas rodadas de alterações ou ajustes;
+   - o suporte de três meses pelo WhatsApp;
+   - as principais responsabilidades e exclusões relevantes para a dúvida.
+2. Dada uma comparação entre serviços, quando uma opção for citada apenas como
+   alternativa secundária, então a Urba pode resumir a explicação, mas deve
+   deixar claro que pode detalhá-la sem sugerir que ela possui menos entregas
+   comuns que os demais serviços.
+3. Dada uma nova dúvida após a apresentação completa, quando a Urba responder,
+   então deve focar na dúvida atual e não repetir todo o pacote.
+4. Dada uma referência às três opções e aos ajustes, quando a Urba explicar essa
+   entrega, então deve usar linguagem equivalente a:
+
+> Com 3 opções de solução do espaço para você escolher, além de 2 rodadas de
+> alterações ou ajustes do que você não gostar na solução apresentada.
+
+5. A expressão “rodadas consolidadas” não deve aparecer para o cliente sem uma
+   explicação simples.
+
+### 2.3 Apresentação da Decor Reforma
+
+1. Dada uma necessidade de reforma interna ou possível mudança técnica, quando a
+   Urba apresentar a Decor Reforma, então deve comunicar todos estes fatos:
+   - é uma consultoria online para reforma de ambiente interno;
+   - custa R$ 450 por ambiente contratado;
+   - atende até 20 m² por ambiente contratado;
+   - demandas e mudanças técnicas dependem da avaliação da arquiteta;
+   - cada ambiente contratado recebe sua própria solução;
+   - inclui Manual do Espaço em PDF, Tour Virtual, três opções de solução e duas
+     rodadas de alterações ou ajustes;
+   - inclui três meses de suporte pelo WhatsApp para dúvidas sobre o Manual e as
+     cores, sem significar garantia, visita ou gestão de obra;
+   - a Urbana não executa a obra;
+   - a Urbana não compra materiais nem contrata profissionais.
+2. A apresentação pode usar como referência adaptável:
+
+> Se houver necessidade de reforma ou mudanças técnicas, existe a Decor Reforma,
+> nossa consultoria para reforma de ambientes internos com até 20 m², sujeita à
+> avaliação da arquiteta. É como um mini projeto para cada ambiente contratado:
+> você recebe um Tour Virtual mostrando como o espaço poderá ficar e o Manual do
+> Espaço, em PDF, explicando os detalhes da solução. Não executamos a obra, não
+> compramos materiais e não contratamos profissionais. 😉
+
+3. A expressão “mini projeto” não pode ser usada para prometer projeto executivo,
+   responsabilidade técnica, viabilidade, aprovação ou execução.
+4. Dado um pedido que envolva estrutura, elétrica, hidráulica, gás, ART/RRT,
+   projeto legal ou aprovação de condomínio ou prefeitura, quando a Urba
+   responder, então deve informar a necessidade de avaliação da arquiteta sem
+   confirmar que o item está incluído ou é viável.
+5. Dado um ambiente acima de 20 m² ou cuja área não possa ser confirmada, quando
+   a Urba responder, então não deve prometer o atendimento ou o preço padrão e
+   deve encaminhar a avaliação para a arquiteta.
+
+### 2.4 Aceite dos termos com “Aceito”
+
+1. Dados os termos já apresentados para o serviço e ambiente atuais no fluxo
+   Hermes usado pela POC, quando o cliente responder somente “Aceito”, com
+   qualquer combinação de maiúsculas, espaços ou pontuação simples, então o
+   aceite deve ser registrado e a conversa deve avançar sem pedir a mesma
+   confirmação novamente.
+2. Continuam válidas respostas explícitas como “aceito os termos”, “concordo com
+   os termos” e “estou de acordo com os termos”.
+3. Dado que os termos ainda não foram apresentados, quando a pessoa disser
+   “Aceito”, então a fala isolada não deve criar um aceite antecipado.
+4. Dada uma resposta negativa ou ambígua, como “não aceito”, “talvez”, “vou ler”
+   ou “ok”, quando ela for recebida, então o aceite não deve ser registrado.
+5. Dada a resposta “Aceito” seguida imediatamente da forma de pagamento, quando
+   as mensagens forem processadas em sequência, então o aceite deve ser aplicado
+   antes da tentativa de preparar o pagamento.
+6. O cliente nunca deve receber uma mensagem dizendo que seu “Aceito” foi
+   entendido e, em seguida, ser obrigado a repetir uma frase mais longa.
+7. Dada uma mensagem única e inequívoca, como “Aceito, quero pagar no cartão”,
+   quando os termos já estiverem apresentados, então o aceite e a forma de
+   pagamento devem ser considerados na ordem correta.
+8. Cada aceite válido deve ser auditável com serviço e ambiente associados. Um
+   identificador de contratação pode representá-los desde que permita recuperar
+   ambos. A evidência também registra versão ou recurso dos termos, instante de
+   apresentação, instante de aceite e texto exato da confirmação do cliente.
+9. A flexibilização aplica-se ao fluxo canônico Hermes e aos canais que o usam.
+   O fluxo legado de WhatsApp/Gemini permanece fora do escopo desta feature.
+
+### 2.5 Orientação de quantidade no pagamento
+
+1. Dados serviço, ambiente, termos aceitos e forma de pagamento confirmados,
+   quando a Urba enviar um link ou uma simulação de pagamento, então deve
+   orientar o cliente a selecionar a quantidade de serviços desejada,
+   considerando uma unidade para cada ambiente, sem depender de um player real
+   estar disponível nesta etapa.
+2. Para um único ambiente, a orientação deve permitir entender que a quantidade
+   correta é uma unidade.
+3. Para mais de um ambiente, a Urba não deve sugerir que uma única contratação
+   cobre todos eles.
+4. Ambientes diferentes do mesmo serviço podem usar o mesmo link, com uma
+   unidade para cada ambiente. Serviços diferentes exigem termos, aceites e
+   links separados; a orientação de quantidade não cria pacote, desconto ou
+   condição especial.
+5. A mensagem deve continuar pedindo o envio do comprovante após o pagamento.
+6. A mensagem não deve prometer que o player possui um seletor enquanto essa
+   capacidade não tiver sido verificada; a verificação do player e a alternativa
+   para o caso negativo ficam registradas como TODO pré-homologação.
+
+Exemplo de orientação:
+
+> No link, selecione a quantidade de serviços que deseja contratar — considere
+> 1 serviço para cada ambiente. Depois do pagamento, envie o comprovante por
+> aqui.
+
+### 2.6 Mensagens enviadas em sequência
+
+1. Dada uma pergunta de perfil ainda sem resposta publicada, quando o cliente
+   enviar uma ou mais mensagens antes da conclusão do turno em andamento, então
+   a próxima resposta publicada deve reconciliar todas as entradas aceitas até
+   aquele momento antes de repetir qualquer pergunta.
+2. Dado um campo de perfil respondido explicitamente, quando uma resposta tardia
+   de um turno anterior for publicada, então ela não deve pedir novamente o
+   mesmo campo como se estivesse ausente.
+3. O envio rápido de “Aceito” e da forma de pagamento não pode inverter a ordem
+   comercial nem gerar uma nova solicitação de aceite.
+4. Na coleta guiada, cada mensagem da Urba pergunta exatamente um campo de
+   perfil. Se o cliente informar espontaneamente vários campos na mesma mensagem
+   ou em mensagens consecutivas, todos devem ser aproveitados sem nova pergunta
+   sobre os campos já respondidos.
+
+## 3. Critérios de aceite
+
+### 3.1 Voz e linguagem
+
+- **CA-001**: a Urba usa linguagem casual e amigável nos momentos leves, sem
+  parecer excessivamente formal, técnica ou burocrática.
+- **CA-002**: pelo menos uma transição positiva do fluxo completo usa uma
+  expressão casual coerente, sem repetir a mesma expressão automaticamente.
+- **CA-003**: o fluxo completo contém pelo menos um emoji contextual em momento
+  leve; cada mensagem usa no máximo um, e termos, pagamento, comprovante, falha,
+  recusa, frustração e handoff não usam emoji algum.
+- **CA-004**: nenhum termo técnico evitável fica sem equivalente ou explicação
+  simples na conversa avaliada.
+- **CA-005**: exemplos de voz não se tornam respostas idênticas em todas as
+  execuções nem substituem a leitura do contexto real.
+
+### 3.2 Catálogo e apresentação
+
+- **CA-006**: a primeira apresentação completa de um serviço contém Manual do
+  Espaço em PDF, Tour Virtual, três opções, duas rodadas de alterações, suporte
+  de três meses, preço e limite de área aplicável.
+- **CA-007a**: a apresentação completa da Decor Reforma informa R$ 450 por
+  ambiente e o limite padrão de até 20 m² por ambiente.
+- **CA-007b**: a apresentação completa da Decor Reforma deixa claro que é uma
+  consultoria online e que mudanças técnicas dependem da avaliação da arquiteta.
+- **CA-007c**: a apresentação completa da Decor Reforma inclui Manual do Espaço
+  em PDF, Tour Virtual, três opções e duas rodadas de alterações ou ajustes.
+- **CA-007d**: a apresentação completa da Decor Reforma explica os três meses de
+  suporte pelo WhatsApp para dúvidas sobre Manual e cores, sem tratá-lo como
+  garantia, visita ou gestão de obra.
+- **CA-007e**: a apresentação completa da Decor Reforma informa que a Urbana não
+  executa a obra, não compra materiais e não contrata profissionais.
+- **CA-007f**: ambientes acima de 20 m² são encaminhados para avaliação sem
+  promessa de atendimento, exceção ou preço padrão.
+- **CA-007g**: pedidos envolvendo estrutura, instalações, ART/RRT ou aprovações
+  são encaminhados para avaliação sem confirmação de inclusão ou viabilidade.
+- **CA-008**: a frase “3 opções de solução e até 2 rodadas consolidadas de
+  ajustes” não é apresentada isoladamente ao cliente.
+- **CA-009**: preço, área, responsabilidades, exclusões e suporte permanecem
+  coerentes com o catálogo comercial vigente.
+- **CA-010**: “Manual do Espaço”, “Tour Virtual” e “suporte” mantêm essas
+  denominações na primeira explicação relevante.
+
+### 3.3 Termos e pagamento
+
+- **CA-011**: “Aceito”, como resposta isolada após a apresentação dos termos,
+  registra o aceite em 100% dos testes aplicáveis e preserva os dados de
+  auditoria definidos em 2.4.8.
+- **CA-012**: respostas negativas, antecipadas ou ambíguas não registram aceite.
+- **CA-013**: após um “Aceito” válido, nenhuma mensagem pede repetição do aceite.
+- **CA-013a**: “Aceito, quero pagar no cartão” e o par consecutivo “Aceito” +
+  “cartão” registram primeiro o aceite e depois a forma de pagamento, sem
+  tentativa prematura nem retrabalho.
+- **CA-014**: toda primeira mensagem que envia um link ou uma simulação de
+  pagamento inclui a orientação textual de uma unidade por ambiente e o pedido
+  de comprovante.
+- **CA-014a**: o relatório da POC registra explicitamente que a capacidade do
+  player de selecionar quantidade ainda não foi verificada e não apresenta essa
+  capacidade como fato observado.
+- **CA-015**: a orientação de quantidade não comunica pacote, desconto ou
+  cobertura de múltiplos ambientes por uma única unidade; serviços diferentes
+  mantêm termos, aceites e links separados.
+
+### 3.4 Continuidade e segurança
+
+- **CA-016**: mensagens aceitas antes da publicação da resposta do turno em
+  andamento são reconciliadas e não produzem pergunta de perfil duplicada sobre
+  um campo já respondido.
+- **CA-017**: a identidade virtual, a descoberta progressiva e a coleta guiada
+  de exatamente uma pergunta de perfil por mensagem da Urba não regridem.
+- **CA-018**: termos não são aceitos antes de serem apresentados; pagamento não é
+  preparado antes do aceite; comprovante não confirma pagamento automaticamente.
+- **CA-019**: solicitações técnicas de Decor Reforma continuam sujeitas à
+  avaliação da arquiteta.
+- **CA-020**: nenhuma informação comercial é obtida de links ou preços legados
+  do roteiro de atendimento.
+
+## 4. Edge Cases
+
+- O cliente responde “ACEITO!”, “ aceito ” ou “Aceito.” após receber os termos.
+- O cliente responde “não aceito”, “não sei se aceito”, “aceito depois”, “ok” ou
+  apenas envia uma reação.
+- O cliente diz “aceito” antes da apresentação dos termos ou durante a escolha
+  do serviço.
+- O cliente envia “Aceito” e “cartão” em duas mensagens rápidas.
+- O cliente envia “Aceito, quero pagar no cartão” em uma única mensagem; a
+  resposta deve ser interpretada pelo contexto sem relaxar os casos negativos.
+- O cliente possui dois ambientes do mesmo tipo e pergunta se um pagamento cobre
+  ambos.
+- O cliente possui serviços diferentes no mesmo ambiente.
+- O cliente solicita Decor Reforma para um ambiente acima de 20 m².
+- O cliente pergunta se a Decor Reforma inclui ART/RRT, alteração estrutural,
+  projeto elétrico ou aprovação de condomínio.
+- O cliente pergunta sobre quantidade, parcelamento ou valor total sem ter
+  informado quantos ambientes deseja contratar.
+- A Decor Reforma é citada apenas como alternativa durante uma comparação.
+- O cliente usa “mini projeto” como sinônimo de projeto executivo ou pede
+  confirmação de responsabilidade técnica.
+- O cliente está frustrado ou relata uma falha durante uma etapa normalmente
+  leve; a emoção do contexto prevalece sobre o uso de gírias e emojis.
+- O link de pagamento não permite selecionar quantidade; a Urba não deve afirmar
+  uma capacidade inexistente e o caso precisa de tratamento operacional antes de
+  disponibilização real.
+- O cliente envia um comprovante após o link; a Urba transfere a validação ao
+  humano e não confirma o pagamento automaticamente.
+- O humano aprova o comprovante; só então o fluxo pode liberar o briefing e o
+  próximo passo previsto no contrato vigente.
+
+## 5. Observabilidade e validação
+
+### 5.1 Gate 1 — consistência do contrato
+
+Antes da implementação, a revisão deve confirmar que:
+
+- os comportamentos não contradizem o catálogo comercial vigente;
+- a nova aceitação de “Aceito” ocorre somente no contexto de termos apresentados;
+- a descrição da Decor Reforma preserva avaliação humana e exclusões;
+- a instrução de quantidade é tratada como orientação de mensagem e não como
+  evidência de que um player real já oferece seleção;
+- a evolução de voz não remove proteções em falha, handoff ou pagamento.
+
+### 5.2 Gate 2 — validações determinísticas
+
+Devem existir verificações automatizadas para:
+
+- aceitar as variações válidas de “Aceito”;
+- rejeitar negação, ambiguidade e aceite antecipado;
+- aplicar aceite antes do pagamento em mensagens consecutivas;
+- preservar a associação auditável entre o aceite e serviço, ambiente, recurso
+  ou versão dos termos, instantes e texto da confirmação;
+- manter a ordem termos → aceite → pagamento → comprovante;
+- incluir quantidade por ambiente na primeira orientação de pagamento da
+  simulação, sem alegar que um player real já foi validado;
+- preservar preço, área, entregas, suporte e exclusões da Decor Reforma;
+- encaminhar corretamente casos acima de 20 m² e demandas técnicas como ART/RRT;
+- impedir duplicação de pergunta de perfil em mensagens rápidas;
+- garantir que termos, pagamento, comprovante, falha e handoff não recebam emoji
+  nem tom celebratório;
+- preservar o handoff exclusivo após o comprovante e a liberação do briefing
+  somente depois da aprovação humana.
+
+### 5.3 Gate 3 — corpus conversacional
+
+O corpus mínimo deve conter:
+
+| ID | Cenário | Resultado obrigatório |
+|---|---|---|
+| C01 | Saudação simples | Apresentação curta, sem catálogo automático |
+| C02 | Origem pelo Instagram | Acolhimento natural e pergunta útil |
+| C03 | Pedido genérico sobre serviços | Descoberta progressiva, sem relatório |
+| C04 | Apresentação da Decor Reforma | Fatos completos, linguagem humana e limite técnico |
+| C05 | Apresentação da Decor Interiores | Entregas comuns e suporte presentes |
+| C06 | Confirmação positiva do serviço | Transição casual e contextual, com um emoji adequado |
+| C07 | “Aceito” após os termos | Aceite único e avanço para forma de pagamento |
+| C08 | “Não aceito” ou resposta ambígua | Sem aceite e sem pagamento |
+| C09 | Envio do link/simulação para um ambiente | Mensagem explica quantidade 1 e comprovante; não valida player |
+| C10 | Envio do link/simulação para vários ambientes | Uma unidade por ambiente, sem pacote implícito; não valida player |
+| C11 | Respostas rápidas de perfil | Sem pergunta duplicada |
+| C12 | Dúvida técnica ou frustração | Clareza, sem promessa ou entusiasmo inadequado |
+| C13 | Comprovante recebido | Sem aprovação automática; handoff humano exclusivo |
+| C14 | Comprovante aprovado pelo humano | Briefing e próximo passo liberados somente após a aprovação |
+| C15 | Decor Reforma acima de 20 m² | Sem promessa de preço ou atendimento; avaliação da arquiteta |
+| C16 | Decor Reforma com ART/RRT ou demanda técnica | Sem confirmação de inclusão ou viabilidade; avaliação da arquiteta |
+
+Os cenários comparativos C01–C12 formam os 12 pares baseline/candidata. Os
+cenários variáveis C02, C03, C04, C05, C06 e C12 devem ser executados três vezes
+com a candidata em sessões novas. C13–C16 são regressões operacionais e precisam
+passar integralmente, mas não entram na preferência qualitativa entre os 12
+pares. Variação natural de palavras é permitida; fatos e invariantes devem
+permanecer estáveis.
+
+### 5.4 Gate 4 — replay da conversa Yohanna
+
+O baseline reproduzível está preservado em
+[evidence/yohanna-baseline.md](evidence/yohanna-baseline.md), com os 31 eventos,
+horários em UTC, estado final e o ponto de concorrência observado. A candidata
+deve ser executada no frontend em uma conversa nova e sem histórico anterior,
+enviando exatamente as mesmas mensagens de entrada, na mesma ordem.
+
+Em cada passo, o executor aguarda a resposta terminar e ficar visível antes de
+enviar a entrada seguinte, exceto no passo de concorrência identificado no
+baseline: a resposta “sim” sobre a primeira contratação é enviada enquanto a
+resposta ao nome ainda está sendo concluída. Esse passo é controlado pela ordem
+dos eventos, e não pela tentativa de repetir um intervalo arbitrário de relógio.
+
+A sequência funcional contém:
+
+1. saudação;
+2. origem pelo Instagram;
+3. pedido de informações;
+4. necessidade de organizar a varanda usada por uma manicure;
+5. comparação entre Interiores e Reforma;
+6. pergunta de valor para sala de estar;
+7. escolha de decorar e organizar;
+8. confirmação da Decor Interiores;
+9. respostas de perfil, incluindo mensagens rápidas;
+10. apresentação dos termos;
+11. resposta isolada “Aceito”;
+12. escolha de cartão;
+13. envio do link com orientação de quantidade.
+
+Equivalência semântica significa preservar intenção, fatos obrigatórios, ordem
+comercial e próximo passo; não exige repetir as palavras da resposta baseline.
+As falas de entrada, o contexto do ambiente, o serviço escolhido, os preços e os
+estados observáveis precisam ser os definidos na evidência.
+
+O replay comercial passa somente se:
+
+- nenhuma pergunta de perfil respondida for repetida;
+- “Aceito” for suficiente e não houver retrabalho;
+- o link for enviado uma única vez, no estágio correto;
+- a orientação de quantidade estiver presente;
+- a conversa mantiver naturalidade e fatos comerciais corretos.
+
+Após esse replay, a mesma sessão recebe uma evidência sintética de comprovante e
+uma decisão humana simulada, em duas etapas distintas:
+
+1. ao receber o comprovante, a Urba não confirma o pagamento, transfere a
+   validação ao humano e deixa de responder autonomamente durante o handoff;
+2. somente após a aprovação humana, o fluxo libera o briefing e o próximo passo
+   previsto no contrato vigente.
+
+Essas duas etapas verificam C13 e C14 e são obrigatórias para aprovar o replay.
+
+O relatório deve preservar a transcrição integral, os estados observáveis e as
+avaliações, sem expor segredos ou credenciais.
+
+### 5.5 Gate 5 — avaliação qualitativa
+
+Os 12 pares C01–C12 serão apresentados à PO em ordem aleatória e sem indicar
+qual transcrição é baseline ou candidata. Cada transcrição será avaliada de 1 a
+5 em:
+
+- acolhimento;
+- naturalidade de WhatsApp;
+- linguagem casual sem exagero;
+- clareza;
+- completude comercial proporcional ao momento;
+- correção factual;
+- adequação de emoji e energia;
+- clareza do próximo passo.
+
+Cada transcrição soma de 8 a 40 pontos. Para um cenário:
+
+- a candidata é **igual ou melhor** quando sua soma é maior ou igual à baseline,
+  nenhuma dimensão fica abaixo de 3 e não há regressão de invariante objetivo;
+- a candidata é **claramente preferível** quando supera a baseline em pelo menos
+  4 pontos, nenhuma dimensão fica abaixo de 3 e não há regressão de invariante;
+- empates ou ganhos qualitativos nunca compensam falhas de termos, pagamento,
+  catálogo, handoff ou segurança.
+
+O conjunto é aprovado quando:
+
+- as dimensões da candidata alcançam média mínima 4,0 considerando C01–C12;
+- 100% dos invariantes de termos, pagamento e segurança passam;
+- a candidata é igual ou melhor em pelo menos 10 dos 12 pares;
+- a candidata é claramente preferível em pelo menos 8 dos 12 pares;
+- C13–C16 passam integralmente;
+- o replay Yohanna é aprovado integralmente.
+
+### 5.6 Evidência de entrega
+
+A entrega deve conter:
+
+- lista dos comportamentos modificados;
+- validações automatizadas executadas e resultados;
+- relatório do corpus com transcrições;
+- replay manual Yohanna pelo frontend, incluindo comprovante e decisão humana;
+- limitações da POC, especialmente a inexistência de player/link real e o link de
+  pagamento apenas simulado;
+- riscos residuais e itens que dependem de homologação;
+- referência ao ticket e ao Pull Request aplicável.
+
+## 6. Fora de escopo
+
+- Alterar preços, descontos, prazos ou limites de área.
+- Transformar a Urba em arquiteta ou responsável técnica.
+- Prometer execução de obra, compra de materiais ou contratação de profissionais.
+- Validar ou confirmar pagamento sem ação humana.
+- Alterar o conteúdo jurídico dos termos de uso.
+- Implementar o seletor de quantidade no provedor de pagamento.
+- Validar uma transação financeira real através dos links simulados da POC.
+- Reescrever o primeiro greeting determinístico do fluxo legado de WhatsApp.
+- Migrar ou substituir as integrações existentes do Hermes.
+- Fazer deploy em homologação ou produção como parte da criação desta spec.
+
+## 7. TODO pré-homologação
+
+Não há dúvida bloqueante para planejamento. Quando o player de pagamento for
+escolhido, a operação deve verificar se cada link aplicável permite selecionar
+quantidade de produtos/serviços. O resultado e, se necessário, a alternativa
+operacional devem ser registrados antes da homologação; nenhum link real é
+assumido ou validado por esta feature.
+
+## 8. Entidades conceituais
+
+- **Momento conversacional**: saudação, descoberta, apresentação, confirmação,
+  termos, pagamento, falha ou handoff; determina energia e linguagem permitidas.
+- **Apresentação de serviço**: conjunto proporcional de escopo, preço, área,
+  entregas, suporte, responsabilidades e exclusões.
+- **Aceite dos termos**: confirmação textual associada a termos já apresentados
+  para um serviço e ambiente específicos.
+- **Quantidade da contratação**: número de unidades no pagamento, sendo uma
+  unidade correspondente a cada ambiente contratado.
+- **Evidência conversacional**: transcrição e estados observáveis usados para
+  comparar o comportamento com os critérios desta feature.
+
+## 9. Critérios mensuráveis de sucesso
+
+- 100% das respostas “Aceito” válidas avançam sem repetição.
+- 100% das respostas negativas ou antecipadas permanecem sem aceite.
+- 100% dos aceites válidos preservam os dados mínimos de auditoria.
+- 100% das mensagens de link/simulação produzidas nesta feature contêm a
+  orientação de uma unidade por ambiente e o pedido de comprovante.
+- O relatório de validação registra que não há player/link real disponível e que
+  a capacidade de selecionar quantidade permanece TODO pré-homologação.
+- 100% das apresentações completas de serviço citam as cinco entregas comuns.
+- 100% das apresentações completas de Decor Reforma preservam preço, área,
+  entregas, suporte, avaliação da arquiteta e exclusões.
+- Cada replay completo contém pelo menos um emoji adequado em um momento leve e
+  nenhuma mensagem contém mais de um; etapas sensíveis não contêm nenhum.
+- Nenhum cenário de mensagens rápidas repete um campo de perfil já respondido.
+- 100% dos cenários C13–C16 preservam os limites técnicos, a validação humana do
+  comprovante e o handoff exclusivo.
+- Nenhuma resposta factual diverge do catálogo vigente.
+- A avaliação qualitativa da candidata atinge média mínima 4,0 em cada dimensão,
+  é igual ou melhor em pelo menos 10 dos 12 pares e claramente preferível em pelo
+  menos 8 deles.
+- A PO aprova integralmente o replay Yohanna pelo frontend.

--- a/specs/010-refine-urba-sales-dialogue/tasks.md
+++ b/specs/010-refine-urba-sales-dialogue/tasks.md
@@ -1,0 +1,142 @@
+# Tasks: Refinamento da conversa comercial da Urba
+
+**Input**: Design documents from `specs/010-refine-urba-sales-dialogue/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `quickstart.md`
+
+**Strategy**: uma pessoa desenvolvedora é a única escritora dos arquivos de
+produção sobrepostos. Os testes novos devem ser escritos e falhar antes da
+implementação correspondente. A QA independente só começa depois que o escritor
+parar.
+
+## Phase 1: Setup
+
+**Purpose**: confirmar o contrato e preparar a execução local sem alterar
+infraestrutura ou criar player de pagamento.
+
+- [x] T001 Conferir branch `010-refine-urba-sales-dialogue`, checklist aprovado e artefatos `plan.md`, `spec.md`, `research.md`, `data-model.md` e `quickstart.md`
+- [x] T002 Registrar o baseline de testes atual com `apps/urbana-connect-api/gradlew test` e `python -m unittest` do plugin, separando falhas preexistentes de regressões
+
+## Phase 2: Foundational — contratos executáveis
+
+**Purpose**: escrever primeiro as verificações que definem o comportamento novo.
+
+- [x] T003 [P] Criar testes para aceitar `Aceito` após termos, rejeitar aceite antecipado/negado e aceitar `Aceito` combinado com método em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/CommercialPolicyServiceTest.java`
+- [x] T004 [P] Criar testes para mensagem de pagamento com orientação de uma unidade por ambiente e comprovante em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/tools/StatefulDomainToolServiceTest.java`
+- [x] T005 [P] Criar/ajustar testes do catálogo para preço, limite, entregas, suporte, exclusões e escopo da Decor Reforma em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItemTest.java` e `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/CommercialPolicyServiceTest.java`
+- [x] T006 [P] Atualizar os testes estáticos do profile para exigir linguagem casual, termos `Manual do Espaço`, `Tour Virtual`, suporte e orientação de quantidade sem ampliar a superfície de ferramentas em `integrations/hermes-agent/plugins/urbana-domain/test_tools.py`
+- [x] T007 [P] Criar testes de unidade para `TermsConsentAudit` e o gateway/use case: campos obrigatórios, transição condicional `PRESENTED -> ACCEPTED`, primeiro aceite vence e replay é idempotente em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/TermsAcceptanceUseCaseTest.java` e `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/MongoTermsConsentAuditGatewayTest.java`
+- [ ] T008 Executar somente os testes T003–T007 e confirmar que as novas expectativas falham antes da implementação
+
+**Checkpoint**: contratos executáveis definidos; nenhuma alteração de produção
+deve ser aceita se os testes novos não demonstrarem a lacuna inicial.
+
+## Phase 3: User Story 1 — conversa casual e apresentação comercial (Priority: P1)
+
+**Goal**: tornar a Urba mais humana, amigável e clara, apresentando serviços
+com os fatos canônicos sem roteiro rígido ou termos técnicos desnecessários.
+
+**Independent Test**: testes do profile/plugin e replay de C01–C06 demonstram
+saudação curta, emoji apenas em momento leve, linguagem casual, apresentação
+completa proporcional e Decor Reforma com limites/exclusões.
+
+### Implementation for User Story 1
+
+- [x] T009 [US1] Atualizar as instruções de identidade, voz, emojis, vocabulário, perguntas de perfil e apresentação progressiva em `integrations/hermes-agent/profile/SOUL.md`, preservando seis ferramentas e guardrails de termos/pagamento/handoff
+- [x] T010 [US1] Enriquecer a apresentação canônica dos serviços — especialmente Decor Reforma com R$ 450, até 20 m², entregas, suporte e exclusões — em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/servicecatalog/model/ServiceCatalogItem.java` e seus seeders/testes
+- [x] T011 [US1] Atualizar descrições textuais do catálogo exposto pelo plugin para manter os termos preferenciais e a distinção entre consulta informativa e ação comercial em `integrations/hermes-agent/plugins/urbana-domain/__init__.py`
+- [x] T012 [US1] Executar os testes de catálogo e profile e confirmar que C01–C06 não introduzem preço, link ou serviço legado
+
+**Checkpoint**: a conversa informativa e as apresentações canônicas passam sem
+alterar estado comercial, superfície Hermes ou recursos de pagamento.
+
+## Phase 4: User Story 2 — aceite e pagamento sem retrabalho (Priority: P1)
+
+**Goal**: registrar `Aceito` no contexto correto, preservar a ordem comercial e
+orientar quantidade por ambiente na mensagem de pagamento simulado.
+
+**Independent Test**: testes de política e ferramenta passam para entradas
+válidas/negadas, formas combinadas, estado `ACCEPTED -> PREPARED` e mensagem com
+quantidade/comprovante; nenhum player real é criado.
+
+### Implementation for User Story 2
+
+- [x] T013 [US2] Implementar `TermsConsentAudit`, o contrato `TermsConsentAuditGateway` e o caso de uso de aceite com identidade opaca da unidade, em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/domain/reception/model/`, `.../port/out/` e `.../application/reception/`
+- [x] T014 [US2] Implementar o documento/adaptador Mongo, repositório, índices e wiring aditivo para a evidência, preservando registros legados, em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/infrastructure/persistence/mongodb/reception/` e `PocReceptionConfiguration.java`
+- [x] T015 [US2] Implementar normalização determinística de aceite isolado, variações de pontuação/case e mensagem inequívoca com método, rejeitando negação/antecipação, em `apps/urbana-connect-api/src/main/java/br/com/urbana/connect/application/reception/CommercialPolicyService.java`
+- [x] T016 [US2] Ajustar orquestrador/ferramenta para só aceitar após apresentação durável, usar a mensagem inbound exata, respeitar a ordem aceite → método → pagamento e não retrovalidar aceite anterior no mesmo turno em `ReceptionOrchestrator.java` e `StatefulDomainToolService.java`
+- [x] T017 [US2] Atualizar a mensagem de pagamento preparado para orientar `1 serviço por ambiente` e envio do comprovante, deixando explícito que o link da POC é simulado e sem afirmar capacidade do player em `StatefulDomainToolService.java`
+- [x] T018 [US2] Executar os testes focados de política, auditoria e ferramentas, incluindo regressões de termos, método inválido, comprovante e aprovação humana
+
+**Checkpoint**: nenhuma contratação avança sem termos/aceite; nenhum pagamento
+é confirmado automaticamente; a orientação de quantidade é somente textual.
+
+## Phase 5: User Story 3 — continuidade e segurança da conversa (Priority: P2)
+
+**Goal**: aproveitar mensagens consecutivas, evitar perguntas duplicadas e
+preservar handoff, comprovante e briefing sob decisão humana.
+
+**Independent Test**: cenários de concorrência e handoff passam sem duplicação,
+sem chamada Hermes após transferência e sem liberação antes da aprovação.
+
+### Tests and implementation for User Story 3
+
+- [x] T019 [P] [US3] Criar testes de regressão para respostas de perfil consecutivas e publicação tardia sem repetir campo em `apps/urbana-connect-api/src/test/java/br/com/urbana/connect/application/reception/ReceptionTurnReconciliationTest.java`, `AgentOutputReconcilerTest.java` e `ReceptionOrchestratorTest.java`
+- [x] T020 [US3] Corrigir apenas a reconciliação necessária para consumir entradas já recebidas, instalar publication fence e manter uma pergunta de perfil por mensagem da Urba em `ReceptionOrchestrator.java`, `ReceptionTurnReconciliationService.java` e/ou `AgentOutputReconciler.java`
+- [x] T021 [P] [US3] Adicionar/ajustar testes de comprovante, handoff exclusivo e liberação pós-aprovação em `CommercialPolicyServiceTest.java` e `StatefulDomainToolServiceTest.java`
+- [ ] T022 [US3] Executar os cenários C07–C16 determinísticos e confirmar que falha, termos, pagamento, comprovante e handoff não usam tom celebratório nem emojis indevidos
+
+**Checkpoint**: continuidade e segurança preservadas; qualquer falha deve ser
+classificada como produto, teste ou ambiente antes de correção.
+
+## Phase 6: Polish, regressão e handoff
+
+**Purpose**: consolidar evidências e deixar a implementação pronta para QA e
+PR em `hml`, sem fazer deploy.
+
+- [x] T023 Executar suíte Gradle completa, JaCoCo e testes do plugin/profile; registrar comandos, resultados e falhas ambientais em `specs/010-refine-urba-sales-dialogue/quickstart.md`
+- [x] T024 Executar `smoke-contract.sh`, `smoke-isolation.sh` e `verify-tool-surface.sh` quando o ambiente local estiver disponível e registrar limitações do player inexistente
+- [x] T025 Revisar diff contra `spec.md`, `plan.md` e `data-model.md`, confirmar que não há links/provedor real, secrets, nova ferramenta ou arquivo fora do escopo
+- [x] T026 Preparar relatório de validação C01–C16 e replay Yohanna conforme `specs/010-refine-urba-sales-dialogue/evidence/yohanna-baseline.md`, para execução pela QA independente
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1) deve preceder os testes.
+- Foundational (Phase 2) bloqueia todas as user stories.
+- US1 e US2 compartilham catálogo/profile e devem ser implementadas
+  sequencialmente pelo mesmo escritor; US3 começa depois dos guardrails de US2.
+- Polish depende de US1, US2 e US3 concluídas.
+- QA independente acontece depois de T023 e da parada do Developer.
+
+### Parallel Opportunities
+
+- T003–T007 podem ser escritos em paralelo por arquivos distintos, mas T008 é
+  serial e deve confirmar falha.
+- T016 e T018 podem ser preparados em paralelo, sem alterar produção.
+- Não há paralelismo de escritores em `SOUL.md`, `ServiceCatalogItem.java` ou
+  `StatefulDomainToolService.java`.
+
+## Implementation Strategy
+
+1. Executar T001–T008 e validar o ciclo red → green esperado.
+2. Entregar US1 (MVP de voz/catalogo) e testar isoladamente.
+3. Entregar US2 (aceite/pagamento textual) e testar invariantes.
+4. Entregar US3 (continuidade/handoff) e executar regressões.
+5. Consolidar evidências, parar o Developer e acionar QA independente.
+6. Corrigir no máximo duas vezes a mesma causa, reutilizando o Developer; depois
+   escalar ou consultar Emanuel se o bloqueio persistir.
+
+## Validation notes
+
+- T008 não foi reexecutado como uma fase red isolada depois que a implementação
+  já estava presente; os testes novos foram mantidos como contrato executável e
+  estão verdes na rodada focada.
+- T022 permanece pendente como execução literal do corpus C07–C16; a suíte e o
+  E2E live cobrem os invariantes equivalentes, mas não substituem o corpus
+  definido na spec.
+- O replay literal de Yohanna, os 12 pares cegos e a avaliação qualitativa da
+  PO também permanecem como passos de homologação, descritos no relatório.
+- A publication fence fecha as corridas comuns e deixa o turno retryable, mas a
+  janela entre a última leitura e o append normal só será eliminada com CAS ou
+  transação no gateway de transcript.


### PR DESCRIPTION
## Objetivo
Refinar a experiência conversacional da Urba e consolidar os guardrails comerciais aprovados na PEE-106, mantendo o escopo de integração do Hermes estável.

Refs PEE-106.

## O que mudou
- Ajuste do SOUL para uma abertura mais humana, tom casual e uso contextual de emojis.
- Perguntas de ICP em formato progressivo, com opções e exemplos para orientar o cliente.
- Catálogo canônico dos serviços, incluindo a descrição aprovada da Decor Reforma, Tour Virtual, Manual do Espaço, suporte e limites de execução.
- Consentimento determinístico: aceite contextual com texto simples como “Aceito”, rejeição de respostas ambíguas e auditoria aditiva.
- Orientação de pagamento sobre selecionar a quantidade de serviços/ambientes; nenhum player ou link real foi criado.
- Evidências de validação, reconciliação e publicação do corpus preservadas na documentação da feature.

## Validação
- Suíte Gradle: 423 testes, 0 falhas (JDK 21).
- Suíte focada da feature: 58 testes, 0 falhas.
- Testes do plugin: 14/14 aprovados.
- Frontend: 81 testes, typecheck, lint e build aprovados.
- Contratos, isolamento de ferramentas e superfície do plugin aprovados.
- Playwright ao vivo: 18/18 cenários aprovados.
- `git diff --check` sem problemas.

## Pendências explícitas
- O replay literal da conversa da Yohanna/C01–C16 e a avaliação manual da PO continuam como gates de homologação.
- A capacidade de selecionar quantidades no player de pagamento permanece TODO dependente da solução de pagamento escolhida.
- Não foram realizados merge, deploy ou alteração de integrações produtivas.